### PR TITLE
OAuth: frontend-driven browser flow + Gemini CLI adapter fixes

### DIFF
--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -2713,6 +2713,167 @@ class ChatRoom(ToolSet):
         return {"success": False, "error": f"Unsupported OAuth provider: {provider}"}
 
     @tool
+    async def oauth_start(self, provider: str = "codex") -> dict:
+        """Start a browser-based OAuth login that the frontend drives.
+
+        The backend prepares PKCE state + starts a local callback server but
+        does NOT call webbrowser.open — the frontend opens ``auth_url`` in
+        the user's own browser (via ``window.open``), so the tab lands on
+        the user's machine even when the backend is remote / headless /
+        running inside WSL.
+
+        Finish the flow with one of:
+          - ``oauth_wait(session_id)`` — the normal path, backend's callback
+            server catches the redirect (works when the user's browser can
+            reach the callback host: local, WSL2, docker-with-port-mapping).
+          - ``oauth_complete(session_id, callback_url)`` — the manual
+            paste fallback for remote / WSL1 / docker-without-port-mapping,
+            where the redirect can't reach the backend.
+
+        Args:
+            provider: OAuth provider name ('codex' or 'gemini')
+
+        Returns:
+            dict with success, session_id, auth_url, redirect_uri, expires_at.
+        """
+        try:
+            if provider == "codex":
+                from pantheon.utils.oauth import CodexOAuthManager
+
+                started = CodexOAuthManager().start_login()
+                return {"success": True, "provider": "codex", **started}
+            if provider == "gemini":
+                from pantheon.utils.oauth import GeminiCliOAuthManager
+
+                started = GeminiCliOAuthManager().start_login()
+                return {"success": True, "provider": "gemini", **started}
+            return {"success": False, "error": f"Unsupported OAuth provider: {provider}"}
+        except Exception as e:
+            logger.error(f"oauth_start({provider}) failed: {e}")
+            return {"success": False, "error": str(e)}
+
+    @tool
+    async def oauth_wait(
+        self,
+        session_id: str,
+        provider: str = "codex",
+        timeout_seconds: int = 300,
+    ) -> dict:
+        """Block until the backend callback server receives the OAuth redirect.
+
+        Pairs with ``oauth_start``. Times out without destroying the session,
+        so the frontend can fall back to ``oauth_complete`` (paste URL).
+        """
+        try:
+            if provider == "codex":
+                from pantheon.utils.oauth import CodexOAuthError, CodexOAuthManager
+                from pantheon.utils.model_selector import reset_model_selector
+
+                mgr = CodexOAuthManager()
+                try:
+                    mgr.wait_login(session_id, timeout_seconds=timeout_seconds)
+                    reset_model_selector()
+                    return {
+                        "success": True,
+                        "provider": "codex",
+                        "account_id": mgr.get_account_id(),
+                    }
+                except CodexOAuthError as e:
+                    return {"success": False, "error": str(e), "timed_out": "Timed out" in str(e)}
+            if provider == "gemini":
+                from pantheon.utils.oauth import GeminiCliOAuthError, GeminiCliOAuthManager
+                from pantheon.utils.model_selector import reset_model_selector
+
+                mgr = GeminiCliOAuthManager()
+                try:
+                    mgr.wait_login(session_id, timeout_seconds=timeout_seconds)
+                    reset_model_selector()
+                    return {
+                        "success": True,
+                        "provider": "gemini",
+                        "email": mgr.get_email(),
+                        "project_id": mgr.get_project_id(),
+                        "runtime_ready": bool(mgr.get_project_id()),
+                    }
+                except GeminiCliOAuthError as e:
+                    return {"success": False, "error": str(e), "timed_out": "Timed out" in str(e)}
+            return {"success": False, "error": f"Unsupported OAuth provider: {provider}"}
+        except Exception as e:
+            logger.error(f"oauth_wait({provider}, {session_id[:8]}…) failed: {e}")
+            return {"success": False, "error": str(e)}
+
+    @tool
+    async def oauth_complete(
+        self,
+        session_id: str,
+        callback_url: str,
+        provider: str = "codex",
+    ) -> dict:
+        """Finish an OAuth login from a pasted callback URL.
+
+        Use when the redirect failed to reach the backend (remote mode) —
+        the frontend asks the user to paste the full failed URL
+        (``http://localhost:…/auth/callback?code=…&state=…``) and sends it
+        here for exchange.
+        """
+        try:
+            if provider == "codex":
+                from pantheon.utils.oauth import CodexOAuthError, CodexOAuthManager
+                from pantheon.utils.model_selector import reset_model_selector
+
+                mgr = CodexOAuthManager()
+                try:
+                    mgr.complete_login_from_url(session_id, callback_url)
+                    reset_model_selector()
+                    return {
+                        "success": True,
+                        "provider": "codex",
+                        "account_id": mgr.get_account_id(),
+                    }
+                except CodexOAuthError as e:
+                    return {"success": False, "error": str(e)}
+            if provider == "gemini":
+                from pantheon.utils.oauth import GeminiCliOAuthError, GeminiCliOAuthManager
+                from pantheon.utils.model_selector import reset_model_selector
+
+                mgr = GeminiCliOAuthManager()
+                try:
+                    mgr.complete_login_from_url(session_id, callback_url)
+                    reset_model_selector()
+                    return {
+                        "success": True,
+                        "provider": "gemini",
+                        "email": mgr.get_email(),
+                        "project_id": mgr.get_project_id(),
+                        "runtime_ready": bool(mgr.get_project_id()),
+                    }
+                except GeminiCliOAuthError as e:
+                    return {"success": False, "error": str(e)}
+            return {"success": False, "error": f"Unsupported OAuth provider: {provider}"}
+        except Exception as e:
+            logger.error(f"oauth_complete({provider}, {session_id[:8]}…) failed: {e}")
+            return {"success": False, "error": str(e)}
+
+    @tool
+    async def oauth_cancel(self, session_id: str, provider: str = "codex") -> dict:
+        """Cancel an in-flight OAuth login session (stop the callback server)."""
+        try:
+            if provider == "codex":
+                from pantheon.utils.oauth import CodexOAuthManager
+
+                CodexOAuthManager().cancel_login(session_id)
+            elif provider == "gemini":
+                from pantheon.utils.oauth import GeminiCliOAuthManager
+
+                GeminiCliOAuthManager().cancel_login(session_id)
+            else:
+                return {"success": False, "error": f"Unsupported OAuth provider: {provider}"}
+            return {"success": True}
+        except Exception as e:
+            logger.error(f"oauth_cancel({provider}, {session_id[:8]}…) failed: {e}")
+            return {"success": False, "error": str(e)}
+
+    @tool
     async def oauth_import(self, provider: str = "codex") -> dict:
         """Import OAuth tokens from native CLI tools.
 

--- a/pantheon/toolset.py
+++ b/pantheon/toolset.py
@@ -168,10 +168,14 @@ def tool(func: Callable | None = None, *, exclude: bool = False, **kwargs):
             context_variables = dict(payload.get("context_variables") or {})
         else:
             context_variables = dict(raw_context)
-        # backward compatibility: session_id is now an alias for client_id
-        session_id = func_kwargs.pop("session_id", None)
-        if session_id:
-            context_variables["client_id"] = session_id
+        # backward compatibility: session_id used to be an alias for client_id.
+        # Only rewrite it when the target function does NOT declare session_id
+        # as its own parameter — otherwise we'd steal the argument and Python
+        # would complain about a missing required positional.
+        if "session_id" not in params:
+            session_id = func_kwargs.pop("session_id", None)
+            if session_id:
+                context_variables["client_id"] = session_id
 
         # Ensure dict even if nothing provided/fallback empty
         if not context_variables:

--- a/pantheon/utils/adapters/gemini_cli_adapter.py
+++ b/pantheon/utils/adapters/gemini_cli_adapter.py
@@ -148,12 +148,47 @@ def _clean_schema_for_gemini_cli(schema: Any) -> Any:
 
 
 def _messages_to_gemini_rest_contents(messages: List[Dict]) -> List[Dict[str, Any]]:
-    """Convert OpenAI-style messages to Gemini REST JSON contents."""
+    """Convert OpenAI-style messages to Gemini REST JSON contents.
+
+    Gemini requires that in a "function call turn", the number of
+    ``functionResponse`` parts in the user's reply equals the number of
+    ``functionCall`` parts in the preceding model message. OpenAI-style
+    histories put each tool response in its own ``role:"tool"`` message, so
+    two parallel tool calls produce two separate tool messages. We coalesce
+    runs of consecutive ``role:"tool"`` messages into a single Gemini
+    user content with N ``functionResponse`` parts to satisfy that
+    invariant — otherwise the API rejects with HTTP 400 ``Please ensure
+    that the number of function response parts is equal to the number of
+    function call parts of the function call turn.``
+    """
     contents: List[Dict[str, Any]] = []
+    pending_tool_parts: List[Dict[str, Any]] = []
+
+    def _flush_pending() -> None:
+        if pending_tool_parts:
+            contents.append({"role": "user", "parts": list(pending_tool_parts)})
+            pending_tool_parts.clear()
+
     for message in messages:
         role = str(message.get("role") or "user")
         if role == "system":
             continue
+
+        if role == "tool":
+            # Accumulate — emit as a single user content once the next
+            # non-tool message arrives (or at end of iteration).
+            pending_tool_parts.append({
+                "functionResponse": {
+                    "name": message.get("name", "unknown"),
+                    "response": _gemini_function_response_payload(message.get("content", "")),
+                }
+            })
+            continue
+
+        # About to emit a non-tool message — first close out any pending
+        # parallel tool responses.
+        _flush_pending()
+
         parts: List[Dict[str, Any]] = []
         content = message.get("content", "")
         if isinstance(content, str) and content:
@@ -194,19 +229,14 @@ def _messages_to_gemini_rest_contents(messages: List[Dict]) -> List[Dict[str, An
                         "args": arguments,
                     }
                 })
-        elif role == "tool":
-            parts = [{
-                "functionResponse": {
-                    "name": message.get("name", "unknown"),
-                    "response": _gemini_function_response_payload(message.get("content", "")),
-                }
-            }]
 
         if parts:
             contents.append({
                 "role": "model" if role == "assistant" else "user",
                 "parts": parts,
             })
+
+    _flush_pending()
     return contents
 
 
@@ -257,6 +287,7 @@ def _extract_gemini_text_and_tool_calls(payload: Dict[str, Any]):
     parts = list((content or {}).get("parts") or []) if isinstance(content, dict) else []
     text_parts: List[str] = []
     tool_calls: List[Dict[str, Any]] = []
+    tool_call_idx = 0
     for part in parts:
         if not isinstance(part, dict):
             continue
@@ -269,11 +300,18 @@ def _extract_gemini_text_and_tool_calls(payload: Dict[str, Any]):
             args = function_call.get("args")
             if not isinstance(args, dict):
                 args = {}
+            # ``index`` MUST be set — ``stream_chunk_builder`` uses it to
+            # distinguish concurrent tool calls. Without it, the builder
+            # defaults every entry to 0 and concatenates their
+            # ``function.arguments`` strings, producing invalid JSON like
+            # ``{a:1}{b:2}`` that then fails to parse at call time.
             tool_calls.append({
+                "index": tool_call_idx,
                 "id": _gemini_tool_call_id(name),
                 "type": "function",
                 "function": {"name": name, "arguments": json.dumps(args)},
             })
+            tool_call_idx += 1
 
     stop_reason = "tool_use" if tool_calls else "end_turn"
     finish_reason = str(candidate.get("finishReason") or "").upper()

--- a/pantheon/utils/oauth/codex.py
+++ b/pantheon/utils/oauth/codex.py
@@ -16,6 +16,7 @@ import secrets
 import threading
 import time
 import webbrowser
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -182,6 +183,78 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         return  # Suppress HTTP server logs
 
 
+# ============ In-flight Login Sessions ============
+#
+# Sessions are held in-memory on the backend between `start_login()` and
+# `wait_login()` / `complete_login_from_url()`. The frontend holds only
+# the `session_id` — everything sensitive (PKCE verifier, callback server
+# handle) stays server-side.
+
+
+@dataclass
+class _LoginSession:
+    session_id: str
+    provider: str
+    verifier: str
+    state: str
+    redirect_uri: str
+    auth_url: str
+    server: Optional[ThreadingHTTPServer]
+    server_thread: Optional[threading.Thread]
+    callback_event: threading.Event
+    created_at: float
+    expires_at: float
+    manager: "CodexOAuthManager"
+    auth: Optional[dict[str, Any]] = None
+    finalized: bool = False
+    finalize_lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_SESSIONS_LOCK = threading.Lock()
+_SESSIONS: dict[str, _LoginSession] = {}
+
+
+def _get_session(session_id: str) -> _LoginSession:
+    with _SESSIONS_LOCK:
+        sess = _SESSIONS.get(session_id)
+    if sess is None:
+        raise CodexOAuthError(f"OAuth session '{session_id[:8]}…' not found or expired")
+    return sess
+
+
+def _pop_session(session_id: str) -> Optional[_LoginSession]:
+    with _SESSIONS_LOCK:
+        return _SESSIONS.pop(session_id, None)
+
+
+def _teardown_session(sess: _LoginSession) -> None:
+    server = sess.server
+    thread = sess.server_thread
+    sess.server = None
+    sess.server_thread = None
+    if server is not None:
+        try:
+            server.shutdown()
+            server.server_close()
+        except Exception as e:
+            logger.debug(f"[Codex OAuth] Callback server teardown failed: {e}")
+    if thread is not None:
+        try:
+            thread.join(timeout=2)
+        except Exception:
+            pass
+
+
+def _purge_expired_sessions() -> None:
+    now = time.time()
+    with _SESSIONS_LOCK:
+        expired_ids = [sid for sid, s in _SESSIONS.items() if s.expires_at < now]
+        expired = [_SESSIONS.pop(sid) for sid in expired_ids]
+    for s in expired:
+        logger.debug(f"[Codex OAuth] Purging expired session {s.session_id[:8]}…")
+        _teardown_session(s)
+
+
 # ============ OAuth Manager ============
 
 
@@ -247,21 +320,27 @@ class CodexOAuthManager:
             return True
         return bool(refresh_token)
 
-    # ---- Login Flow ----
+    # ---- Login Flow (split for frontend-driven browser) ----
 
-    def login(
-        self,
-        *,
-        open_browser: bool = True,
-        timeout_seconds: int = 300,
-    ) -> dict[str, Any]:
-        """Start browser-based OAuth login flow.
+    def start_login(self, *, session_ttl_seconds: int = 600) -> dict[str, Any]:
+        """Prepare an OAuth login session — non-blocking.
 
-        Opens browser to OpenAI auth page. User logs in, callback
-        redirects to local server. Returns auth record with tokens.
+        Generates PKCE + state, starts the local callback server, and returns
+        ``{session_id, auth_url, redirect_uri, expires_at}``. The caller
+        (frontend) opens ``auth_url`` in the user's own browser, then calls
+        :meth:`wait_login` (backend-receives-callback path) or
+        :meth:`complete_login_from_url` (user-pastes-URL path).
+
+        Splitting ``login()`` lets the frontend drive ``window.open(auth_url)``
+        so the tab lands on the user's machine — the old ``webbrowser.open``
+        from the Python process only works when backend and user share a
+        desktop (local mode). For WSL / Docker / remote it doesn't.
         """
