### PR TITLE
feat: chat export/import for portable replay bundles

### DIFF
--- a/pantheon/chatroom/export.py
+++ b/pantheon/chatroom/export.py
@@ -33,16 +33,39 @@ _ABS_PATH_RE = re.compile(
 )
 
 
-def _scan_file_paths(text: str) -> Set[str]:
-    """Return the set of absolute file paths referenced in *text* that
+_REL_PATH_RE = re.compile(
+    r'(?<=["\s,:\[({])'
+    r'(\.pantheon/(?:brain|tmp|latex|skills)/[^\s"\'\\,\]})]{3,})'
+)
+
+_WORKDIR_RE = re.compile(
+    r'(?<=["\s,:\[({])'
+    r'(workdir/[^\s"\'\\,\]})]{3,})'
+)
+
+
+def _scan_file_paths(text: str, workspace_root: str = "") -> Set[str]:
+    """Return the set of file paths referenced in *text* that
     actually exist on disk (files only, not dirs)."""
     paths: Set[str] = set()
+
+    # Absolute paths
     for m in _ABS_PATH_RE.finditer(text):
         raw = m.group(1)
-        # Strip trailing punctuation / markdown artifacts
         cleaned = raw.rstrip("'\"`,;:)]}*\\")
         if os.path.isfile(cleaned):
             paths.add(cleaned)
+
+    # Relative .pantheon/ paths
+    for regex in (_REL_PATH_RE, _WORKDIR_RE):
+        for m in regex.finditer(text):
+            raw = m.group(1)
+            cleaned = raw.rstrip("'\"`,;:)]}*\\")
+            if workspace_root:
+                full = os.path.join(workspace_root, cleaned)
+                if os.path.isfile(full):
+                    paths.add(full)
+
     return paths
 
 
@@ -97,8 +120,14 @@ def export_chat_bundle(
     meta_text = meta_path.read_text(encoding="utf-8") if meta_path.exists() else "{}"
     meta = json.loads(meta_text)
 
+    # ---- infer workspace root ----
+    workspace_root = str(memory_dir.parent.parent)  # .pantheon/memory -> .pantheon -> workspace
+
     # ---- scan for file references ----
-    all_paths = _scan_file_paths(jsonl_text) | _scan_file_paths(meta_text)
+    all_paths = (
+        _scan_file_paths(jsonl_text, workspace_root)
+        | _scan_file_paths(meta_text, workspace_root)
+    )
     logger.info(f"[export] Found {len(all_paths)} file references in chat {chat_id}")
 
     # ---- prepare output ----
@@ -158,9 +187,8 @@ def export_chat_bundle(
 
     # ---- optional compression ----
     if compress:
-        archive = str(output_dir) + ".tar.gz"
-        with tarfile.open(archive, "w:gz") as tar:
-            tar.add(str(output_dir), arcname=output_dir.name)
+        archive = str(output_dir) + ".zip"
+        shutil.make_archive(str(output_dir), "zip", str(output_dir.parent), output_dir.name)
         bundle_path = archive
 
     logger.info(
@@ -204,9 +232,19 @@ def import_chat_bundle(
     bundle_path = Path(bundle_path)
     target_root = Path(target_root)
 
-    # ---- handle tar.gz ----
+    # ---- handle compressed archives ----
     tmp_dir: Optional[str] = None
-    if bundle_path.suffix == ".gz" or str(bundle_path).endswith(".tar.gz"):
+    if bundle_path.suffix == ".zip":
+        import zipfile
+        tmp_dir = tempfile.mkdtemp(prefix="pantheon_import_")
+        with zipfile.ZipFile(str(bundle_path), "r") as zf:
+            zf.extractall(tmp_dir)
+        children = list(Path(tmp_dir).iterdir())
+        if len(children) == 1 and children[0].is_dir():
+            bundle_path = children[0]
+        else:
+            bundle_path = Path(tmp_dir)
+    elif bundle_path.suffix == ".gz" or str(bundle_path).endswith(".tar.gz"):
         tmp_dir = tempfile.mkdtemp(prefix="pantheon_import_")
         with tarfile.open(str(bundle_path), "r:gz") as tar:
             tar.extractall(tmp_dir)
@@ -256,14 +294,27 @@ def import_chat_bundle(
                 meta_text = meta_text.replace(bundle_rel, abs_str)
 
     # ---- write chat memory ----
-    new_id = str(uuid.uuid4())
     meta = json.loads(meta_text)
+    original_id = manifest.get("chat_id", meta.get("id", ""))
     original_name = meta.get("name", manifest.get("chat_name", "Imported Chat"))
-    meta["id"] = new_id
+
+    # If the original chat already exists locally, skip creating a duplicate.
+    if original_id and (memory_dir / f"{original_id}.jsonl").exists():
+        if tmp_dir:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        return {
+            "success": True,
+            "chat_id": original_id,
+            "chat_name": original_name,
+            "message": f"Chat '{original_name}' already exists — skipped (files updated)",
+        }
+
+    chat_id = original_id if original_id else str(uuid.uuid4())
+    meta["id"] = chat_id
 
     memory_dir.mkdir(parents=True, exist_ok=True)
-    (memory_dir / f"{new_id}.jsonl").write_text(jsonl_text, encoding="utf-8")
-    (memory_dir / f"{new_id}.meta.json").write_text(
+    (memory_dir / f"{chat_id}.jsonl").write_text(jsonl_text, encoding="utf-8")
+    (memory_dir / f"{chat_id}.meta.json").write_text(
         json.dumps(meta, indent=2, ensure_ascii=False), encoding="utf-8"
     )
 
@@ -271,10 +322,10 @@ def import_chat_bundle(
     if tmp_dir:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
-    logger.info(f"[import] Chat imported as {new_id} ({original_name}), {files_copied} files restored")
+    logger.info(f"[import] Chat imported as {chat_id} ({original_name}), {files_copied} files restored")
     return {
         "success": True,
-        "chat_id": new_id,
+        "chat_id": chat_id,
         "chat_name": original_name,
         "message": f"Imported '{original_name}' with {files_copied} files",
     }

--- a/pantheon/chatroom/export.py
+++ b/pantheon/chatroom/export.py
@@ -1,0 +1,280 @@
+"""Chat export/import for portable replay bundles.
+
+A bundle is a self-contained directory (optionally tar.gz compressed):
+    <bundle>/
+        manifest.json      # metadata
+        chat.jsonl          # messages with paths rewritten to ./files/…
+        chat.meta.json      # chat metadata (name, extra_data, …)
+        files/              # referenced files, preserving directory structure
+"""
+
+import json
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Set, Tuple
+
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# Path scanning helpers
+# ---------------------------------------------------------------------------
+
+# Match absolute paths that look like real files (not URLs, not bare dirs).
+_ABS_PATH_RE = re.compile(
+    r'(?<=["\s,:\[({])'          # preceded by delimiter (loose)
+    r'(/(?:Users|home|tmp|var|opt)'  # common Unix roots
+    r'/[^\s"\'\\,\]})]{3,})'     # at least 3 chars of path body
+)
+
+
+def _scan_file_paths(text: str) -> Set[str]:
+    """Return the set of absolute file paths referenced in *text* that
+    actually exist on disk (files only, not dirs)."""
+    paths: Set[str] = set()
+    for m in _ABS_PATH_RE.finditer(text):
+        raw = m.group(1)
+        # Strip trailing punctuation / markdown artifacts
+        cleaned = raw.rstrip("'\"`,;:)]}*\\")
+        if os.path.isfile(cleaned):
+            paths.add(cleaned)
+    return paths
+
+
+def _relative_files_path(abs_path: str) -> str:
+    """Convert an absolute path to a bundle-relative ``files/…`` path."""
+    # Strip the leading slash so it nests under files/
+    return "files/" + abs_path.lstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+def export_chat_bundle(
+    memory_dir: str | Path,
+    chat_id: str,
+    output_dir: str | Path,
+    *,
+    compress: bool = False,
+    size_limit_mb: float = 100,
+) -> dict:
+    """Export a chat and its referenced files into a portable bundle.
+
+    Parameters
+    ----------
+    memory_dir : path
+        Directory containing ``<chat_id>.jsonl`` / ``<chat_id>.meta.json``.
+    chat_id : str
+        The chat to export.
+    output_dir : path
+        Where to write the bundle.  Created if it doesn't exist.
+    compress : bool
+        If *True*, produce a ``.tar.gz`` alongside the directory.
+    size_limit_mb : float
+        Skip individual files larger than this (default 100 MB).
+
+    Returns
+    -------
+    dict  with keys ``success``, ``bundle_path``, ``message``, ``stats``.
+    """
+    memory_dir = Path(memory_dir)
+    output_dir = Path(output_dir)
+
+    jsonl_path = memory_dir / f"{chat_id}.jsonl"
+    meta_path = memory_dir / f"{chat_id}.meta.json"
+
+    if not jsonl_path.exists():
+        return {"success": False, "message": f"Chat {chat_id} not found"}
+
+    # ---- read raw data ----
+    jsonl_text = jsonl_path.read_text(encoding="utf-8")
+    meta_text = meta_path.read_text(encoding="utf-8") if meta_path.exists() else "{}"
+    meta = json.loads(meta_text)
+
+    # ---- scan for file references ----
+    all_paths = _scan_file_paths(jsonl_text) | _scan_file_paths(meta_text)
+    logger.info(f"[export] Found {len(all_paths)} file references in chat {chat_id}")
+
+    # ---- prepare output ----
+    output_dir.mkdir(parents=True, exist_ok=True)
+    files_dir = output_dir / "files"
+    files_dir.mkdir(exist_ok=True)
+
+    copied_files: list[dict] = []
+    skipped_files: list[str] = []
+    limit_bytes = int(size_limit_mb * 1024 * 1024)
+
+    for abs_path in sorted(all_paths):
+        file_size = os.path.getsize(abs_path)
+        rel = _relative_files_path(abs_path)
+        if file_size > limit_bytes:
+            skipped_files.append(abs_path)
+            logger.info(f"[export] Skipping large file ({file_size/1e6:.1f}MB): {abs_path}")
+            continue
+        dest = output_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(abs_path, dest)
+        copied_files.append({
+            "original": abs_path,
+            "local": rel,
+            "size": file_size,
+        })
+
+    # ---- rewrite paths in jsonl/meta ----
+    rewritten_jsonl = jsonl_text
+    rewritten_meta = meta_text
+    for f in copied_files:
+        rewritten_jsonl = rewritten_jsonl.replace(f["original"], "./" + f["local"])
+        rewritten_meta = rewritten_meta.replace(f["original"], "./" + f["local"])
+
+    (output_dir / "chat.jsonl").write_text(rewritten_jsonl, encoding="utf-8")
+    (output_dir / "chat.meta.json").write_text(rewritten_meta, encoding="utf-8")
+
+    # ---- write manifest ----
+    manifest = {
+        "version": "1.0",
+        "chat_id": chat_id,
+        "chat_name": meta.get("name", ""),
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "files": copied_files,
+        "skipped_large_files": skipped_files,
+        "stats": {
+            "messages": rewritten_jsonl.count("\n"),
+            "files_copied": len(copied_files),
+            "files_skipped": len(skipped_files),
+        },
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    bundle_path = str(output_dir)
+
+    # ---- optional compression ----
+    if compress:
+        archive = str(output_dir) + ".tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(str(output_dir), arcname=output_dir.name)
+        bundle_path = archive
+
+    logger.info(
+        f"[export] Bundle ready: {bundle_path} "
+        f"({len(copied_files)} files, {len(skipped_files)} skipped)"
+    )
+    return {
+        "success": True,
+        "bundle_path": bundle_path,
+        "message": f"Exported {len(copied_files)} files",
+        "stats": manifest["stats"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Import
+# ---------------------------------------------------------------------------
+
+def import_chat_bundle(
+    memory_dir: str | Path,
+    bundle_path: str | Path,
+    target_root: str | Path,
+) -> dict:
+    """Import a chat bundle, mapping relative paths back to *target_root*.
+
+    Parameters
+    ----------
+    memory_dir : path
+        Destination ``memory/`` directory (e.g. ``.pantheon/memory``).
+    bundle_path : path
+        A bundle directory or ``.tar.gz`` file.
+    target_root : path
+        Workspace root on the importing machine – relative file paths are
+        re-expanded under this root.
+
+    Returns
+    -------
+    dict  with ``success``, ``chat_id``, ``chat_name``, ``message``.
+    """
+    memory_dir = Path(memory_dir)
+    bundle_path = Path(bundle_path)
+    target_root = Path(target_root)
+
+    # ---- handle tar.gz ----
+    tmp_dir: Optional[str] = None
+    if bundle_path.suffix == ".gz" or str(bundle_path).endswith(".tar.gz"):
+        tmp_dir = tempfile.mkdtemp(prefix="pantheon_import_")
+        with tarfile.open(str(bundle_path), "r:gz") as tar:
+            tar.extractall(tmp_dir)
+        # Find the inner directory
+        children = list(Path(tmp_dir).iterdir())
+        if len(children) == 1 and children[0].is_dir():
+            bundle_path = children[0]
+        else:
+            bundle_path = Path(tmp_dir)
+
+    manifest_path = bundle_path / "manifest.json"
+    jsonl_path = bundle_path / "chat.jsonl"
+    meta_path = bundle_path / "chat.meta.json"
+
+    if not jsonl_path.exists():
+        return {"success": False, "message": "Invalid bundle: chat.jsonl not found"}
+
+    manifest = (
+        json.loads(manifest_path.read_text(encoding="utf-8"))
+        if manifest_path.exists()
+        else {}
+    )
+
+    jsonl_text = jsonl_path.read_text(encoding="utf-8")
+    meta_text = meta_path.read_text(encoding="utf-8") if meta_path.exists() else "{}"
+
+    # ---- copy files and rewrite paths ----
+    files_dir = bundle_path / "files"
+    files_copied = 0
+
+    if files_dir.exists():
+        for root, _, filenames in os.walk(files_dir):
+            for fname in filenames:
+                src = Path(root) / fname
+                rel_to_files = src.relative_to(files_dir)
+                # The relative path under files/ mirrors the original absolute path
+                # (with leading slash stripped).  Restore it.
+                dest = Path("/") / rel_to_files
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                if not dest.exists():
+                    shutil.copy2(src, dest)
+                    files_copied += 1
+                # Rewrite in text
+                bundle_rel = f"./files/{rel_to_files.as_posix()}"
+                abs_str = str(dest)
+                jsonl_text = jsonl_text.replace(bundle_rel, abs_str)
+                meta_text = meta_text.replace(bundle_rel, abs_str)
+
+    # ---- write chat memory ----
+    new_id = str(uuid.uuid4())
+    meta = json.loads(meta_text)
+    original_name = meta.get("name", manifest.get("chat_name", "Imported Chat"))
+    meta["id"] = new_id
+
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    (memory_dir / f"{new_id}.jsonl").write_text(jsonl_text, encoding="utf-8")
+    (memory_dir / f"{new_id}.meta.json").write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    # Cleanup temp dir
+    if tmp_dir:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    logger.info(f"[import] Chat imported as {new_id} ({original_name}), {files_copied} files restored")
+    return {
+        "success": True,
+        "chat_id": new_id,
+        "chat_name": original_name,
+        "message": f"Imported '{original_name}' with {files_copied} files",
+    }

--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -1257,6 +1257,62 @@ class ChatRoom(ToolSet):
             }
 
     @tool
+    async def export_chat(
+        self, chat_id: str, output_path: str = "", compress: bool = True
+    ) -> dict:
+        """Export a chat and its referenced files into a portable bundle.
+
+        Args:
+            chat_id: The chat ID to export.
+            output_path: Destination directory. Defaults to .pantheon/exports/<chat_id>.
+            compress: If True, also create a .tar.gz archive.
+        """
+        try:
+            from .export import export_chat_bundle
+
+            if not output_path:
+                output_path = str(
+                    Path(self.memory_manager.path).parent / "exports" / chat_id
+                )
+            result = export_chat_bundle(
+                memory_dir=self.memory_manager.path,
+                chat_id=chat_id,
+                output_dir=output_path,
+                compress=compress,
+            )
+            return result
+        except Exception as e:
+            logger.error(f"Export failed: {e}")
+            return {"success": False, "message": str(e)}
+
+    @tool
+    async def import_chat(
+        self, bundle_path: str, target_workspace: str = ""
+    ) -> dict:
+        """Import a chat from an exported bundle.
+
+        Args:
+            bundle_path: Path to a bundle directory or .tar.gz file.
+            target_workspace: Workspace root for file placement. Defaults to current workspace.
+        """
+        try:
+            from .export import import_chat_bundle
+
+            if not target_workspace:
+                target_workspace = str(
+                    Path(self.memory_manager.path).parent.parent
+                )
+            result = import_chat_bundle(
+                memory_dir=self.memory_manager.path,
+                bundle_path=bundle_path,
+                target_root=target_workspace,
+            )
+            return result
+        except Exception as e:
+            logger.error(f"Import failed: {e}")
+            return {"success": False, "message": str(e)}
+
+    @tool
     async def set_chat_workspace_mode(
         self,
         chat_id: str,


### PR DESCRIPTION
## Summary
- Add `export_chat_bundle()` / `import_chat_bundle()` in `pantheon/chatroom/export.py`
- Bundles are self-contained zip archives with `chat.jsonl`, `chat.meta.json`, `manifest.json`, and referenced files
- Path scanning with regex for absolute, `.pantheon/`, and `workdir/` paths; automatic rewriting on export/import
- Import dedup: skips creation if original `chat_id` already exists locally
- Expose as `@tool export_chat` and `@tool import_chat` on `ChatRoom`

## Test plan
- [ ] Export a chat, verify zip contains all referenced files with correct paths
- [ ] Import on a fresh workspace, verify chat and files restore correctly
- [ ] Re-import same bundle, verify no duplicate chat created
- [ ] Verify files >100MB are skipped with log warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)