### PR TITLE
Add WSL browser fallback for auto-ui

### DIFF
--- a/docs/source/interfaces/ui/index.rst
+++ b/docs/source/interfaces/ui/index.rst
@@ -32,6 +32,7 @@ Features
 - **Session Persistence**: Conversations are saved and can be resumed
 - **Team Support**: Use any team configuration
 - **Auto-Connect**: ``--auto-ui`` opens the browser with connection pre-configured
+- **WSL Friendly**: On WSL, ``--auto-ui`` attempts to launch your Windows default browser instead of relying on Linux desktop browser handlers
 
 Command Reference
 -----------------

--- a/docs/source/interfaces/ui/quickstart.rst
+++ b/docs/source/interfaces/ui/quickstart.rst
@@ -106,6 +106,12 @@ Troubleshooting
 - Check the terminal for the connection URL and open it manually
 - Ensure ``--auto-start-nats`` is used together with ``--auto-ui``
 
+**Running in WSL**
+
+- ``--auto-ui`` now tries to open your Windows default browser directly when Pantheon runs inside WSL
+- If automatic launch still fails, copy the ``Full Connection URL`` from the terminal into a Windows browser manually
+- If you use a custom frontend URL, keep ``--auto-start-nats`` enabled so the generated WebSocket connection stays local to your WSL session
+
 **NATS Server Failed to Start**
 
 - Check if another NATS instance is already running on port 4222 or 8080

--- a/pantheon/chatroom/start.py
+++ b/pantheon/chatroom/start.py
@@ -1,9 +1,12 @@
 import asyncio
 import os
+import platform
 import shutil
+import subprocess
 import sys
 import uuid
 from pathlib import Path
+from urllib.parse import urlencode
 
 # Note: pantheon.endpoint import is deferred to after NATS configuration
 # This ensures environment variables are set before Endpoint reads them
@@ -11,6 +14,68 @@ from pantheon.utils.misc import generate_service_id
 from pantheon.utils.log import logger
 
 from .room import ChatRoom
+
+
+def _is_wsl() -> bool:
+    """Return True when running inside Windows Subsystem for Linux."""
+    if platform.system().lower() != "linux":
+        return False
+
+    release = platform.release().lower()
+    if "microsoft" in release or "wsl" in release:
+        return True
+
+    try:
+        return "microsoft" in Path("/proc/version").read_text(encoding="utf-8").lower()
+    except OSError:
+        return False
+
+
+def _open_url_in_windows_browser(url: str) -> bool:
+    """
+    Open a URL using the Windows default browser from WSL.
+
+    Returns True once one of the Windows launch commands succeeds.
+    """
+    launch_commands = [
+        ["powershell.exe", "-NoProfile", "-Command", "Start-Process", url],
+        ["cmd.exe", "/c", "start", "", url],
+    ]
+
+    last_error = None
+    for command in launch_commands:
+        try:
+            subprocess.run(
+                command,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise RuntimeError(
+            f"Failed to open Windows browser from WSL using fallback commands: {last_error}"
+        )
+
+    return False
+
+
+def _open_browser_url(url: str) -> bool:
+    """Open a browser URL, preferring the Windows default browser under WSL."""
+    import webbrowser
+
+    if _is_wsl():
+        try:
+            return _open_url_in_windows_browser(url)
+        except Exception as exc:
+            logger.warning(
+                f"[FRONTEND] WSL browser fallback failed, trying Linux opener instead: {exc}"
+            )
+
+    return bool(webbrowser.open(url))
 
 
 async def _start_endpoint_process(
@@ -277,9 +342,6 @@ async def start_services(
             nats_url: NATS WebSocket URL (e.g., "ws://localhost:8080")
             service_id: Service ID for connection
         """
-        import webbrowser
-        from urllib.parse import urlencode
-
         # Build full connection URL with parameters
         # For Vue Router hash mode, query parameters must come after the hash (#/)
         query = urlencode({"nats": nats_url, "service": service_id, "auto": "true"})
@@ -296,7 +358,7 @@ async def start_services(
 
         try:
             # Try to open browser
-            webbrowser.open(connection_url)
+            _open_browser_url(connection_url)
             logger.info("[FRONTEND] ✓ Browser opened successfully")
         except Exception as e:
             logger.warning(f"[FRONTEND] Could not open browser automatically: {e}")

--- a/tests/test_chatroom_start.py
+++ b/tests/test_chatroom_start.py
@@ -1,0 +1,57 @@
+import subprocess
+
+from pantheon.chatroom import start
+
+
+def test_is_wsl_detects_microsoft_release(monkeypatch):
+    monkeypatch.setattr(start.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(start.platform, "release", lambda: "5.15.153.1-microsoft-standard-WSL2")
+
+    assert start._is_wsl() is True
+
+
+def test_open_browser_url_prefers_windows_browser_on_wsl(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(start, "_is_wsl", lambda: True)
+    monkeypatch.setattr(start, "_open_url_in_windows_browser", lambda url: calls.append(url) or True)
+
+    def fail_webbrowser_open(url):
+        raise AssertionError("webbrowser.open should not be called when WSL fallback succeeds")
+
+    monkeypatch.setattr("webbrowser.open", fail_webbrowser_open)
+
+    assert start._open_browser_url("https://example.com") is True
+    assert calls == ["https://example.com"]
+
+
+def test_open_url_in_windows_browser_falls_back_to_cmd(monkeypatch):
+    commands = []
+
+    def fake_run(command, check, stdout, stderr):
+        commands.append(command)
+        if command[0] == "powershell.exe":
+            raise FileNotFoundError("powershell.exe not found")
+        return None
+
+    monkeypatch.setattr(start.subprocess, "run", fake_run)
+
+    assert start._open_url_in_windows_browser("https://example.com") is True
+    assert commands == [
+        ["powershell.exe", "-NoProfile", "-Command", "Start-Process", "https://example.com"],
+        ["cmd.exe", "/c", "start", "", "https://example.com"],
+    ]
+
+
+def test_open_url_in_windows_browser_raises_when_all_launchers_fail(monkeypatch):
+    def fake_run(command, check, stdout, stderr):
+        raise subprocess.CalledProcessError(returncode=1, cmd=command)
+
+    monkeypatch.setattr(start.subprocess, "run", fake_run)
+
+    try:
+        start._open_url_in_windows_browser("https://example.com")
+    except RuntimeError as exc:
+        assert "Failed to open Windows browser from WSL" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError when all Windows browser launchers fail")


### PR DESCRIPTION
## Summary

This PR improves `pantheon ui --auto-start-nats --auto-ui` when running inside WSL.

## Changes

- detect WSL environments before opening the auto-connect URL
- prefer launching the Windows default browser via `powershell.exe` / `cmd.exe` fallback
- keep the existing `webbrowser.open(...)` behavior for non-WSL environments
- add tests covering WSL detection and Windows browser fallback behavior
- document the WSL behavior in the UI quickstart docs

## Motivation

On WSL, `webbrowser.open(...)` may fall back to Linux browser handlers such as `xdg-open`, which can fail when no Linux desktop browser is installed. In that case, `--auto-ui` generates the correct connection URL but does not open the Pantheon UI automatically.

This change makes `--auto-ui` work more reliably for WSL users by opening the URL with the Windows default browser instead.
