### PR TITLE
fix(examples): drop the mutable default in ridge_regression

### DIFF
--- a/examples/evolution_batch_correction/evolution_bbknn/bbknn/__init__.py
+++ b/examples/evolution_batch_correction/evolution_bbknn/bbknn/__init__.py
@@ -130,7 +130,7 @@ def bbknn(adata, batch_key='batch', use_rep='X_pca', key_added=None, copy=False,
 		f'    `.obsp[{conns_key!r}]`, weighted adjacency matrix'))
 	return adata if copy else None
 
-def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=False, **kwargs):
+def ridge_regression(adata, batch_key, confounder_key=None, chunksize=1e8, copy=False, **kwargs):
 	'''
 	Perform ridge regression on scaled expression data, accepting both technical and 
 	biological categorical variables. The effect of the technical variables is removed 
@@ -156,6 +156,8 @@ def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=Fa
 	kwargs
 		Any arguments to pass to `Ridge <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`_.
 	'''
+	if confounder_key is None:
+		confounder_key = []
 	start = logg.info('computing ridge regression')
 	adata = adata.copy() if copy else adata
 	#just in case the arguments are not provided as lists, convert them to such

--- a/examples/evolution_batch_correction/evolution_bbknn/results/bbknn_balanced/__init__.py
+++ b/examples/evolution_batch_correction/evolution_bbknn/results/bbknn_balanced/__init__.py
@@ -130,7 +130,7 @@ def bbknn(adata, batch_key='batch', use_rep='X_pca', key_added=None, copy=False,
 		f'    `.obsp[{conns_key!r}]`, weighted adjacency matrix'))
 	return adata if copy else None
 
-def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=False, **kwargs):
+def ridge_regression(adata, batch_key, confounder_key=None, chunksize=1e8, copy=False, **kwargs):
 	'''
 	Perform ridge regression on scaled expression data, accepting both technical and 
 	biological categorical variables. The effect of the technical variables is removed 
@@ -156,6 +156,8 @@ def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=Fa
 	kwargs
 		Any arguments to pass to `Ridge <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`_.
 	'''
+	if confounder_key is None:
+		confounder_key = []
 	start = logg.info('computing ridge regression')
 	adata = adata.copy() if copy else adata
 	#just in case the arguments are not provided as lists, convert them to such

--- a/examples/evolution_batch_correction/evolution_bbknn/results/bbknn_fast/__init__.py
+++ b/examples/evolution_batch_correction/evolution_bbknn/results/bbknn_fast/__init__.py
@@ -130,7 +130,7 @@ def bbknn(adata, batch_key='batch', use_rep='X_pca', key_added=None, copy=False,
 		f'    `.obsp[{conns_key!r}]`, weighted adjacency matrix'))
 	return adata if copy else None
 
-def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=False, **kwargs):
+def ridge_regression(adata, batch_key, confounder_key=None, chunksize=1e8, copy=False, **kwargs):
 	'''
 	Perform ridge regression on scaled expression data, accepting both technical and 
 	biological categorical variables. The effect of the technical variables is removed 
@@ -156,6 +156,8 @@ def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=Fa
 	kwargs
 		Any arguments to pass to `Ridge <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`_.
 	'''
+	if confounder_key is None:
+		confounder_key = []
 	start = logg.info('computing ridge regression')
 	adata = adata.copy() if copy else adata
 	#just in case the arguments are not provided as lists, convert them to such

--- a/examples/evolution_batch_correction/evolution_bbknn/results/bbknn_optimized/__init__.py
+++ b/examples/evolution_batch_correction/evolution_bbknn/results/bbknn_optimized/__init__.py
@@ -130,7 +130,7 @@ def bbknn(adata, batch_key='batch', use_rep='X_pca', key_added=None, copy=False,
 		f'    `.obsp[{conns_key!r}]`, weighted adjacency matrix'))
 	return adata if copy else None
 
