### PR TITLE
feat(cli): auto-open OA/proxy + interactive access prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,38 @@ Quick example (Domain Research via agent):
 - Ask: "Research PBMC annotation best practices using live web and cite sources"
 - The agent can call `domain_research.run_research` under the hood.
 
+Date constraints and PubMed usage
+
+- You can include date constraints in your prompt that the agent will translate for web search backends:
+  - `date:>=YYYY` becomes an `after:YYYY` token for web queries and a PubMed date range when using `web:pubmed`.
+  - `date:<=YYYY[-MM[-DD]]` becomes a `before:YYYY[-MM[-DD]]` token.
+  - Example: "Research recent PBMC annotation best practices (date:>=2022 date:<=2024-06-01) using PubMed".
+- To prefer PubMed results, ask explicitly (e.g., "use PubMed") or start the Domain Research toolset with `backend="web:pubmed"`.
+
+Institution Access Flow
+
+- When Domain Research detects paywalled sources, the CLI lists them and offers to open links.
+- Set `INSTITUTION_PROXY_URL` to your library proxy (e.g., `https://libproxy.school.edu/login?url=`) and `ALLOW_BROWSER_OPEN=1` to enable opening links.
+- The prompt lets you open Open Access if available, otherwise via your institution proxy.
+
+Institution Access Automation
+
+- Flags:
+  - `--institution_proxy_url <template>`: Set your library proxy template, e.g. `https://libproxy.school.edu/login?url=` or `https://libproxy.school.edu/login?url={url}`.
+  - `--save_proxy_url True`: Save proxy template into `.pantheon_config.json` for reuse.
+  - `--access_open <mode>`: Auto-open access links: `oa` (open-access) or `proxy` (institution proxy). Default `none`.
+- Env:
+  - `ALLOW_BROWSER_OPEN=1` to enable opening links from the CLI.
+  - These flags set `INSTITUTION_PROXY_URL` and `ACCESS_OPEN_MODE` for the session.
+
+Example:
+
+```bash
+pantheon-cli --access_open oa \
+  --institution_proxy_url "https://libproxy.school.edu/login?url=" \
+  --save_proxy_url True
+```
+
 ## `7` [Configuration Files](#7-configuration-files)
 
 Pantheon CLI supports project-specific configuration files similar to Claude Code's `CLAUDE.md`:

--- a/scripts/test_cli_access_flow.py
+++ b/scripts/test_cli_access_flow.py
@@ -1,0 +1,115 @@
+"""Ad-hoc test for Pantheon-CLI access prompt flow (no network).
+
+Runs the REPL UI tool result printer with a fake Domain Research result
+containing `access_requests`. Verifies auto-open behavior and interactive
+prompt wiring without requiring full REPL or network access.
+
+Usage:
+  python pantheon-cli/scripts/test_cli_access_flow.py --mode oa
+  python pantheon-cli/scripts/test_cli_access_flow.py --mode proxy
+  python pantheon-cli/scripts/test_cli_access_flow.py --mode none
+
+Env:
+  ALLOW_BROWSER_OPEN=1 to enable opening links (monkeypatched in test).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import types
+from typing import List
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["oa", "proxy", "none"], default="none")
+    args = parser.parse_args()
+
+    # Import UI
+    # Prefer local package path
+    sys.path.insert(0, "pantheon-cli")
+    from pantheon_cli.repl.ui import ReplUI
+
+    # Prepare a fake result (as returned by domain_research.run_research)
+    result = {
+        "report": "# Demo Report\n...",
+        "backend_used": "web:pubmed",
+        "used_demo": False,
+        "access_requests": [
+            {
+                "title": "Open-access item",
+                "url": "https://journals.example.org/item",
+                "open_access_url": "https://oa.example.org/item.pdf",
+                "proxy_url": "https://libproxy.example.edu/login?url=https%3A%2F%2Fjournals.example.org%2Fitem",
+            },
+            {
+                "title": "Proxy-only item",
+                "url": "https://publisher.example.com/locked",
+                "proxy_url": "https://libproxy.example.edu/login?url=https%3A%2F%2Fpublisher.example.com%2Flocked",
+                "access_required": True,
+            },
+            {
+                "title": "OA-only item",
+                "url": "https://preprint.example.net/article",
+                "open_access_url": "https://preprint.example.net/article.pdf",
+            },
+            {
+                "title": "No links item (should be skipped)",
+                "url": "https://unknown.example.net/",
+            },
+        ],
+    }
+
+    # Prepare UI with captured console
+    ui = ReplUI()
+    out = io.StringIO()
+    from rich.console import Console
+
+    ui.console = Console(file=out, force_terminal=False, no_color=True)
+
+    # Monkeypatch webbrowser.open to capture calls
+    import webbrowser as _wb
+    # Monkeypatch Prompt.ask to avoid interactive input
+    from rich import prompt as _rich_prompt
+
+    opened: List[str] = []
+
+    def fake_open(url: str, *a, **k):
+        opened.append(url)
+        return True
+
+    # Set envs
+    os.environ["ALLOW_BROWSER_OPEN"] = "1"
+    os.environ["ACCESS_OPEN_MODE"] = args.mode
+
+    # Apply monkeypatch via assignment
+    _wb_open_orig = _wb.open
+    _wb.open = fake_open  # type: ignore
+    _orig_ask = _rich_prompt.Prompt.ask
+    def _fake_ask(*a, **k):
+        return 's'
+    _rich_prompt.Prompt.ask = _fake_ask  # type: ignore
+
+    try:
+        ui.print_tool_result("domain_research.run_research", result)
+        # Call prompt explicitly to ensure coverage
+        ui._prompt_access_requests(result["access_requests"])  # type: ignore
+    finally:
+        _rich_prompt.Prompt.ask = _orig_ask  # restore
+        _wb.open = _wb_open_orig  # restore
+
+    # Emit summary
+    print("=== Captured Output ===")
+    print(out.getvalue())
+    print("=== Opened URLs (mode=%s) ===" % args.mode)
+    for u in opened:
+        print(u)
+    print("COUNT:", len(opened))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR adds interactive access prompts and automation for Domain Research results in Pantheon-CLI.

Highlights
- Flags: `--access_open {oa|proxy|none}`, `--institution_proxy_url <template>`, `--save_proxy_url`.
- REPL UI: displays a table of `access_requests` and offers per-item actions; auto-opens OA or proxy links per mode.
- Persistence: proxy template optionally saved to `.pantheon_config.json` (prefs.institution_proxy_url).
- Docs: README updates for flags, env vars, and examples.
- Test utility: `scripts/test_cli_access_flow.py` for validating auto-open and prompts without network.

Files
- pantheon_cli/cli/core.py (flags + persistence)
- pantheon_cli/repl/ui.py (prompts + auto-open)
- README.md
- scripts/test_cli_access_flow.py

Notes
- Non-breaking: defaults to interactive prompts only when `access_requests` are present; auto-open is opt-in.
