### PR TITLE
Add scFM execution workflow and route to single_cell_team

### DIFF
--- a/pantheon/factory/templates/agents/single_cell/analysis_expert.md
+++ b/pantheon/factory/templates/agents/single_cell/analysis_expert.md
@@ -317,13 +317,25 @@ re-implement it in raw Python.
    filling in any missing values from the routing decision's
    `resolved_params` (e.g. `output_path`, `batch_key`, `label_key`) or
    from the leader's instruction.
-3. If `scfm_preprocess_validate` returns `status != "ready"`, apply the
-   suggested `auto_fixes` (or note them in the report) before calling
-   `scfm_run`.
-4. After `scfm_run` completes, call `scfm_interpret_results` on the output
-   path to produce QA metrics and UMAPs.
+3. Branch on the `scfm_preprocess_validate` result before calling
+   `scfm_run`:
+   - `status == "ready"` — proceed.
+   - `status == "needs_preprocessing"` — apply the suggested `auto_fixes`
+     to the data (or write the converted file under `{workdir}/data/`),
+     then re-run `scfm_preprocess_validate` on the fixed file. Only call
+     `scfm_run` once status is `"ready"`.
+   - `status == "incompatible"` — **do not call `scfm_run`**. Stop the
+     plan, record the validation `diagnostics` in `report_analysis.md`,
+     and return the failure to the leader so it can ask `fm_router` for
+     a different model (or surface the issue to the user). `scfm_run`
+     would only echo the same incompatibility error.
+4. Only call `scfm_interpret_results` after `scfm_run` returns
+   successfully (no `error` key, valid `output_path`). If `scfm_run`
+   errors out, skip interpretation and escalate the error and any
+   `validation` payload to the leader.
 5. Record provenance in `report_analysis.md` (model name, task, input/
-   output paths, key metrics).
+   output paths, key metrics, and any validation diagnostics that were
+   resolved or skipped).
 
 Only fall back to raw Python in `python_interpreter` when the plan needs a
 step the `scfm` toolset does not cover (e.g. custom plotting beyond

--- a/pantheon/factory/templates/agents/single_cell/analysis_expert.md
+++ b/pantheon/factory/templates/agents/single_cell/analysis_expert.md
@@ -9,6 +9,7 @@ toolsets:
   - file_manager
   - integrated_notebook
   - python_interpreter
+  - scfm
 ---
 You are an analysis expert in Single-Cell and Spatial Omics data analysis.
 You will receive the instruction from the leader agent or other agents for different kinds of analysis tasks.
@@ -301,6 +302,32 @@ runtime gate. Agent responsibilities when a GPS task arrives:
    `estimate_spapros_runtime` before `select_spapros`; when `severity`
    comes back `"slow"` or `"very_slow"`, stop and return the estimate to
    the leader so it can ask the user via `notify_user`.
+
+## scFM execution workflow
+
+When the leader hands you a routing decision from `fm_router` (a JSON
+object with a `plan` array of `{tool, args}` steps), you are the executor.
+Run each step as a **typed tool call** against the `scfm` toolset — do not
+re-implement it in raw Python.
+
+1. Read the plan top-to-bottom. Typical order is `scfm_preprocess_validate`
+   → `scfm_run` → `scfm_interpret_results`.
+2. For each step, call the named tool (`scfm_preprocess_validate`,
+   `scfm_run`, `scfm_interpret_results`, etc.) with the provided `args`,
+   filling in any missing values from the routing decision's
+   `resolved_params` (e.g. `output_path`, `batch_key`, `label_key`) or
+   from the leader's instruction.
+3. If `scfm_preprocess_validate` returns `status != "ready"`, apply the
+   suggested `auto_fixes` (or note them in the report) before calling
+   `scfm_run`.
+4. After `scfm_run` completes, call `scfm_interpret_results` on the output
+   path to produce QA metrics and UMAPs.
+5. Record provenance in `report_analysis.md` (model name, task, input/
+   output paths, key metrics).
+
+Only fall back to raw Python in `python_interpreter` when the plan needs a
+step the `scfm` toolset does not cover (e.g. custom plotting beyond
+`scfm_interpret_results`).
 
 ---
 

--- a/pantheon/factory/templates/teams/default.md
+++ b/pantheon/factory/templates/teams/default.md
@@ -5,7 +5,7 @@ icon: 🏠
 id: default
 name: General Team
 type: team
-version: 1.4.0
+version: 1.5.0
 agents:
   - leader
   - researcher
@@ -110,5 +110,23 @@ call_agent("researcher", "Search the web for best practices on X. Gather informa
 | Read 1 known file | Execute directly |
 | Write/edit/create files (post-research) | Execute directly |
 | Synthesize researcher results | Execute directly (your core role) |
+
+## Single-Cell Foundation Model (scFM) tasks
+
+If the user's request mentions a single-cell foundation model — by name (e.g.
+**scGPT**, **Geneformer**, **UCE**, **scFoundation**, **scBERT**, **CellPLM**,
+**Nicheformer**, **scMulan**, **scPlantLLM**, **GeneCompass**, **tGPT**, etc.)
+or by capability (cell embeddings from an scFM, scFM batch integration, scFM
+cell-type annotation, perturbation prediction, drug-response prediction) — the
+General Team does **not** carry the right tools.
+
+In that case, do **not** attempt the work yourself. Tell the user once, in
+plain language, that this work belongs in the dedicated
+**`single_cell_team`** template (which ships with `fm_router` for
+model selection and `analysis_expert` for execution), and ask them to switch
+the chat to that template (or start a new chat with it) before proceeding.
+Keep the message short — one or two sentences — and only mention it when the
+scFM signal is clear; do not nudge for generic single-cell analysis without an
+scFM cue.
 
 {{delegation}}

--- a/pantheon/toolsets/scfm/toolset.py
+++ b/pantheon/toolsets/scfm/toolset.py
@@ -495,7 +495,7 @@ class SCFMToolSet(ToolSet):
     # Router Tool
     # =========================================================================
 
-    @tool
+    @tool(exclude=True)
     async def scfm_router(
         self,
         query: str,
@@ -513,9 +513,10 @@ class SCFMToolSet(ToolSet):
         """
         DEPRECATED: LLM-based router for single-cell foundation model tasks.
 
-        Prefer the template-based router sub-agent `fm_router` inside `single_cell_team`
-        (call via `call_agent("fm_router", ...)`) for better integration with the
-        Pantheon Team + template system.
+        Hidden from LLM agents (``exclude=True``); still callable from Python for
+        tests and internal callers. Prefer the template-based router sub-agent
+        ``fm_router`` inside ``single_cell_team`` (``call_agent("fm_router", ...)``)
+        for better integration with the Pantheon Team + template system.
 
         Takes a natural language query and returns:
         - Inferred scFM task (embed/integrate/annotate/spatial/perturb/drug_response)
@@ -582,11 +583,6 @@ class SCFMToolSet(ToolSet):
         # Include data profile error as warning if present
         if data_profile and "error" in data_profile:
             result.setdefault("warnings", []).append(f"Data profiling failed: {data_profile['error']}")
-
-        # Always include deprecation notice in-band for tool consumers
-        result.setdefault("warnings", []).append(
-            "DEPRECATED: scfm_router tool. Prefer `single_cell_team` + `fm_router` sub-agent (call_agent('fm_router', ...))."
-        )
 
         return result
 


### PR DESCRIPTION
This PR integrates single-cell foundation model (scFM) task execution into the analysis expert agent and establishes proper routing for scFM requests. It adds comprehensive execution guidance for the scfm toolset, deprecates the old scfm_router tool in favor of a template-based router, and updates the default team to redirect scFM requests to the dedicated single_cell_team.

Key Changes

analysis_expert.md: Added scfm to the toolsets list and documented a complete scFM execution workflow section that:

Explains how to execute routing decisions from fm_router as typed tool calls
Specifies the typical execution order (preprocess → run → interpret)
Describes handling of validation results and auto-fixes
Clarifies when to fall back to raw Python for custom work
default.md:

Bumped team version from 1.4.0 to 1.5.0
Added "Single-Cell Foundation Model (scFM) tasks" section that instructs the leader agent to redirect scFM requests to single_cell_team instead of attempting them locally
Provides clear guidance on recognising scFM signals (by model name or capability)
toolset.py:

Marked scfm_router tool with exclude=True to hide it from LLM agents
Updated docstring to clarify deprecation and redirect users to the template-based fm_router sub-agent
Removed the in-band deprecation warning from the result dictionary (now only in docstring)
Implementation Details

The changes establish a clear separation of concerns: the default team recognises scFM requests and routes them to single_cell_team, which uses fm_router for model selection and analysis_expert for execution. The old scfm_router tool remains available for internal/test use but is hidden from LLM agents to prevent confusion.