-def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=False, **kwargs):
+def ridge_regression(adata, batch_key, confounder_key=None, chunksize=1e8, copy=False, **kwargs):
 	'''
 	Perform ridge regression on scaled expression data, accepting both technical and 
 	biological categorical variables. The effect of the technical variables is removed 
@@ -156,6 +156,8 @@ def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=Fa
 	kwargs
 		Any arguments to pass to `Ridge <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`_.
 	'''
+	if confounder_key is None:
+		confounder_key = []
 	start = logg.info('computing ridge regression')
 	adata = adata.copy() if copy else adata
 	#just in case the arguments are not provided as lists, convert them to such

--- a/examples/evolution_batch_correction/evolution_bbknn/results/bbknn_similar_speed/__init__.py
+++ b/examples/evolution_batch_correction/evolution_bbknn/results/bbknn_similar_speed/__init__.py
@@ -130,7 +130,7 @@ def bbknn(adata, batch_key='batch', use_rep='X_pca', key_added=None, copy=False,
 		f'    `.obsp[{conns_key!r}]`, weighted adjacency matrix'))
 	return adata if copy else None
 
-def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=False, **kwargs):
+def ridge_regression(adata, batch_key, confounder_key=None, chunksize=1e8, copy=False, **kwargs):
 	'''
 	Perform ridge regression on scaled expression data, accepting both technical and 
 	biological categorical variables. The effect of the technical variables is removed 
@@ -156,6 +156,8 @@ def ridge_regression(adata, batch_key, confounder_key=[], chunksize=1e8, copy=Fa
 	kwargs
 		Any arguments to pass to `Ridge <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`_.
 	'''
+	if confounder_key is None:
+		confounder_key = []
 	start = logg.info('computing ridge regression')
 	adata = adata.copy() if copy else adata
 	#just in case the arguments are not provided as lists, convert them to such

--- a/examples/evolution_batch_correction/evolution_scanorama/results/scanorama_optimized/scanorama.py
+++ b/examples/evolution_batch_correction/evolution_scanorama/results/scanorama_optimized/scanorama.py
@@ -1349,8 +1349,10 @@ def assemble(datasets, verbose=VERBOSE, view_match=False, knn=KNN,
 
 # Sketch-based acceleration of integration.
 def integrate_sketch(datasets_dimred, sketch_method='geosketch', N=10000,
-                     integration_fn=assemble, integration_fn_args={}):
+                     integration_fn=assemble, integration_fn_args=None):
 
+    if integration_fn_args is None:
+        integration_fn_args = {}
     from geosketch import gs, uniform
 
     if sketch_method.lower() == 'geosketch' or sketch_method.lower() == 'gs':

--- a/examples/evolution_batch_correction/evolution_scanorama/scanorama/scanorama.py
+++ b/examples/evolution_batch_correction/evolution_scanorama/scanorama/scanorama.py
@@ -966,8 +966,10 @@ def assemble(datasets, verbose=VERBOSE, view_match=False, knn=KNN,
 
 # Sketch-based acceleration of integration.
 def integrate_sketch(datasets_dimred, sketch_method='geosketch', N=10000,
-                     integration_fn=assemble, integration_fn_args={}):
+                     integration_fn=assemble, integration_fn_args=None):
 
+    if integration_fn_args is None:
+        integration_fn_args = {}
     from geosketch import gs, uniform
 
     if sketch_method.lower() == 'geosketch' or sketch_method.lower() == 'gs':


### PR DESCRIPTION
I noticed this while tracing through examples/evolution_batch_correction/evolution_bbknn/bbknn/__init__.py. Drop the mutable default in ridge_regression. Mutable defaults are shared across calls and usually turn into state leaks. I kept the patch small and re-ran syntax checks after applying it.

Backward-compat note: This changes a public function signature by replacing mutable defaults with None guards. Call sites stay source-compatible, but callers introspecting defaults will see None now.