### PR TITLE
Fix parallel call_agent display: tag streams with parent_tool_call_id

### DIFF
--- a/pantheon/agent.py
+++ b/pantheon/agent.py
@@ -8,7 +8,7 @@ import sys
 import time
 from abc import ABC, abstractmethod
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from uuid import uuid4
 
@@ -206,6 +206,11 @@ class AgentRunContext:
     cache_safe_tool_definitions: list[dict] | None = None
     context_collapse_manager: Any | None = None
     current_model: str | None = None
+    # Maps a call_agent tool_call_id → the child's execution_context_id so the
+    # eventual tool_message can be stamped with it. Lets the UI link a
+    # call_agent response back to the exact sub-agent invocation, even when
+    # the parent launches multiple parallel calls to the same agent name.
+    sub_agent_exec_ids: dict[str, str] = field(default_factory=dict)
 
 
 _RUN_CONTEXT: ContextVar[AgentRunContext | None] = ContextVar(
@@ -1445,6 +1450,16 @@ class Agent:
                     "execution_duration": execution_duration,
                 },
             }
+
+            # Stamp the child's execution_context_id if this was a call_agent
+            # invocation. The PantheonTeam.call_agent closure records the
+            # (tool_call_id → child_exec_id) mapping on run_context when it
+            # spawns the sub-agent.
+            _run_ctx = _RUN_CONTEXT.get()
+            if _run_ctx is not None and tool_call_id:
+                _child_exec_id = _run_ctx.sub_agent_exec_ids.pop(tool_call_id, None)
+                if _child_exec_id:
+                    tool_message["execution_context_id"] = _child_exec_id
 
             if isinstance(result, (Agent, RemoteAgent)):
                 tool_message.update(

--- a/pantheon/team/pantheon.py
+++ b/pantheon/team/pantheon.py
@@ -606,6 +606,15 @@ class PantheonTeam(Team):
                     self.max_delegate_depth,
                 )
 
+                # Record tool_call_id → child execution_context_id on the parent's
+                # run_context so the tool_message built back in Agent._call_tools
+                # can be stamped with this sub-agent's execution_context_id.
+                # Without this, the UI cannot tell apart two parallel call_agent()
+                # invocations to the same agent name.
+                parent_tool_call_id = context_variables.get("tool_call_id") if context_variables else None
+                if parent_tool_call_id and run_context is not None:
+                    run_context.sub_agent_exec_ids[parent_tool_call_id] = execution_context_id
+
                 child_context_variables = dict(context_variables)
                 child_context_variables["_metadata"] = child_metadata
                 # P2: Set execution_context_id at top level for child agent
@@ -640,16 +649,26 @@ class PantheonTeam(Team):
                 parent_step_hook = run_context.process_step_message
                 parent_chunk_hook = run_context.process_chunk
 
+                # Stamp the parent's call_agent tool_call_id onto every child
+                # message so the UI can pair (tool_call_id → execution_context_id)
+                # as soon as the first streaming chunk arrives — not only after
+                # the tool response lands. Without this, two parallel call_agent
+                # invocations to the same agent name can't be told apart while
+                # the sub-agents are still running.
+                _parent_tool_call_id = parent_tool_call_id
+
                 async def wrapped_step(step_message: dict):
                     # P2: Set execution_context_id at message top level
                     if "execution_context_id" not in step_message:
                         step_message["execution_context_id"] = execution_context_id
-                    
+                    if _parent_tool_call_id and "parent_tool_call_id" not in step_message:
+                        step_message["parent_tool_call_id"] = _parent_tool_call_id
+
                     # P0 FIX + P2: Merge metadata using setdefault chaining
                     step_message.setdefault("_metadata", child_metadata).setdefault(
                         "chain_path", child_metadata["chain_path"]
                     )
-                    
+
                     if parent_step_hook is not None:
                         await run_func(parent_step_hook, step_message)
 
@@ -657,12 +676,14 @@ class PantheonTeam(Team):
                     # P2: Set execution_context_id at message top level
                     if "execution_context_id" not in chunk:
                         chunk["execution_context_id"] = execution_context_id
-                    
+                    if _parent_tool_call_id and "parent_tool_call_id" not in chunk:
+                        chunk["parent_tool_call_id"] = _parent_tool_call_id
+
                     # P0 FIX + P2: Merge metadata using setdefault chaining
                     chunk.setdefault("_metadata", child_metadata).setdefault(
                         "chain_path", child_metadata["chain_path"]
                     )
-                    
+
                     if parent_chunk_hook is not None:
                         await run_func(parent_chunk_hook, chunk)
 


### PR DESCRIPTION
## Summary

When the main agent launches two parallel `call_agent()` invocations to the same agent name (e.g., two `researcher` sub-agents), the Timeline UI previously collapsed them into a single view — identical step counts, indistinguishable action lists. Two pieces of information were missing from the stream:
1. The child's `execution_context_id` never made it onto the `call_agent` tool response, so the frontend had no exec_id to scope by once the sub-agent finished.
2. While the sub-agents were still running (no tool response yet), streamed child messages had `execution_context_id` but no back-link to which parent `call_agent` tool_call they belonged to.

## Changes

- **`AgentRunContext.sub_agent_exec_ids`**: new dict mapping `parent tool_call_id → child execution_context_id`. `PantheonTeam.call_agent` records it right after building the child context; `Agent._call_tools` reads it when constructing the tool_message and stamps `execution_context_id` on the response so parallel siblings can be scoped post-completion.
- **`wrapped_step` / `wrapped_chunk`**: stamp `parent_tool_call_id` on every streamed child message. The UI can now pair `tool_call_id → execution_context_id` from the very first chunk, so parallel same-named sub-agents are distinguishable while still pending.

The UI side lives in pantheon-ui PR: https://github.com/Nanguage/pantheon-ui (branch `fix/sub-agent-card-parallel-dedup`).

## Test plan

- [x] `pytest tests/test_chat_rename_guards.py tests/test_conversation_recovery.py tests/test_responses_api.py tests/test_tool_result_vision.py` — 107 passed, 9 skipped
- [x] Smoke: `AgentRunContext(...).sub_agent_exec_ids` defaults to a fresh dict per instance
- [x] Manual: main agent launches two parallel `researcher` calls; while pending, each SubAgentCard shows its own step count and action list (previously identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)