+        _purge_expired_sessions()
+
         verifier, challenge = _pkce_pair()
         state = _b64url(secrets.token_bytes(24))
+        session_id = _b64url(secrets.token_bytes(12))
 
         event = threading.Event()
         server = self._create_server(event)
@@ -284,51 +363,157 @@ class CodexOAuthManager:
             })
         )
 
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
 
-        try:
-            logger.info(f"[Codex OAuth] Opening browser for login...")
-            logger.info(f"[Codex OAuth] Auth URL: {auth_url}")
-            if open_browser:
-                webbrowser.open(auth_url)
+        now = time.time()
+        sess = _LoginSession(
+            session_id=session_id,
+            provider="codex",
+            verifier=verifier,
+            state=state,
+            redirect_uri=redirect_uri,
+            auth_url=auth_url,
+            server=server,
+            server_thread=server_thread,
+            callback_event=event,
+            created_at=now,
+            expires_at=now + session_ttl_seconds,
+            manager=self,
+        )
+        with _SESSIONS_LOCK:
+            _SESSIONS[session_id] = sess
 
-            if not event.wait(timeout_seconds):
-                raise CodexOAuthError("Timed out waiting for OAuth callback")
-
-            params = getattr(server, "result", {}) or {}
-        finally:
-            server.shutdown()
-            server.server_close()
-            thread.join(timeout=2)
-
-        # Validate callback
-        if params.get("state") != state:
-            raise CodexOAuthError("OAuth callback state mismatch")
-        if params.get("error"):
-            raise CodexOAuthError(f"OAuth failed: {params.get('error_description', params['error'])}")
-
-        code = str(params.get("code", "")).strip()
-        if not code:
-            raise CodexOAuthError("OAuth callback missing authorization code")
-
-        # Exchange code for tokens
-        tokens = _exchange_code(code, redirect_uri, verifier)
-        claims = _jwt_org_context(tokens["id_token"])
-
-        auth = {
-            "provider": "codex",
-            "tokens": {
-                **tokens,
-                "account_id": claims.get("chatgpt_account_id"),
-                "organization_id": claims.get("organization_id"),
-                "project_id": claims.get("project_id"),
-            },
-            "last_refresh": _utc_now(),
+        logger.info(
+            f"[Codex OAuth] Session {session_id[:8]}… started; "
+            f"callback redirect_uri={redirect_uri}"
+        )
+        return {
+            "session_id": session_id,
+            "auth_url": auth_url,
+            "redirect_uri": redirect_uri,
+            "expires_at": sess.expires_at,
         }
 
-        logger.info("[Codex OAuth] Login successful")
-        return self._save(auth)
+    def wait_login(
+        self,
+        session_id: str,
+        timeout_seconds: int = 300,
+    ) -> dict[str, Any]:
+        """Block until the local callback server sees a redirect, then finalize.
+
+        Times out without cleaning up the session — caller can still fall
+        back to :meth:`complete_login_from_url` afterwards (useful when the
+        user's browser can't reach our callback host, e.g. in remote mode).
+        """
+        sess = _get_session(session_id)
+        if sess.finalized:
+            return sess.auth  # type: ignore[return-value]
+        if not sess.callback_event.wait(timeout_seconds):
+            raise CodexOAuthError("Timed out waiting for OAuth callback")
+        # Callback handler wrote to sess.server.result; move into finalize path.
+        params = dict(getattr(sess.server, "result", {}) or {})
+        return self._finalize_login(sess, params)
+
+    def complete_login_from_url(
+        self,
+        session_id: str,
+        callback_url: str,
+    ) -> dict[str, Any]:
+        """Finalize by parsing a callback URL the user pasted manually.
+
+        Remote / WSL1 / Docker-without-port-mapping scenarios: the browser
+        redirect lands on an unreachable host, but the address bar still
+        holds ``...?code=...&state=...``. The frontend takes that string
+        and sends it here.
+        """
+        sess = _get_session(session_id)
+        if sess.finalized:
+            return sess.auth  # type: ignore[return-value]
+        parsed = urlparse(callback_url)
+        params: dict[str, str] = {k: v[-1] for k, v in parse_qs(parsed.query).items() if v}
+        if not params:
+            raise CodexOAuthError("Callback URL has no query parameters (no ?code=…)")
+        return self._finalize_login(sess, params)
+
+    def cancel_login(self, session_id: str) -> None:
+        """Abort an in-flight login session and release its callback server."""
+        sess = _pop_session(session_id)
+        if sess is not None:
+            _teardown_session(sess)
+
+    # ---- Back-compat wrapper for CLI & old single-shot callers ----
+
+    def login(
+        self,
+        *,
+        open_browser: bool = True,
+        timeout_seconds: int = 300,
+    ) -> dict[str, Any]:
+        """Start → open browser → wait, in one call. Kept for CLI use."""
+        started = self.start_login()
+        auth_url = started["auth_url"]
+        session_id = started["session_id"]
+        logger.info(f"[Codex OAuth] Auth URL: {auth_url}")
+        if open_browser:
+            try:
+                webbrowser.open(auth_url)
+                logger.info("[Codex OAuth] Opened browser for login")
+            except Exception as e:
+                logger.warning(f"[Codex OAuth] Failed to open browser automatically: {e}")
+        try:
+            return self.wait_login(session_id, timeout_seconds)
+        except Exception:
+            self.cancel_login(session_id)
+            raise
+
+    # ---- Finalize (shared between callback-server and paste-URL paths) ----
+
+    def _finalize_login(
+        self,
+        sess: "_LoginSession",
+        params: dict[str, str],
+    ) -> dict[str, Any]:
+        """Validate callback params, exchange for tokens, save. Idempotent.
+
+        Always drops the session (frees the callback server) on exit, even
+        on validation / exchange errors — caller starts a fresh session to
+        retry.
+        """
+        with sess.finalize_lock:
+            if sess.finalized and sess.auth is not None:
+                return sess.auth
+            try:
+                if params.get("state") != sess.state:
+                    raise CodexOAuthError("OAuth callback state mismatch")
+                if params.get("error"):
+                    raise CodexOAuthError(
+                        f"OAuth failed: {params.get('error_description', params['error'])}"
+                    )
+                code = str(params.get("code", "")).strip()
+                if not code:
+                    raise CodexOAuthError("OAuth callback missing authorization code")
+
+                tokens = _exchange_code(code, sess.redirect_uri, sess.verifier)
+                claims = _jwt_org_context(tokens["id_token"])
+                auth = {
+                    "provider": "codex",
+                    "tokens": {
+                        **tokens,
+                        "account_id": claims.get("chatgpt_account_id"),
+                        "organization_id": claims.get("organization_id"),
+                        "project_id": claims.get("project_id"),
+                    },
+                    "last_refresh": _utc_now(),
+                }
+                saved = self._save(auth)
+                sess.auth = saved
+                sess.finalized = True
+                logger.info("[Codex OAuth] Login successful")
+                return saved
+            finally:
+                _pop_session(sess.session_id)
+                _teardown_session(sess)
 
     # ---- Refresh ----
 

--- a/pantheon/utils/oauth/gemini.py
+++ b/pantheon/utils/oauth/gemini.py
@@ -16,10 +16,11 @@ import secrets
 import threading
 import time
 import webbrowser
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
@@ -64,6 +65,37 @@ GEMINI_CLI_AUTH = Path.home() / ".gemini" / "oauth_creds.json"
 
 _GOOGLE_CLIENT_ID_RE = re.compile(r"(\d+-[a-z0-9]+\.apps\.googleusercontent\.com)")
 _GOOGLE_CLIENT_SECRET_RE = re.compile(r"(GOCSPX-[A-Za-z0-9_-]+)")
+
+# The Gemini CLI source assigns its OAuth creds to literal variable names.
+# We prefer these anchored matches over the bare regexes above, because
+# recent bundles also contain CLOUD_SDK_CLIENT_ID (a non-OAuth client used
+# for google-cloud SDK telemetry); picking that one pairs it with the real
+# secret and the token exchange fails with "invalid_client".
+_OAUTH_ID_ASSIGN_RE = re.compile(
+    r"OAUTH_CLIENT_ID\s*[:=]\s*['\"](\d+-[a-z0-9]+\.apps\.googleusercontent\.com)['\"]"
+)
+_OAUTH_SECRET_ASSIGN_RE = re.compile(
+    r"OAUTH_CLIENT_SECRET\s*[:=]\s*['\"](GOCSPX-[A-Za-z0-9_-]+)['\"]"
+)
+
+
+def _extract_creds_from_text(text: str) -> tuple[str, str | None] | None:
+    """Prefer ``OAUTH_CLIENT_ID``/``OAUTH_CLIENT_SECRET`` assignments; fall
+    back to loose pattern matching only if those named constants are absent.
+    """
+    id_match = _OAUTH_ID_ASSIGN_RE.search(text)
+    secret_match = _OAUTH_SECRET_ASSIGN_RE.search(text)
+    if id_match and secret_match:
+        return id_match.group(1), secret_match.group(1)
+    if id_match:
+        loose_secret = _GOOGLE_CLIENT_SECRET_RE.search(text)
+        return id_match.group(1), loose_secret.group(1) if loose_secret else None
+    # No named OAUTH_CLIENT_ID — fall through to the loose, legacy match.
+    cid = _GOOGLE_CLIENT_ID_RE.search(text)
+    if not cid:
+        return None
+    sec = _GOOGLE_CLIENT_SECRET_RE.search(text)
+    return cid.group(1), sec.group(1) if sec else None
 
 
 class GeminiCliOAuthError(RuntimeError):
@@ -180,11 +212,51 @@ def _find_file(root: Path, filename: str, depth: int = 10) -> Path | None:
     return None
 
 
+def _scan_js_for_oauth_creds(root: Path, depth: int = 5) -> tuple[str, str | None] | None:
+    """Walk ``root`` and return the first ``(client_id, client_secret)`` found
+    in any ``.js`` file. Used as a fallback when the unminified ``oauth2.js``
+    isn't shipped (e.g. Homebrew bundles everything into ``bundle/chunk-*.js``).
+
+    Prefers files that contain the anchored ``OAUTH_CLIENT_ID`` assignment
+    (first pass) over files that only contain a loose ``apps.googleusercontent.com``
+    match (second pass) — the latter picks up unrelated constants like
+    ``CLOUD_SDK_CLIENT_ID`` which are not paired with the real OAuth secret.
+    """
+    if depth <= 0 or not root.is_dir():
+        return None
+    try:
+        entries = list(root.iterdir())
+    except Exception:
+        return None
+
+    # Pass 1: files in this directory that contain OAUTH_CLIENT_ID = "..."
+    for entry in entries:
+        if entry.is_file() and entry.suffix == ".js":
+            try:
+                text = entry.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+            if _OAUTH_ID_ASSIGN_RE.search(text):
+                match = _extract_creds_from_text(text)
+                if match is not None:
+                    return match
+
+    # Recurse into subdirectories, still preferring the anchored pattern.
+    for entry in entries:
+        if entry.is_dir() and not entry.name.startswith("."):
+            match = _scan_js_for_oauth_creds(entry, depth - 1)
+            if match is not None:
+                return match
+
+    return None
+
+
 def extract_gemini_cli_credentials() -> tuple[str, str | None] | None:
     gemini_path = _find_binary_on_path("gemini")
     if gemini_path is None:
         return None
 
+    # Fast path — npm-style install keeps unminified source at known paths.
     content = ""
     for root in _candidate_gemini_cli_dirs(gemini_path):
         search_paths = [
@@ -210,15 +282,22 @@ def extract_gemini_cli_credentials() -> tuple[str, str | None] | None:
             if content:
                 break
 
-    if not content:
-        return None
+    if content:
+        found = _extract_creds_from_text(content)
+        if found is not None:
+            return found
 
-    client_id_match = _GOOGLE_CLIENT_ID_RE.search(content)
-    client_secret_match = _GOOGLE_CLIENT_SECRET_RE.search(content)
-    if not client_id_match:
-        return None
-    secret = client_secret_match.group(1) if client_secret_match else None
-    return client_id_match.group(1), secret
+    # Fallback — Homebrew / esbuild-bundled installs split oauth logic into
+    # bundle/chunk-*.js. Scan every .js under the gemini-cli package dir for
+    # the first file that carries the OAUTH_CLIENT_ID assignment.
+    for root in _candidate_gemini_cli_dirs(gemini_path):
+        if not root.exists() or not root.is_dir():
+            continue
+        match = _scan_js_for_oauth_creds(root, depth=5)
+        if match is not None:
+            return match
+
+    return None
 
 
 def resolve_oauth_client_config() -> tuple[str, str | None]:
@@ -638,6 +717,75 @@ class _OAuthCallbackHandler(BaseHTTPRequestHandler):
         return
 
 
+# ============ In-flight Login Sessions ============
+# Mirrors the design in codex.py: the frontend holds only a session_id,
+# everything sensitive stays server-side.
+
+
+@dataclass
+class _GeminiLoginSession:
+    session_id: str
+    verifier: str
+    state: str
+    redirect_uri: str
+    auth_url: str
+    server: Optional[ThreadingHTTPServer]
+    server_thread: Optional[threading.Thread]
+    callback_event: threading.Event
+    created_at: float
+    expires_at: float
+    manager: "GeminiCliOAuthManager"
+    auth: Optional[dict[str, Any]] = None
+    finalized: bool = False
+    finalize_lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_GEMINI_SESSIONS_LOCK = threading.Lock()
+_GEMINI_SESSIONS: dict[str, _GeminiLoginSession] = {}
+
+
+def _get_gemini_session(session_id: str) -> _GeminiLoginSession:
+    with _GEMINI_SESSIONS_LOCK:
+        sess = _GEMINI_SESSIONS.get(session_id)
+    if sess is None:
+        raise GeminiCliOAuthError(
+            f"OAuth session '{session_id[:8]}…' not found or expired"
+        )
+    return sess
+
+
+def _pop_gemini_session(session_id: str) -> Optional[_GeminiLoginSession]:
+    with _GEMINI_SESSIONS_LOCK:
+        return _GEMINI_SESSIONS.pop(session_id, None)
+
+
+def _teardown_gemini_session(sess: _GeminiLoginSession) -> None:
+    server = sess.server
+    thread = sess.server_thread
+    sess.server = None
+    sess.server_thread = None
+    if server is not None:
+        try:
+            server.shutdown()
+            server.server_close()
+        except Exception as e:
+            logger.debug(f"[Gemini CLI OAuth] Callback server teardown failed: {e}")
+    if thread is not None:
+        try:
+            thread.join(timeout=2)
+        except Exception:
+            pass
+
+
+def _purge_expired_gemini_sessions() -> None:
+    now = time.time()
+    with _GEMINI_SESSIONS_LOCK:
+        expired_ids = [sid for sid, s in _GEMINI_SESSIONS.items() if s.expires_at < now]
+        expired = [_GEMINI_SESSIONS.pop(sid) for sid in expired_ids]
+    for s in expired:
+        _teardown_gemini_session(s)
+
+
 class GeminiCliOAuthManager:
     """Manage Gemini CLI OAuth state."""
 
@@ -818,14 +966,15 @@ class GeminiCliOAuthManager:
             return self.refresh(record=normalized)
         return self.save(normalized)
 
-    def login(
-        self,
-        *,
-        open_browser: bool = True,
-        timeout_seconds: int = 300,
-    ) -> dict[str, Any]:
+    # ---- Login Flow (split for frontend-driven browser) ----
+
+    def start_login(self, *, session_ttl_seconds: int = 600) -> dict[str, Any]:
+        """Prepare an OAuth login session. See codex.start_login for rationale."""
+        _purge_expired_gemini_sessions()
+
         verifier, challenge = _pkce_pair()
         state = verifier
+        session_id = _b64url(secrets.token_bytes(12))
         client_id, _ = resolve_oauth_client_config()
         auth_url = (
             f"{GOOGLE_AUTH_URL}?"
@@ -845,39 +994,117 @@ class GeminiCliOAuthManager:
         )
 
         server = self._create_callback_server()
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-        try:
-            if open_browser:
-                try:
-                    webbrowser.open(auth_url)
-                except Exception:
-                    pass
-            if not server.event.wait(timeout_seconds):  # type: ignore[attr-defined]
-                raise GeminiCliOAuthError("Timed out waiting for Gemini CLI OAuth callback")
-            params = dict(getattr(server, "result", {}) or {})
-        finally:
-            server.shutdown()
-            server.server_close()
-            thread.join(timeout=2)
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
 
-        if str(params.get("state") or "").strip() != state:
-            raise GeminiCliOAuthError("Gemini CLI OAuth callback state mismatch")
-        if params.get("error"):
-            raise GeminiCliOAuthError(
-                f"Gemini CLI OAuth failed: {params.get('error_description') or params['error']}"
-            )
-        code = str(params.get("code") or "").strip()
-        if not code:
-            raise GeminiCliOAuthError("Gemini CLI OAuth callback did not include a code")
+        now = time.time()
+        sess = _GeminiLoginSession(
+            session_id=session_id,
+            verifier=verifier,
+            state=state,
+            redirect_uri=GOOGLE_REDIRECT_URI,
+            auth_url=auth_url,
+            server=server,
+            server_thread=server_thread,
+            callback_event=server.event,  # type: ignore[attr-defined]
+            created_at=now,
+            expires_at=now + session_ttl_seconds,
+            manager=self,
+        )
+        with _GEMINI_SESSIONS_LOCK:
+            _GEMINI_SESSIONS[session_id] = sess
 
-        tokens = exchange_code_for_tokens(code=code, code_verifier=verifier)
-        record = {
-            "provider": "gemini_cli",
-            "tokens": tokens,
-            "last_refresh": _utc_now(),
+        logger.info(
+            f"[Gemini CLI OAuth] Session {session_id[:8]}… started; "
+            f"callback redirect_uri={GOOGLE_REDIRECT_URI}"
+        )
+        return {
+            "session_id": session_id,
+            "auth_url": auth_url,
+            "redirect_uri": GOOGLE_REDIRECT_URI,
+            "expires_at": sess.expires_at,
         }
-        return self.save(record)
+
+    def wait_login(self, session_id: str, timeout_seconds: int = 300) -> dict[str, Any]:
+        sess = _get_gemini_session(session_id)
+        if sess.finalized:
+            return sess.auth  # type: ignore[return-value]
+        if not sess.callback_event.wait(timeout_seconds):
+            raise GeminiCliOAuthError("Timed out waiting for Gemini CLI OAuth callback")
+        params = dict(getattr(sess.server, "result", {}) or {})
+        return self._finalize_login(sess, params)
+
+    def complete_login_from_url(self, session_id: str, callback_url: str) -> dict[str, Any]:
+        sess = _get_gemini_session(session_id)
+        if sess.finalized:
+            return sess.auth  # type: ignore[return-value]
+        parsed = urlparse(callback_url)
+        params: dict[str, str] = {k: v[-1] for k, v in parse_qs(parsed.query).items() if v}
+        if not params:
+            raise GeminiCliOAuthError("Callback URL has no query parameters (no ?code=…)")
+        return self._finalize_login(sess, params)
+
+    def cancel_login(self, session_id: str) -> None:
+        sess = _pop_gemini_session(session_id)
+        if sess is not None:
+            _teardown_gemini_session(sess)
+
+    def login(
+        self,
+        *,
+        open_browser: bool = True,
+        timeout_seconds: int = 300,
+    ) -> dict[str, Any]:
+        """Start → open browser → wait, in one call. Kept for CLI use."""
+        started = self.start_login()
+        auth_url = started["auth_url"]
+        session_id = started["session_id"]
+        if open_browser:
+            try:
+                webbrowser.open(auth_url)
+            except Exception as e:
+                logger.warning(f"[Gemini CLI OAuth] Failed to open browser: {e}")
+        try:
+            return self.wait_login(session_id, timeout_seconds)
+        except Exception:
+            self.cancel_login(session_id)
+            raise
+
+    def _finalize_login(
+        self,
+        sess: "_GeminiLoginSession",
+        params: dict[str, str],
+    ) -> dict[str, Any]:
+        """Validate callback params, exchange for tokens, save. Idempotent."""
+        with sess.finalize_lock:
+            if sess.finalized and sess.auth is not None:
+                return sess.auth
+            try:
+                if str(params.get("state") or "").strip() != sess.state:
+                    raise GeminiCliOAuthError("Gemini CLI OAuth callback state mismatch")
+                if params.get("error"):
+                    raise GeminiCliOAuthError(
+                        f"Gemini CLI OAuth failed: "
+                        f"{params.get('error_description') or params['error']}"
+                    )
+                code = str(params.get("code") or "").strip()
+                if not code:
+                    raise GeminiCliOAuthError("Gemini CLI OAuth callback did not include a code")
+
+                tokens = exchange_code_for_tokens(code=code, code_verifier=sess.verifier)
+                record = {
+                    "provider": "gemini_cli",
+                    "tokens": tokens,
+                    "last_refresh": _utc_now(),
+                }
+                saved = self.save(record)
+                sess.auth = saved
+                sess.finalized = True
+                logger.info("[Gemini CLI OAuth] Login successful")
+                return saved
+            finally:
+                _pop_gemini_session(sess.session_id)
+                _teardown_gemini_session(sess)
 
     def refresh(self, record: dict[str, Any] | None = None) -> dict[str, Any]:
         auth = _normalize_auth_record(record or self.load())

--- a/tests/test_gemini_cli_adapter_parsing.py
+++ b/tests/test_gemini_cli_adapter_parsing.py
@@ -1,0 +1,182 @@
+"""Regression tests for Gemini CLI adapter parsing.
+
+Protects against the bug where multiple ``functionCall`` parts in a single
+Gemini response got merged into one tool_call with concatenated ``arguments``
+strings (``{a}{b}``), producing invalid JSON at call time. Root cause was
+the missing ``index`` field on emitted tool_calls — ``stream_chunk_builder``
+keys tool_calls by ``index`` and, when it's missing, every entry defaults to
+``0`` and their ``function.arguments`` get ``+=`` concatenated.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pantheon.utils.adapters.gemini_cli_adapter import _extract_gemini_text_and_tool_calls
+from pantheon.utils.llm import stream_chunk_builder
+
+
+def test_multiple_function_calls_get_distinct_indices():
+    payload = {
+        "candidates": [{
+            "content": {
+                "parts": [
+                    {"functionCall": {"name": "write_file", "args": {"path": "/a", "content": "foo"}}},
+                    {"functionCall": {"name": "write_file", "args": {"path": "/b", "content": "bar"}}},
+                ],
+            },
+            "finishReason": "STOP",
+        }],
+    }
+    _text, tool_calls, _raw, _stop = _extract_gemini_text_and_tool_calls(payload)
+
+    assert len(tool_calls) == 2
+    indices = [tc.get("index") for tc in tool_calls]
+    assert indices == [0, 1], f"expected sequential indices, got {indices}"
+
+
+def test_single_function_call_still_has_index_zero():
+    payload = {
+        "candidates": [{
+            "content": {
+                "parts": [
+                    {"functionCall": {"name": "search", "args": {"q": "hello"}}},
+                ],
+            },
+            "finishReason": "STOP",
+        }],
+    }
+    _text, tool_calls, _raw, _stop = _extract_gemini_text_and_tool_calls(payload)
+    assert len(tool_calls) == 1
+    assert tool_calls[0].get("index") == 0
+
+
+def test_builder_keeps_parallel_tool_calls_separate():
+    """End-to-end: parsed parts → stream_chunk_builder → assembled message.
+    Before the fix this test would produce a single tool_call whose
+    ``function.arguments`` is ``{...}{...}`` (invalid JSON).
+    """
+    payload = {
+        "candidates": [{
+            "content": {
+                "parts": [
+                    {"functionCall": {"name": "write_file", "args": {"path": "/a", "content": "foo"}}},
+                    {"functionCall": {"name": "write_file", "args": {"path": "/b", "content": "bar"}}},
+                ],
+            },
+            "finishReason": "STOP",
+        }],
+    }
+    _text, tool_calls, _raw, _stop = _extract_gemini_text_and_tool_calls(payload)
+    chunks = [
+        {"choices": [{"index": 0, "delta": {"role": "assistant", "tool_calls": tool_calls}, "finish_reason": None}]},
+        {"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]},
+    ]
+    resp = stream_chunk_builder(chunks)
+    built = resp.choices[0].message.tool_calls
+
+    assert built is not None and len(built) == 2
+    # Both must have valid JSON arguments (the bug made them invalid)
+    for tc in built:
+        args = json.loads(tc["function"]["arguments"])
+        assert "path" in args and "content" in args
+
+
+def test_text_only_response_has_no_tool_calls():
+    payload = {
+        "candidates": [{
+            "content": {"parts": [{"text": "hello"}]},
+            "finishReason": "STOP",
+        }],
+    }
+    text, tool_calls, _raw, _stop = _extract_gemini_text_and_tool_calls(payload)
+    assert text == "hello"
+    assert tool_calls == []
+
+
+# ============================================================================
+# _messages_to_gemini_rest_contents — parallel tool-response coalescing
+# ============================================================================
+
+from pantheon.utils.adapters.gemini_cli_adapter import _messages_to_gemini_rest_contents
+
+
+def test_parallel_tool_responses_coalesce_into_one_user_content():
+    """Gemini requires the number of functionResponse parts in the user
+    turn to equal the number of functionCall parts in the preceding model
+    turn. Our OpenAI-style history has one tool message per tool_call_id,
+    so two parallel calls end up as two separate tool messages. The
+    adapter must merge them into a single user content.
+    """
+    messages = [
+        {"role": "user", "content": "do two things"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "write_file", "arguments": '{"path":"/a"}'}},
+                {"id": "c2", "type": "function", "function": {"name": "write_file", "arguments": '{"path":"/b"}'}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "name": "write_file", "content": '{"ok":true,"path":"/a"}'},
+        {"role": "tool", "tool_call_id": "c2", "name": "write_file", "content": '{"ok":true,"path":"/b"}'},
+        {"role": "user", "content": "thanks"},
+    ]
+
+    contents = _messages_to_gemini_rest_contents(messages)
+
+    # Expect 4 contents: user(text), model(2 functionCalls), user(2 functionResponses), user(text)
+    roles = [c["role"] for c in contents]
+    assert roles == ["user", "model", "user", "user"], roles
+
+    model_parts = contents[1]["parts"]
+    function_calls = [p for p in model_parts if "functionCall" in p]
+    assert len(function_calls) == 2
+
+    tool_response_content = contents[2]
+    function_responses = [p for p in tool_response_content["parts"] if "functionResponse" in p]
+    assert len(function_responses) == 2, (
+        f"Expected 2 functionResponse parts coalesced, got {len(function_responses)}"
+    )
+    assert len(function_responses) == len(function_calls), (
+        "Gemini requires matching counts of functionCall ↔ functionResponse"
+    )
+
+
+def test_single_tool_response_still_emits_single_user_content():
+    """Single tool call path: no coalescing regression."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "read", "arguments": '{"p":"/a"}'}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "name": "read", "content": '{"ok":true}'},
+    ]
+    contents = _messages_to_gemini_rest_contents(messages)
+    assert [c["role"] for c in contents] == ["model", "user"]
+    assert len(contents[1]["parts"]) == 1
+    assert "functionResponse" in contents[1]["parts"][0]
+
+
+def test_tool_messages_at_end_still_get_flushed():
+    """A trailing run of tool messages must still be emitted."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "read", "arguments": "{}"}},
+                {"id": "c2", "type": "function", "function": {"name": "read", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "name": "read", "content": "ok"},
+        {"role": "tool", "tool_call_id": "c2", "name": "read", "content": "ok"},
+    ]
+    contents = _messages_to_gemini_rest_contents(messages)
+    assert [c["role"] for c in contents] == ["model", "user"]
+    assert sum(1 for p in contents[1]["parts"] if "functionResponse" in p) == 2

--- a/tests/test_oauth_split_flow.py
+++ b/tests/test_oauth_split_flow.py
@@ -1,0 +1,207 @@
+"""Tests for the split OAuth login flow (start / wait / complete / cancel).
+
+The old ``login()`` was all-in-one: backend opened the browser, backend ran
+a local callback server, backend blocked until the redirect came back.
+That doesn't work when the backend isn't on the user's desktop (WSL1,
+remote, headless). The split flow lets the frontend drive
+``window.open(auth_url)`` instead, and adds a paste-URL fallback when the
+browser can't reach the callback host.
+
+These tests patch the token-exchange network call so everything runs
+in-process.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pantheon.utils.oauth import codex as codex_mod
+from pantheon.utils.oauth.codex import CodexOAuthError, CodexOAuthManager
+
+
+def _fake_exchange_code(code: str, redirect_uri: str, verifier: str) -> dict:
+    """Stand-in for the POST /oauth/token call. Returns deterministic fake tokens."""
+    return {
+        "id_token": "fake.id.token",
+        "access_token": f"access-for-{code}",
+        "refresh_token": "refresh-abc",
+    }
+
+
+def _fake_jwt_claims(_token: str) -> dict:
+    return {
+        "chatgpt_account_id": "acct-test",
+        "organization_id": "org-test",
+        "project_id": "proj-test",
+    }
+
+
+@pytest.fixture
+def codex_mgr(tmp_path: Path, monkeypatch):
+    """Codex manager with isolated auth file and patched token exchange."""
+    auth_file = tmp_path / "codex_auth.json"
+    monkeypatch.setattr(codex_mod, "_exchange_code", _fake_exchange_code)
+    monkeypatch.setattr(codex_mod, "_jwt_org_context", _fake_jwt_claims)
+    # Reset in-memory session store between tests
+    with codex_mod._SESSIONS_LOCK:
+        codex_mod._SESSIONS.clear()
+    return CodexOAuthManager(auth_file=auth_file)
+
+
+# ============================================================================
+# start_login
+# ============================================================================
+
+
+def test_start_login_returns_session_id_and_auth_url(codex_mgr):
+    result = codex_mgr.start_login()
+
+    assert result["session_id"]
+    assert result["auth_url"].startswith("https://auth.openai.com/oauth/authorize?")
+    assert "code_challenge=" in result["auth_url"]
+    assert "state=" in result["auth_url"]
+    assert result["redirect_uri"].startswith("http://localhost:")
+    assert result["expires_at"] > 0
+
+    # Session is kept in the in-memory store so wait/complete can find it.
+    sess = codex_mod._get_session(result["session_id"])
+    assert sess.provider == "codex"
+    assert not sess.finalized
+    # Teardown to release the callback port
+    codex_mgr.cancel_login(result["session_id"])
+
+
+def test_start_login_every_call_makes_a_fresh_session(codex_mgr):
+    a = codex_mgr.start_login()
+    b = codex_mgr.start_login()
+    assert a["session_id"] != b["session_id"]
+    assert a["redirect_uri"] != b["redirect_uri"]  # different random ports
+    codex_mgr.cancel_login(a["session_id"])
+    codex_mgr.cancel_login(b["session_id"])
+
+
+# ============================================================================
+# complete_login_from_url (paste-URL fallback)
+# ============================================================================
+
+
+def test_complete_login_from_url_happy_path(codex_mgr):
+    started = codex_mgr.start_login()
+    sess = codex_mod._get_session(started["session_id"])
+    callback = f"{started['redirect_uri']}?code=ABC123&state={sess.state}"
+
+    auth = codex_mgr.complete_login_from_url(started["session_id"], callback)
+
+    assert auth["provider"] == "codex"
+    assert auth["tokens"]["access_token"] == "access-for-ABC123"
+    assert auth["tokens"]["account_id"] == "acct-test"
+    # Session has been dropped so a second attempt fails cleanly.
+    with pytest.raises(CodexOAuthError):
+        codex_mod._get_session(started["session_id"])
+
+
+def test_complete_login_from_url_rejects_state_mismatch(codex_mgr):
+    started = codex_mgr.start_login()
+    callback = f"{started['redirect_uri']}?code=ABC123&state=someone-elses-state"
+
+    with pytest.raises(CodexOAuthError, match="state mismatch"):
+        codex_mgr.complete_login_from_url(started["session_id"], callback)
+
+    # Session was torn down even on error — can't retry with the same session.
+    with pytest.raises(CodexOAuthError):
+        codex_mod._get_session(started["session_id"])
+
+
+def test_complete_login_from_url_rejects_missing_code(codex_mgr):
+    started = codex_mgr.start_login()
+    sess = codex_mod._get_session(started["session_id"])
+    callback = f"{started['redirect_uri']}?state={sess.state}"
+
+    with pytest.raises(CodexOAuthError, match="missing authorization code"):
+        codex_mgr.complete_login_from_url(started["session_id"], callback)
+
+
+def test_complete_login_from_url_rejects_error_param(codex_mgr):
+    started = codex_mgr.start_login()
+    sess = codex_mod._get_session(started["session_id"])
+    callback = (
+        f"{started['redirect_uri']}?error=access_denied"
+        f"&error_description=User+cancelled&state={sess.state}"
+    )
+
+    with pytest.raises(CodexOAuthError, match="User cancelled"):
+        codex_mgr.complete_login_from_url(started["session_id"], callback)
+
+
+def test_complete_login_from_url_rejects_unknown_session(codex_mgr):
+    with pytest.raises(CodexOAuthError, match="not found or expired"):
+        codex_mgr.complete_login_from_url(
+            "abcdef1234567890", "http://localhost:1/auth/callback?code=x&state=y"
+        )
+
+
+def test_complete_login_from_url_rejects_empty_query(codex_mgr):
+    started = codex_mgr.start_login()
+    callback = started["redirect_uri"]  # no ?query
+
+    with pytest.raises(CodexOAuthError, match="no query parameters"):
+        codex_mgr.complete_login_from_url(started["session_id"], callback)
+
+
+# ============================================================================
+# wait_login + cancel_login
+# ============================================================================
+
+
+def test_wait_login_times_out_without_destroying_session(codex_mgr):
+    """After a timeout the caller can still fall back to paste-URL —
+    so the session must survive timeouts."""
+    started = codex_mgr.start_login()
+
+    with pytest.raises(CodexOAuthError, match="Timed out"):
+        codex_mgr.wait_login(started["session_id"], timeout_seconds=0)
+
+    # Session is still usable for the paste-URL fallback.
+    sess = codex_mod._get_session(started["session_id"])
+    callback = f"{started['redirect_uri']}?code=AFTER_TIMEOUT&state={sess.state}"
+    auth = codex_mgr.complete_login_from_url(started["session_id"], callback)
+    assert auth["tokens"]["access_token"] == "access-for-AFTER_TIMEOUT"
+
+
+def test_cancel_login_releases_session(codex_mgr):
+    started = codex_mgr.start_login()
+    codex_mgr.cancel_login(started["session_id"])
+    with pytest.raises(CodexOAuthError, match="not found or expired"):
+        codex_mgr.complete_login_from_url(
+            started["session_id"], f"{started['redirect_uri']}?code=x&state=y"
+        )
+
+
+# ============================================================================
+# Back-compat: old login() wrapper still works
+# ============================================================================
+
+
+def test_login_wrapper_calls_start_open_browser_wait(codex_mgr, monkeypatch):
+    """``login(open_browser=False)`` should start a session, skip browser,
+    then wait. With a 0 timeout and no browser it should raise — but the
+    session still gets cleaned up via the wrapper's except path."""
+
+    calls = {"opened": 0}
+    monkeypatch.setattr(
+        codex_mod.webbrowser,
+        "open",
+        lambda url: calls.__setitem__("opened", calls["opened"] + 1),
+    )
+
+    with pytest.raises(CodexOAuthError, match="Timed out"):
+        codex_mgr.login(open_browser=False, timeout_seconds=0)
+
+    assert calls["opened"] == 0
+
+    # Session was torn down by the wrapper's except-path cancel.
+    with codex_mod._SESSIONS_LOCK:
+        assert not codex_mod._SESSIONS, "wrapper must clean up on failure"


### PR DESCRIPTION
## Summary

Two related groups of changes that land together.

### 1. OAuth login flow (`69c76ca`)

Splits the backend's all-in-one `login()` into `start_login` / `wait_login` / `complete_login_from_url` / `cancel_login`, so the frontend can drive `window.open(auth_url)` on the user's own browser instead of relying on the backend Python process to spawn a tab. Adds a manual paste-URL fallback for setups where the backend's callback host is unreachable from the user's browser (remote / WSL1 / docker without port mapping). Fixes:

- WSL: Python side often can't spawn the Windows default browser reliably.
- Remote/headless: `webbrowser.open` has nothing to open.
- Homebrew Gemini CLI installs: `extract_gemini_cli_credentials` now handles the bundled `bundle/chunk-*.js` layout (not just npm-style `oauth2.js`) and prefers the anchored `OAUTH_CLIENT_ID = "..."` assignment over the loose regex so it doesn't pick `CLOUD_SDK_CLIENT_ID` by mistake.
- The `@tool` decorator's `session_id → client_id` back-compat alias was stealing the argument from tools that declare `session_id` themselves; now guarded by `"session_id" not in params`.

New tools in `ChatRoom`: `oauth_start`, `oauth_wait`, `oauth_complete`, `oauth_cancel`. Legacy `oauth_login` kept for back-compat.

Frontend companion PR: https://github.com/Nanguage/pantheon-ui (`feat/oauth-paste-and-tool-details`).

### 2. Gemini CLI adapter parallel tool-call fixes (`f22e1d7`)

`gemini-cli/gemini-3.1-pro` likes to emit multiple `functionCall` parts per turn. Two bugs broke that:

- `_extract_gemini_text_and_tool_calls` appended tool_call dicts without an `index` field → `stream_chunk_builder` defaults missing index to 0 → all calls got `+=` into one `function.arguments` → invalid JSON like `{a:1}{b:2}` → "Failed to parse tool arguments: Extra data" on every retry.
- `_messages_to_gemini_rest_contents` emitted each OpenAI-style tool response as its own `user` content. Gemini requires *N* `functionResponse` parts in the user turn to match *N* `functionCall` parts in the preceding model turn, so two parallel tool responses → 2 separate user contents with 1 part each → HTTP 400 "Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn."

Fixed both: add per-extractor `tool_call_idx += 1`, and coalesce consecutive `role:"tool"` messages into a single `user` content with N `functionResponse` parts.

## Test plan

- [x] `pytest tests/test_oauth_split_flow.py` — 11 passed
- [x] `pytest tests/test_gemini_cli_adapter_parsing.py` — 7 passed
- [x] `pytest tests/test_gemini_oauth.py` — 9 passed (no regressions on old OAuth suite)
- [x] Manual: click Codex Login in the UI → tab opens on user's browser → auto-complete via callback server
- [x] Manual: click Gemini Login → OAuth completes, token exchange uses correct `OAUTH_CLIENT_ID`
- [x] Manual: `gemini-cli/gemini-3.1-pro` with parallel `write_file` calls — arguments parse cleanly, no 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)