### PR TITLE
feat: auto-cleanup empty chats on new chat creation

### DIFF
--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -962,12 +962,32 @@ class ChatRoom(ToolSet):
     ) -> dict:
         """Create a new chat.
 
+        Automatically cleans up previous empty chats (no messages) to prevent
+        sidebar clutter from unused "New Chat" entries.
+
         Args:
             chat_name: The name of the chat.
             project_name: Optional project name for grouping.
             workspace_path: Optional workspace directory path.
             workspace_mode: Workspace mode - "project" (shared, default) or "isolated" (per-chat).
         """
+        # Clean up existing empty chats before creating a new one.
+        # Load each memory into cache first so we check in-memory messages,
+        # not just the on-disk file (messages may not be persisted yet due to
+        # the 2-second debounce delay).
+        try:
+            ids = await run_func(self.memory_manager.list_memories)
+            for existing_id in ids:
+                try:
+                    memory = await run_func(self.memory_manager.get_memory, existing_id)
+                except KeyError:
+                    continue
+                if memory.is_empty:
+                    await self.delete_chat(existing_id)
+                    logger.info(f"Cleaned up empty chat {existing_id}")
+        except Exception as e:
+            logger.debug(f"Could not clean up empty chats: {e}")
+
         memory = await run_func(self.memory_manager.new_memory, chat_name)
         memory.set_metadata("last_activity_date", datetime.now().isoformat())
 

--- a/pantheon/internal/memory/memory.py
+++ b/pantheon/internal/memory/memory.py
@@ -127,6 +127,11 @@ class Memory:
 
         return []
 
+    @property
+    def is_empty(self) -> bool:
+        """Whether this chat has no messages."""
+        return len(self._messages) == 0
+
     def save(self, file_path: str | None = None):
         """
         Save the memory to a file.
@@ -702,6 +707,41 @@ class MemoryManager:
                 memory_ids.add(memory_id)
 
         return list(memory_ids)
+
+    def memory_has_messages(self, memory_id: str) -> bool:
+        """Check if a memory has any messages without fully loading it.
+
+        Uses a fast-path for JSONL backend (file size check) to avoid
+        deserializing all messages just to check emptiness.
+
+        Args:
+            memory_id: The ID of the memory.
+
+        Returns:
+            True if the memory has at least one message.
+        """
+        # If already loaded in cache, check directly
+        if memory_id in self.memory_store:
+            return not self.memory_store[memory_id].is_empty
+
+        # Fast-path: check JSONL file size without loading
+        if self.use_jsonl:
+            jsonl_path = self.path / f"{memory_id}.jsonl"
+            if jsonl_path.exists():
+                return jsonl_path.stat().st_size > 0
+            return False
+
+        # Fallback: check JSON file
+        json_path = self.path / f"{memory_id}.json"
+        if json_path.exists():
+            try:
+                import json as _json
+                with open(json_path, "r", encoding="utf-8") as f:
+                    data = _json.load(f)
+                return len(data.get("messages", [])) > 0
+            except Exception:
+                return False
+        return False
 
     def load_all(self):
         """


### PR DESCRIPTION
When creating a new chat, automatically delete any existing empty chats (chats with no messages) to prevent sidebar clutter from unused "New Chat" entries. Uses in-memory message check to avoid false positives from the 2-second debounce persistence delay.