### PR TITLE
feat: add rare disease ontology-first skill with bundled scripts

### DIFF
--- a/pantheon/factory/templates/agents/rare_disease/auditor.md
+++ b/pantheon/factory/templates/agents/rare_disease/auditor.md
@@ -1,0 +1,84 @@
+---
+id: auditor
+name: auditor
+icon: ✅
+toolsets:
+  - file_manager
+---
+
+# rare_disease/auditor
+
+You are the audit and reflection specialist for a rare disease multi-agent team.
+
+Your job is to review the current reasoning package before final delivery.
+You check for contradictions, unsupported claims, weak evidence use, missing critical information,
+and overconfident conclusions.
+
+## Core Objective
+
+Stress-test the current case reasoning and ensure the final output is:
+- evidence-grounded,
+- uncertainty-aware,
+- internally consistent,
+- and safe for clinician review.
+
+## What You Check
+
+You should review:
+1. whether the structured case summary matches the original input;
+2. whether phenotype normalization introduced distortion;
+3. whether ranked candidates are actually supported by retrieved evidence;
+4. whether conflicting evidence has been acknowledged;
+5. whether important missing information has been ignored;
+6. whether any statements sound too definitive for the evidence level;
+7. whether references are actually tied to claims rather than appended decoratively.
+
+## What You Must Not Do
+
+- Do not rewrite the full final report unless asked.
+- Do not introduce new unsupported disease candidates casually.
+- Do not pretend all uncertainty can be resolved.
+- Do not approve outputs that rely mainly on fluent speculation.
+
+## Output Format
+
+Return your review in the following sections:
+
+1. **Audit verdict**
+   - pass / revise / major revision needed
+
+2. **Supported strengths**
+   - what is well-grounded
+
+3. **Major issues**
+   - unsupported ranking
+   - missing evidence
+   - contradictions
+   - missing phenotype detail
+   - weak citation linkage
+   - overclaiming
+
+4. **Risk notes**
+   - where the output may mislead a clinician or overstate certainty
+
+5. **Required fixes before final delivery**
+   - concise action list only
+
+## Audit Mindset
+
+Be strict but useful.
+Your role is not to block everything.
+Your role is to improve reliability and reviewability.
+
+## Quality Standard
+
+A strong output after your review should make it clear:
+- what is known,
+- what is inferred,
+- what is still missing,
+- and why the current candidate ordering is only provisional when evidence is incomplete.
+
+## Entity Precision Guardrail
+
+Do **not** broaden an exact ontology-backed disease entity into a family/spectrum label just because confidence is low.
+Instead, preserve the exact entity and explicitly downgrade confidence or add uncertainty notes.

--- a/pantheon/factory/templates/agents/rare_disease/evidence_researcher.md
+++ b/pantheon/factory/templates/agents/rare_disease/evidence_researcher.md
@@ -1,0 +1,107 @@
+---
+id: evidence_researcher
+name: evidence_researcher
+icon: 🔎
+toolsets:
+  - shell
+  - web
+  - database_api
+  - file_manager
+mcp_servers:
+  - biomcp
+---
+
+# rare_disease/evidence_researcher
+
+You are an evidence retrieval specialist for rare disease case support.
+
+Your job is to gather evidence-backed support for candidate diseases, phenotypes, genes,
+and related diagnostic considerations from literature, databases, and trusted medical knowledge sources.
+
+## Core Objective
+
+Given a structured phenotype package, disease query, or gene query, produce a concise, reviewable,
+citation-aware evidence summary that supports downstream differential reasoning.
+
+## Skill Pack (Required)
+
+Use the rare disease ontology skill pack before evidence retrieval:
+{{skills(root_dir="../../skills/rare_disease")}}
+
+## What You Do
+
+You should:
+1. search for evidence related to phenotype-disease associations;
+2. retrieve candidate-disease support from literature and trusted databases;
+3. retrieve gene-disease or variant-disease support when explicitly requested or when genomic context is present;
+4. collect evidence snippets that are useful for comparison and review;
+5. organize evidence by candidate disease, not as one undifferentiated dump;
+6. track source identity clearly enough that the final answer can cite or reference it.
+
+## What You Must Not Do
+
+- Do not give a final diagnosis.
+- Do not overstate weak evidence.
+- Do not merge unsupported model inference into evidence.
+- Do not hide conflicts across sources.
+- Do not produce citation-looking claims without an actual retrievable source basis.
+
+## Retrieval Priorities
+
+Prefer evidence in this order when available:
+1. disease/ontology and rare disease reference databases
+2. peer-reviewed literature and review papers
+3. guideline-like or institutional medical resources
+4. lower-authority background sources only when clearly labeled as background
+
+## Operational Retrieval Sequence
+
+Follow the ontology-first retrieval pattern defined in the rare disease skill pack. In addition, apply these agent-specific refinements:
+
+1. **Exact-entity refinement**
+   - If a leading candidate is currently a family/spectrum label, enumerate 1-3 exact ontology entities beneath it when the ontology database surfaces them.
+   - Include `canonical_name` and `disease_uid` when available.
+   - Prefer exact entities that best match the supplied phenotype package; do not stop at the family label if an ontology-backed leaf candidate is already visible.
+
+2. **Sparse-phenotype differential expansion**
+   - When the phenotype set is very small (≤ 4 findings) and non-specific, include at least one alternative mechanistic pathway in your search.
+   - For ophthalmic presentations with visual impairment + abnormal fundus but no retinal-specific terms, also search for optic atrophy / optic neuropathy entities.
+   - For hypogonadism presentations, when CHH spectrum is favored, also enumerate specific genetic subtypes (e.g., FGFR1-related, GNRHR-related, KAL1-related) rather than stopping at "normosmic CHH" or "isolated CHH".
+   - Label these expanded searches as `[exploratory]` so the downstream auditor can weigh them appropriately.
+
+## Output Format
+
+For each candidate disease or query target, return:
+
+### Candidate / Query Target
+- disease or gene name
+- aliases if relevant
+
+### Evidence Summary
+- 2–5 concise bullets of evidence-backed relevance to the case
+
+### Phenotype Match Notes
+- which case features are supported
+- which major features are missing or inconsistent
+
+### Source Notes
+- source title / database / paper identifier / link-ready reference info
+- short support snippet or paraphrased rationale
+
+### Confidence Notes
+- strong / moderate / weak support
+- note any contradictions or uncertainty
+
+## Evidence Discipline
+
+- Clearly separate retrieved evidence from your own synthesis.
+- Prefer compact, discriminative evidence over generic disease descriptions.
+- Explicitly flag when a disease explains only part of the phenotype.
+- If evidence is sparse, say it is sparse.
+
+## Quality Standard
+
+Your output should help the leader answer:
+- Which candidates are actually supported?
+- Which candidates are only superficially plausible?
+- What citations or references are worth surfacing in the UI/report?

--- a/pantheon/factory/templates/agents/rare_disease/genotype_analyst.md
+++ b/pantheon/factory/templates/agents/rare_disease/genotype_analyst.md
@@ -1,0 +1,56 @@
+---
+id: genotype_analyst
+name: genotype_analyst
+icon: 🧬
+toolsets:
+  - python_interpreter
+  - shell
+  - database_api
+  - file_manager
+mcp_servers:
+  - biomcp
+---
+
+# rare_disease/genotype_analyst
+
+You are a genotype and variant support specialist for rare disease workflows.
+
+Your job is to analyze genomic input in the context of phenotype-guided rare disease reasoning.
+You do not make a final molecular diagnosis on your own.
+You provide genotype-side support, conflicts, and prioritization signals.
+
+## Core Objective
+
+Given genomic inputs such as VCF-derived summaries, variant tables, gene lists, inheritance clues,
+or test reports, produce a structured genotype support summary for downstream candidate re-ranking.
+
+## What You Do
+
+You should:
+1. identify candidate genes or variants relevant to the phenotype package;
+2. evaluate inheritance compatibility when pedigree or family information is available;
+3. highlight whether the genomic signal supports, weakens, or conflicts with phenotype-driven candidates;
+4. note variant interpretation limits when data is incomplete;
+5. provide a genotype-side prioritization summary rather than a definitive diagnosis.
+
+## What You Must Not Do
+
+- Do not claim pathogenicity beyond the provided evidence.
+- Do not replace formal clinical variant interpretation.
+- Do not ignore phenotype mismatch.
+- Do not rank variants without noting evidence limitations.
+
+## Output Format
+
+1. **Genomic input summary**
+2. **Candidate genes / variants of interest**
+3. **Phenotype-genotype match notes**
+4. **Inheritance / family consistency notes**
+5. **Conflict or caution notes**
+6. **Genotype-side prioritization summary**
+7. **Missing data needed for stronger interpretation**
+
+## Quality Standard
+
+Your output should help the leader answer:
+Does the genomic evidence materially narrow, support, or contradict the current candidate set?

--- a/pantheon/factory/templates/agents/rare_disease/leader.md
+++ b/pantheon/factory/templates/agents/rare_disease/leader.md
@@ -1,0 +1,101 @@
+---
+id: leader
+name: leader
+icon: 🧭
+toolsets:
+  - task
+  - file_manager
+---
+
+# rare_disease/leader
+
+You are the lead coordinator for a rare disease multi-agent team.
+
+Your job is not to provide an automatic final diagnosis.
+Your job is to convert messy case input into a reviewable differential-support output:
+- a structured case object,
+- a phenotype summary,
+- a prioritized candidate set when appropriate,
+- an evidence chain,
+- a missing-information checklist,
+- and a final report after audit.
+
+## Core Objective
+
+Support clinicians and researchers in complex rare disease cases by:
+1. organizing case information,
+2. coordinating specialized agents,
+3. synthesizing candidate diseases,
+4. identifying missing critical information,
+5. and producing evidence-grounded, reviewable outputs.
+
+## Skill Pack (Required)
+
+For ontology-first orchestration, apply:
+{{skills(root_dir="../../skills/rare_disease")}}
+
+## Non-Goals
+
+- Do not claim a definitive diagnosis unless the user explicitly frames the task as a retrospective confirmed-case explanation.
+- Do not provide treatment decisions.
+- Do not hide uncertainty.
+- Do not present unsupported guesses as evidence.
+
+## Mandatory Operating Protocol
+
+For every case, follow this order unless the user explicitly asks for a narrower subtask:
+
+1. Build or update a structured case object.
+2. Call `phenotype_structurer` for phenotype normalization/structuring, even if the input already appears somewhat organized.
+3. Require ontology-backed normalization through delegated agent outputs before comparing fine-grained disease candidates.
+4. Call `evidence_researcher` to gather literature/database support.
+5. If genomic evidence is present, call `genotype_analyst`.
+6. Produce a provisional candidate set with rationale, ranking only when the case context supports it.
+7. If the case remains under-specified, ask focused follow-up questions instead of forcing premature ranking.
+8. Re-rank when new information is provided.
+9. Before final delivery, call `auditor`.
+10. After audit, call `reporter` for the final structured output.
+
+Skipping required delegation steps is a degraded run and must not be treated as the normal product path.
+
+## Delegation Rules
+
+- Use `phenotype_structurer` for phenotype extraction, HPO alignment, symptom timeline, and terminology cleanup.
+- Use `evidence_researcher` for literature, database, and citation-backed evidence.
+- Use `genotype_analyst` only when genomic files, variant tables, or test reports are available.
+- Use `auditor` before any final answer that presents ranked candidates or evidence claims.
+- Use `reporter` only after the reasoning path is stable enough to summarize.
+- Do not complete the case in leader-only mode unless the system is explicitly recording a degraded fallback caused by tool/runtime failure.
+
+## Clarification Policy
+
+Ask follow-up questions when:
+- onset age is missing,
+- family history is missing,
+- phenotype coverage is sparse,
+- lab/imaging context is incomplete,
+- or the current candidate set remains too broad.
+
+Follow-up questions must be prioritized and minimal.
+Prefer the smallest set of questions that can most reduce uncertainty.
+
+## Escalation Rule
+
+Escalate to a harder multi-view re-ranking path only if:
+- multiple strong but conflicting candidates remain,
+- evidence sources disagree,
+- phenotype and genotype signals diverge,
+- or ordinary re-ranking fails to narrow the list.
+
+## Final Answer Contract
+
+When giving a final answer, always separate:
+1. Structured case summary
+2. Key phenotype / ontology normalization
+3. Leading candidate diseases / differential considerations
+4. Evidence summary with references
+5. Missing information / follow-up questions
+6. Risk notes / uncertainty
+7. Suggested next verification direction
+
+Never collapse all of these into one unstructured paragraph.

--- a/pantheon/factory/templates/agents/rare_disease/phenotype_structurer.md
+++ b/pantheon/factory/templates/agents/rare_disease/phenotype_structurer.md
@@ -1,0 +1,87 @@
+---
+id: phenotype_structurer
+name: phenotype_structurer
+icon: 🧾
+toolsets:
+  - shell
+  - file_manager
+---
+
+# rare_disease/phenotype_structurer
+
+You are a phenotype structuring specialist for rare disease cases.
+
+Your job is to transform messy clinical descriptions into a structured phenotype representation
+that can support downstream evidence retrieval and differential reasoning.
+
+## Core Objective
+
+Convert user-provided case descriptions into a clean, structured phenotype package including:
+- key symptoms and signs,
+- onset and progression timeline,
+- affected systems,
+- severity and frequency clues,
+- HPO-style phenotype normalization when possible,
+- and a list of missing critical phenotype information.
+
+## Skill Pack (Required)
+
+Use the rare disease ontology skill pack before normalization output:
+{{skills(root_dir="../../skills/rare_disease")}}
+
+## What You Do
+
+You should:
+1. extract symptoms, signs, abnormal findings, developmental features, and progression clues;
+2. normalize synonymous or vague expressions into more standard phenotype descriptions;
+3. organize findings by body system when useful;
+4. identify onset age, progression pattern, triggering context, and family history clues if present;
+5. distinguish confirmed findings from uncertain or user-suspected findings;
+6. identify important missing phenotype information that would materially improve differential reasoning.
+
+## What You Must Not Do
+
+- Do not generate a final diagnosis.
+- Do not rank diseases.
+- Do not invent HPO terms if confidence is low.
+- Do not present uncertain information as confirmed fact.
+- Do not over-interpret sparse lay descriptions into overly specific clinical findings.
+
+## Output Format
+
+Return your output in the following sections:
+
+1. **Structured phenotype summary**
+   - concise bullet list of main findings
+
+2. **Phenotype normalization**
+   - original phrase → normalized clinical phrase
+   - include HPO-style mapping when reasonably confident
+
+3. **Timeline**
+   - onset
+   - progression
+   - current status
+
+4. **Contextual modifiers**
+   - age
+   - sex
+   - family history
+   - system involvement
+   - notable negatives if explicitly provided
+
+5. **Missing critical phenotype information**
+   - minimal high-value follow-up items only
+
+## Normalization Guidance
+
+- Prefer clinically useful phrasing over literal copying.
+- Preserve ambiguity where ambiguity exists.
+- If multiple interpretations are possible, explicitly say so.
+- Treat user-reported symptoms, clinician findings, imaging findings, and lab abnormalities as different evidence types when relevant.
+
+## Quality Standard
+
+Your output should make downstream retrieval easier.
+The main test is:
+Can another agent use your phenotype package directly to search diseases, papers, and similar cases more effectively?

--- a/pantheon/factory/templates/agents/rare_disease/reporter.md
+++ b/pantheon/factory/templates/agents/rare_disease/reporter.md
@@ -1,0 +1,84 @@
+---
+id: reporter
+name: reporter
+icon: 📝
+toolsets:
+  - file_manager
+---
+
+# rare_disease/reporter
+
+You are the final report writer for a rare disease case-support team.
+
+Your job is to convert the reviewed reasoning package into a clear, structured,
+discussion-ready output for clinicians, researchers, or MDT-style review.
+
+## Core Objective
+
+Produce a final deliverable that is:
+- concise but complete,
+- evidence-aware,
+- easy to review,
+- and explicit about uncertainty and next-step verification needs.
+
+## What You Do
+
+You should:
+1. organize the final answer into stable sections;
+2. preserve the distinction between confirmed facts, inferred hypotheses, and missing information;
+3. present candidate diseases in a reviewable way;
+4. surface evidence and references where they support actual claims;
+5. keep the tone clinically useful, not overdramatic or overly conversational.
+6. preserve exact ontology-backed disease names when upstream reasoning has already narrowed to specific entities.
+
+## What You Must Not Do
+
+- Do not present a definitive diagnosis unless the task explicitly concerns a confirmed retrospective case.
+- Do not bury uncertainty.
+- Do not copy internal agent chatter or intermediate planning text.
+- Do not turn evidence notes into an unreadable literature dump.
+- Do not broaden an exact ontology-backed disease entity back into a family/spectrum label unless the reviewed reasoning package says the exact entity is unsupported.
+
+## Final Output Structure
+
+Use the following structure unless the user asked for a different format:
+
+1. **Case Summary**
+   - brief structured recap of the patient/case
+
+2. **Key Phenotype Features**
+   - normalized phenotype highlights
+
+3. **Top Candidate Diseases**
+   - ranked or grouped candidates
+   - 1–3 line rationale for each
+
+4. **Evidence Highlights**
+   - compact evidence summary tied to each candidate or major claim
+
+5. **Missing Information / Follow-up Questions**
+   - highest-value unresolved items only
+
+6. **Risk and Uncertainty Notes**
+   - what remains unclear
+   - where caution is needed
+
+7. **Suggested Next Verification Direction**
+   - tests, record review, family history clarification, phenotype refinement, or literature follow-up
+
+## Style Guidance
+
+- Prefer compact structure over long narrative.
+- Write like a careful MDT support memo, not like a generic chatbot.
+- Use headings and bullets when helpful.
+- Make the output easy to compare across repeated iterations of the same case.
+- Prefer exact ontology-backed disease names over vague family labels whenever the evidence package already supports the narrower entity.
+
+## Quality Standard
+
+A good final report should let a clinician quickly understand:
+- what the case looks like,
+- what the leading possibilities are,
+- what evidence supports them,
+- what is still missing,
+- and what to verify next.

--- a/pantheon/factory/templates/skills/rare_disease/rd_ontology_first.md
+++ b/pantheon/factory/templates/skills/rare_disease/rd_ontology_first.md
@@ -1,0 +1,125 @@
+---
+id: rd_ontology_first
+name: Rare Disease Ontology-First Workflow
+description: |
+  Ontology-first workflow for rare disease support. Use Orphanet/OMIM/HPO
+  normalized data layer first, then online evidence (BioMCP/Web/DB API).
+tags: [rare_disease, ontology, orphanet, omim, hpo, normalization]
+params:
+  skill_dir:
+    type: path
+    default: "."
+---
+
+# Rare Disease Ontology-First Workflow
+
+## Goal
+
+Before literature retrieval or ranking, first complete deterministic normalization against the local `rd_ontology` layer.
+
+## What "Ontology Layer" Means
+
+For this project, ontology layer is **not** generic web search and not only BioMCP disease search.
+It is your controlled local knowledge base built from:
+- Orphanet
+- OMIM
+- HPO
+
+Typical normalized entities:
+- disease canonical name / aliases
+- cross references (ORPHA / OMIM / MONDO / HPO links when available)
+- phenotype associations
+
+## Execution Order (Mandatory)
+
+1. **Normalize input terms first**
+   - map free text phenotype → normalized clinical phrase
+   - map disease aliases → canonical disease entity
+
+2. **Resolve cross-IDs**
+   - keep traceable IDs when possible (ORPHA / OMIM / MONDO / HPO)
+   - if multiple matches exist, keep top candidates + ambiguity note
+
+3. **Build ontology package**
+   - output concise structured package for downstream agents:
+     - normalized disease candidates
+     - matched phenotype terms
+     - xrefs
+     - miss/ambiguous flags
+
+4. **Only then run online evidence retrieval**
+   - use BioMCP / web / database_api for latest literature & trial evidence
+   - keep ontology output as candidate anchor, avoid drifting synonyms
+
+## Retrieval Pattern (Ontology-First)
+
+When performing evidence or disease retrieval, follow this sequence:
+
+1. **Ontology layer first (offline/local retrieval preferred)**
+   - Use `python {skill_dir}/scripts/query_rd_ontology.py resolve "<term>"` to normalize disease aliases and phenotype terms against the local SQLite database.
+   - Use this layer for disease alias normalization, phenotype term alignment, and candidate-name standardization.
+   - If the database does not exist yet, build it: `python {skill_dir}/scripts/build_rd_ontology.py build --reset`
+
+2. **Literature and public evidence layer**
+   - Then retrieve evidence from PubMed/Crossref/Google-Scholar-like sources via `biomcp`, `web`, and `database_api`.
+   - Prefer recent and discriminative evidence (case reports, reviews, cohort papers) over generic disease summaries.
+
+3. **Evidence labeling and traceability**
+   - Label each support point by source type: `[ontology]`, `[literature]`, `[case]`, `[background]`.
+   - Keep claims traceable to retrievable sources (title / DB / identifier / URL-ready reference info).
+   - If local ontology retrieval is unavailable, explicitly state this and continue with public-source retrieval.
+
+## Local Data Access (SQLite-first)
+
+Database location (global, shared across projects):
+- `~/.pantheon/rd_ontology/rd_ontology.sqlite`
+
+This database is built once and reused. If it does not exist, build it first with the bundled script.
+
+The skill ships with helper scripts under its own `scripts/` directory. Resolve the skill directory from the agent's current skill pack context and invoke:
+
+```bash
+# build / rebuild ontology db (one-time setup)
+python {skill_dir}/scripts/build_rd_ontology.py build --reset
+
+# quick stats
+python {skill_dir}/scripts/build_rd_ontology.py stats
+
+# quick lookup
+python {skill_dir}/scripts/build_rd_ontology.py search "Marfan syndrome"
+
+# normalize + query
+python {skill_dir}/scripts/query_rd_ontology.py resolve "your_alias_or_term"
+
+# fetch one candidate in detail
+python {skill_dir}/scripts/query_rd_ontology.py disease "OMIM:154700"
+
+# find diseases by HPO phenotype
+python {skill_dir}/scripts/query_rd_ontology.py find_by_hpo "HP:0001166,HP:0001250"
+
+# get HPO term details
+python {skill_dir}/scripts/query_rd_ontology.py hpo_term "HP:0001166"
+
+# database table counts
+python {skill_dir}/scripts/query_rd_ontology.py stats
+```
+
+All query commands accept `--db <path>` to override the default database location.
+Output is JSON; parse with `jq` or the agent's Python interpreter when needed.
+
+## Output Contract (Minimum)
+
+Return these fields whenever possible:
+
+- `normalized_terms`: list of normalized phenotype/disease terms
+- `canonical_candidates`: list of canonical disease candidates
+- `xrefs`: ORPHA/OMIM/MONDO/HPO references
+- `ontology_support`: short support notes from ontology layer
+- `ontology_miss`: unresolved terms or ambiguity notes
+
+## Guardrails
+
+- Do not skip ontology normalization when terms are ambiguous.
+- Do not fabricate xref IDs.
+- Do not present online evidence as ontology truth.
+- If ontology has no good match, explicitly mark `ontology_miss` and continue with cautious fallback.

--- a/pantheon/factory/templates/skills/rare_disease/scripts/build_rd_ontology.py
+++ b/pantheon/factory/templates/skills/rare_disease/scripts/build_rd_ontology.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+"""
+Build local rare-disease ontology database (SQLite) from offline sources.
+
+Inputs (default under ~/.pantheon/rd_ontology/data):
+  - orphanet/en_product1.xml  (disease + synonyms + xrefs)
+  - orphanet/en_product4.xml  (disease-HPO associations)
+  - orphanet/en_product6.xml  (disease-gene associations)
+  - hpo/hp.obo                (HPO terms)
+  - hpo/phenotype.hpoa        (disease-HPO annotations)
+  - omim/mim2gene.txt         (OMIM-gene mapping)
+
+Output: ~/.pantheon/rd_ontology/rd_ontology.sqlite
+
+Examples:
+  python build_rd_ontology.py build --reset
+  python build_rd_ontology.py stats
+  python build_rd_ontology.py search "Marfan syndrome"
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sqlite3
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+def default_rd_dir() -> Path:
+    return Path.home() / ".pantheon" / "rd_ontology"
+
+
+DEFAULT_INPUT_DIR = Path.home() / ".pantheon" / "rd_ontology" / "data"
+DEFAULT_OUTPUT_DB = Path.home() / ".pantheon" / "rd_ontology" / "rd_ontology.sqlite"
+
+
+def clean_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    s = value.strip()
+    return s if s else None
+
+
+def child_text(elem: ET.Element, path: str) -> Optional[str]:
+    node = elem.find(path)
+    if node is None:
+        return None
+    return clean_text(node.text)
+
+
+def iter_disorders(xml_path: Path) -> Iterable[ET.Element]:
+    # Streaming parser to keep memory stable for large XML files.
+    context = ET.iterparse(xml_path, events=("start", "end"))
+    _, root = next(context)
+    for event, elem in context:
+        if event == "end" and elem.tag == "Disorder":
+            yield elem
+            root.clear()
+
+
+class RdOntologyBuilder:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(db_path))
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA synchronous=NORMAL")
+        self.conn.execute("PRAGMA foreign_keys=ON")
+
+    def close(self):
+        self.conn.close()
+
+    def reset(self):
+        self.conn.executescript(
+            """
+            DROP TABLE IF EXISTS source_meta;
+            DROP TABLE IF EXISTS disease_aliases;
+            DROP TABLE IF EXISTS disease_xrefs;
+            DROP TABLE IF EXISTS phenotype_assoc;
+            DROP TABLE IF EXISTS gene_assoc;
+            DROP TABLE IF EXISTS hpo_terms;
+            DROP TABLE IF EXISTS diseases;
+            """
+        )
+        self.conn.commit()
+
+    def create_schema(self):
+        self.conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS diseases (
+              disease_uid TEXT PRIMARY KEY,
+              canonical_name TEXT,
+              primary_source TEXT,
+              primary_id TEXT,
+              definition TEXT,
+              expert_link TEXT,
+              raw_payload TEXT,
+              created_at INTEGER DEFAULT (strftime('%s','now')),
+              updated_at INTEGER DEFAULT (strftime('%s','now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS disease_aliases (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              disease_uid TEXT NOT NULL,
+              alias TEXT NOT NULL,
+              alias_type TEXT,
+              source TEXT,
+              UNIQUE(disease_uid, alias, source)
+            );
+
+            CREATE TABLE IF NOT EXISTS disease_xrefs (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              disease_uid TEXT NOT NULL,
+              xref_db TEXT NOT NULL,
+              xref_id TEXT NOT NULL,
+              source TEXT,
+              UNIQUE(disease_uid, xref_db, xref_id, source)
+            );
+
+            CREATE TABLE IF NOT EXISTS hpo_terms (
+              hpo_id TEXT PRIMARY KEY,
+              label TEXT,
+              definition TEXT,
+              synonyms_json TEXT,
+              parents_json TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS phenotype_assoc (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              disease_uid TEXT NOT NULL,
+              hpo_id TEXT,
+              hpo_term TEXT,
+              qualifier TEXT,
+              evidence TEXT,
+              onset TEXT,
+              frequency_label TEXT,
+              frequency_id TEXT,
+              sex TEXT,
+              modifier TEXT,
+              aspect TEXT,
+              reference TEXT,
+              source TEXT,
+              raw_payload TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS gene_assoc (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              disease_uid TEXT NOT NULL,
+              gene_symbol TEXT,
+              gene_name TEXT,
+              association_type TEXT,
+              association_status TEXT,
+              source_of_validation TEXT,
+              entrez_id TEXT,
+              ensembl_id TEXT,
+              hgnc_id TEXT,
+              omim_gene_id TEXT,
+              source TEXT,
+              raw_payload TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS source_meta (
+              source_name TEXT PRIMARY KEY,
+              source_path TEXT,
+              version TEXT,
+              loaded_at INTEGER,
+              row_count INTEGER
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_diseases_name ON diseases(canonical_name);
+            CREATE INDEX IF NOT EXISTS idx_alias_text ON disease_aliases(alias);
+            CREATE INDEX IF NOT EXISTS idx_xrefs_lookup ON disease_xrefs(xref_db, xref_id);
+            CREATE INDEX IF NOT EXISTS idx_hpo_label ON hpo_terms(label);
+            CREATE INDEX IF NOT EXISTS idx_pa_disease ON phenotype_assoc(disease_uid);
+            CREATE INDEX IF NOT EXISTS idx_pa_hpo ON phenotype_assoc(hpo_id);
+            CREATE INDEX IF NOT EXISTS idx_gene_disease ON gene_assoc(disease_uid);
+            CREATE INDEX IF NOT EXISTS idx_gene_symbol ON gene_assoc(gene_symbol);
+            """
+        )
+        self.conn.commit()
+
+    def upsert_disease(
+        self,
+        disease_uid: str,
+        canonical_name: Optional[str] = None,
+        primary_source: Optional[str] = None,
+        primary_id: Optional[str] = None,
+        definition: Optional[str] = None,
+        expert_link: Optional[str] = None,
+        raw_payload: Optional[dict] = None,
+    ):
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO diseases
+            (disease_uid, canonical_name, primary_source, primary_id, definition, expert_link, raw_payload)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                disease_uid,
+                canonical_name,
+                primary_source,
+                primary_id,
+                definition,
+                expert_link,
+                json.dumps(raw_payload, ensure_ascii=False) if raw_payload else None,
+            ),
+        )
+
+        # Fill blanks only; do not overwrite existing non-empty values.
+        if canonical_name:
+            self.conn.execute(
+                """
+                UPDATE diseases
+                SET canonical_name = CASE
+                    WHEN canonical_name IS NULL OR canonical_name = '' THEN ?
+                    ELSE canonical_name END,
+                    updated_at = strftime('%s','now')
+                WHERE disease_uid = ?
+                """,
+                (canonical_name, disease_uid),
+            )
+        if primary_source:
+            self.conn.execute(
+                """
+                UPDATE diseases
+                SET primary_source = COALESCE(primary_source, ?),
+                    updated_at = strftime('%s','now')
+                WHERE disease_uid = ?
+                """,
+                (primary_source, disease_uid),
+            )
+        if primary_id:
+            self.conn.execute(
+                """
+                UPDATE diseases
+                SET primary_id = COALESCE(primary_id, ?),
+                    updated_at = strftime('%s','now')
+                WHERE disease_uid = ?
+                """,
+                (primary_id, disease_uid),
+            )
+        if definition:
+            self.conn.execute(
+                """
+                UPDATE diseases
+                SET definition = COALESCE(definition, ?),
+                    updated_at = strftime('%s','now')
+                WHERE disease_uid = ?
+                """,
+                (definition, disease_uid),
+            )
+        if expert_link:
+            self.conn.execute(
+                """
+                UPDATE diseases
+                SET expert_link = COALESCE(expert_link, ?),
+                    updated_at = strftime('%s','now')
+                WHERE disease_uid = ?
+                """,
+                (expert_link, disease_uid),
+            )
+
+    def insert_alias(
+        self, disease_uid: str, alias: Optional[str], alias_type: str, source: str
+    ):
+        alias = clean_text(alias)
+        if not alias:
+            return
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO disease_aliases(disease_uid, alias, alias_type, source)
+            VALUES (?, ?, ?, ?)
+            """,
+            (disease_uid, alias, alias_type, source),
+        )
+
+    def insert_xref(
+        self, disease_uid: str, xref_db: Optional[str], xref_id: Optional[str], source: str
+    ):
+        xref_db = clean_text(xref_db)
+        xref_id = clean_text(xref_id)
+        if not xref_db or not xref_id:
+            return
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO disease_xrefs(disease_uid, xref_db, xref_id, source)
+            VALUES (?, ?, ?, ?)
+            """,
+            (disease_uid, xref_db, xref_id, source),
+        )
+
+    def parse_hpo_obo(self, hp_obo: Path):
+        print(f"[build] HPO terms: {hp_obo}")
+        current = None
+        rows = 0
+
+        def flush_term(term: dict):
+            nonlocal rows
+            if not term or "id" not in term:
+                return
+            self.conn.execute(
+                """
+                INSERT OR REPLACE INTO hpo_terms(hpo_id, label, definition, synonyms_json, parents_json)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    term["id"],
+                    term.get("name"),
+                    term.get("definition"),
+                    json.dumps(term.get("synonyms", []), ensure_ascii=False),
+                    json.dumps(term.get("parents", []), ensure_ascii=False),
+                ),
+            )
+            rows += 1
+
+        synonym_re = re.compile(r'^synonym:\s+"(.+?)"')
+        parent_re = re.compile(r"^is_a:\s+(HP:\d+)")
+        def_re = re.compile(r'^def:\s+"(.+?)"')
+
+        with hp_obo.open("r", encoding="utf-8", errors="ignore") as f:
+            for raw in f:
+                line = raw.rstrip("\n")
+                if line == "[Term]":
+                    flush_term(current)
+                    current = {"synonyms": [], "parents": []}
+                    continue
+                if not current:
+                    continue
+                if line.startswith("id: "):
+                    current["id"] = line[4:].strip()
+                elif line.startswith("name: "):
+                    current["name"] = line[6:].strip()
+                elif line.startswith("def: "):
+                    m = def_re.search(line)
+                    if m:
+                        current["definition"] = m.group(1)
+                elif line.startswith("synonym: "):
+                    m = synonym_re.search(line)
+                    if m:
+                        current["synonyms"].append(m.group(1))
+                elif line.startswith("is_a: "):
+                    m = parent_re.search(line)
+                    if m:
+                        current["parents"].append(m.group(1))
+            flush_term(current)
+
+        self.conn.execute(
+            """
+            INSERT OR REPLACE INTO source_meta(source_name, source_path, version, loaded_at, row_count)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("hpo_hp_obo", str(hp_obo), None, int(time.time()), rows),
+        )
+        self.conn.commit()
+        print(f"[done] HPO terms loaded: {rows}")
+
+    def parse_hpoa(self, hpoa: Path):
+        print(f"[build] HPOA annotations: {hpoa}")
+        rows = 0
+        with hpoa.open("r", encoding="utf-8", errors="ignore") as f:
+            data_lines = (line for line in f if line and not line.startswith("#"))
+            reader = csv.DictReader(data_lines, delimiter="\t")
+            for rec in reader:
+                disease_uid = clean_text(rec.get("database_id"))
+                disease_name = clean_text(rec.get("disease_name"))
+                hpo_id = clean_text(rec.get("hpo_id"))
+                if not disease_uid:
+                    continue
+
+                db_prefix = disease_uid.split(":", 1)[0] if ":" in disease_uid else "UNKNOWN"
+                db_id = disease_uid.split(":", 1)[1] if ":" in disease_uid else disease_uid
+
+                self.upsert_disease(
+                    disease_uid=disease_uid,
+                    canonical_name=disease_name,
+                    primary_source="hpoa",
+                    primary_id=db_id,
+                )
+                self.insert_alias(disease_uid, disease_name, "canonical", "hpoa")
+                self.insert_xref(disease_uid, db_prefix, db_id, "hpoa")
+
+                self.conn.execute(
+                    """
+                    INSERT INTO phenotype_assoc(
+                      disease_uid, hpo_id, hpo_term, qualifier, evidence, onset,
+                      frequency_label, frequency_id, sex, modifier, aspect, reference, source, raw_payload
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        disease_uid,
+                        hpo_id,
+                        None,  # filled in post-process from hpo_terms
+                        clean_text(rec.get("qualifier")),
+                        clean_text(rec.get("evidence")),
+                        clean_text(rec.get("onset")),
+                        clean_text(rec.get("frequency")),
+                        None,
+                        clean_text(rec.get("sex")),
+                        clean_text(rec.get("modifier")),
+                        clean_text(rec.get("aspect")),
+                        clean_text(rec.get("reference")),
+                        "hpoa",
+                        json.dumps(
+                            {
+                                "biocuration": clean_text(rec.get("biocuration")),
+                                "disease_name": disease_name,
+                            },
+                            ensure_ascii=False,
+                        ),
+                    ),
+                )
+                rows += 1
+                if rows % 50000 == 0:
+                    self.conn.commit()
+                    print(f"  ... hpoa rows={rows}")
+
+        self.conn.execute(
+            """
+            INSERT OR REPLACE INTO source_meta(source_name, source_path, version, loaded_at, row_count)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("hpo_phenotype_hpoa", str(hpoa), None, int(time.time()), rows),
+        )
+        self.conn.commit()
+        print(f"[done] HPOA annotations loaded: {rows}")
+
+    def parse_orphanet_product1(self, path: Path):
+        print(f"[build] Orphanet product1: {path}")
+        rows = 0
+        for disorder in iter_disorders(path):
+            orpha_code = child_text(disorder, "OrphaCode")
+            if not orpha_code:
+                continue
+            disease_uid = f"ORPHA:{orpha_code}"
+            name = child_text(disorder, "Name")
+            expert_link = child_text(disorder, "ExpertLink")
+
+            self.upsert_disease(
+                disease_uid=disease_uid,
+                canonical_name=name,
+                primary_source="orphanet_product1",
+                primary_id=orpha_code,
+                expert_link=expert_link,
+                raw_payload={"xml_id": disorder.attrib.get("id")},
+            )
+            self.insert_alias(disease_uid, name, "canonical", "orphanet_product1")
+
+            for syn in disorder.findall("./SynonymList/Synonym"):
+                self.insert_alias(
+                    disease_uid,
+                    clean_text(syn.text),
+                    "synonym",
+                    "orphanet_product1",
+                )
+
+            for x in disorder.findall("./ExternalReferenceList/ExternalReference"):
+                self.insert_xref(
+                    disease_uid=disease_uid,
+                    xref_db=child_text(x, "Source"),
+                    xref_id=child_text(x, "Reference"),
+                    source="orphanet_product1",
+                )
+
+            rows += 1
+            if rows % 2000 == 0:
+                self.conn.commit()
+                print(f"  ... product1 disorders={rows}")
+
+        self.conn.execute(
+            """
+            INSERT OR REPLACE INTO source_meta(source_name, source_path, version, loaded_at, row_count)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("orphanet_product1", str(path), None, int(time.time()), rows),
+        )
+        self.conn.commit()
+        print(f"[done] Orphanet product1 disorders loaded: {rows}")
+
+    def parse_orphanet_product4(self, path: Path):
+        print(f"[build] Orphanet product4 (HPO links): {path}")
+        rows = 0
+        for disorder in iter_disorders(path):
+            orpha_code = child_text(disorder, "OrphaCode")
+            if not orpha_code:
+                continue
+            disease_uid = f"ORPHA:{orpha_code}"
+            name = child_text(disorder, "Name")
+            self.upsert_disease(
+                disease_uid=disease_uid,
+                canonical_name=name,
+                primary_source="orphanet_product4",
+                primary_id=orpha_code,
+            )
+            self.insert_alias(disease_uid, name, "canonical", "orphanet_product4")
+
+            for assoc in disorder.findall("./HPODisorderAssociationList/HPODisorderAssociation"):
+                hpo_id = child_text(assoc, "HPO/HPOId")
+                hpo_term = child_text(assoc, "HPO/HPOTerm")
+                freq_node = assoc.find("HPOFrequency")
+                freq_label = child_text(assoc, "HPOFrequency/Name")
+                freq_id = freq_node.attrib.get("id") if freq_node is not None else None
+                diagnostic = child_text(assoc, "DiagnosticCriteria/Name") or child_text(
+                    assoc, "DiagnosticCriteria"
+                )
+                evidence = child_text(assoc, "ValidationStatus/Name")
+                reference = child_text(assoc, "Source")
+
+                self.conn.execute(
+                    """
+                    INSERT INTO phenotype_assoc(
+                      disease_uid, hpo_id, hpo_term, qualifier, evidence, onset,
+                      frequency_label, frequency_id, sex, modifier, aspect, reference, source, raw_payload
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        disease_uid,
+                        hpo_id,
+                        hpo_term,
+                        None,
+                        evidence,
+                        None,
+                        freq_label,
+                        clean_text(freq_id),
+                        None,
+                        diagnostic,
+                        None,
+                        reference,
+                        "orphanet_product4",
+                        None,
+                    ),
+                )
+                rows += 1
+
+            if rows and rows % 50000 == 0:
+                self.conn.commit()
+                print(f"  ... product4 phenotype_assoc={rows}")
+
+        self.conn.execute(
+            """
+            INSERT OR REPLACE INTO source_meta(source_name, source_path, version, loaded_at, row_count)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("orphanet_product4", str(path), None, int(time.time()), rows),
+        )
+        self.conn.commit()
+        print(f"[done] Orphanet product4 phenotype associations loaded: {rows}")
+
+    def parse_orphanet_product6(self, path: Path):
+        print(f"[build] Orphanet product6 (gene links): {path}")
+        rows = 0
+        for disorder in iter_disorders(path):
+            orpha_code = child_text(disorder, "OrphaCode")
+            if not orpha_code:
+                continue
+            disease_uid = f"ORPHA:{orpha_code}"
+            name = child_text(disorder, "Name")
+            self.upsert_disease(
+                disease_uid=disease_uid,
+                canonical_name=name,
+                primary_source="orphanet_product6",
+                primary_id=orpha_code,
+            )
+            self.insert_alias(disease_uid, name, "canonical", "orphanet_product6")
+
+            for assoc in disorder.findall("./DisorderGeneAssociationList/DisorderGeneAssociation"):
+                source_of_validation = child_text(assoc, "SourceOfValidation")
+                assoc_type = child_text(assoc, "DisorderGeneAssociationType/Name")
+                assoc_status = child_text(assoc, "DisorderGeneAssociationStatus/Name")
+                gene = assoc.find("Gene")
+                if gene is None:
+                    continue
+                gene_symbol = child_text(gene, "Symbol")
+                gene_name = child_text(gene, "Name")
+
+                entrez_id = None
+                ensembl_id = None
+                hgnc_id = None
+                omim_gene_id = None
+                xrefs_payload = []
+                for x in gene.findall("./ExternalReferenceList/ExternalReference"):
+                    src = clean_text(child_text(x, "Source"))
+                    ref = clean_text(child_text(x, "Reference"))
+                    if not src or not ref:
+                        continue
+                    src_l = src.lower()
+                    if "ensembl" in src_l:
+                        ensembl_id = ref
+                    elif "hgnc" in src_l:
+                        hgnc_id = ref
+                    elif src_l == "omim":
+                        omim_gene_id = ref
+                    elif "entrez" in src_l or "ncbi gene" in src_l:
+                        entrez_id = ref
+                    xrefs_payload.append({"source": src, "reference": ref})
+
+                self.conn.execute(
+                    """
+                    INSERT INTO gene_assoc(
+                      disease_uid, gene_symbol, gene_name, association_type, association_status,
+                      source_of_validation, entrez_id, ensembl_id, hgnc_id, omim_gene_id, source, raw_payload
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        disease_uid,
+                        gene_symbol,
+                        gene_name,
+                        assoc_type,
+                        assoc_status,
+                        source_of_validation,
+                        entrez_id,
+                        ensembl_id,
+                        hgnc_id,
+                        omim_gene_id,
+                        "orphanet_product6",
+                        json.dumps({"gene_xrefs": xrefs_payload}, ensure_ascii=False),
+                    ),
+                )
+                rows += 1
+
+            if rows and rows % 50000 == 0:
+                self.conn.commit()
+                print(f"  ... product6 gene_assoc={rows}")
+
+        self.conn.execute(
+            """
+            INSERT OR REPLACE INTO source_meta(source_name, source_path, version, loaded_at, row_count)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("orphanet_product6", str(path), None, int(time.time()), rows),
+        )
+        self.conn.commit()
+        print(f"[done] Orphanet product6 gene associations loaded: {rows}")
+
+    def parse_omim_mim2gene(self, path: Path):
+        print(f"[build] OMIM mim2gene: {path}")
+        rows = 0
+        with path.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if not line.strip() or line.startswith("#"):
+                    continue
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) < 5:
+                    continue
+                mim_number, entry_type, entrez_gene_id, gene_symbol, ensembl_id = parts[:5]
+                mim_number = clean_text(mim_number)
+                if not mim_number:
+                    continue
+                disease_uid = f"OMIM:{mim_number}"
+                self.upsert_disease(
+                    disease_uid=disease_uid,
+                    canonical_name=None,
+                    primary_source="omim_mim2gene",
+                    primary_id=mim_number,
+                )
+                self.insert_xref(disease_uid, "OMIM", mim_number, "omim_mim2gene")
+                self.conn.execute(
+                    """
+                    INSERT INTO gene_assoc(
+                      disease_uid, gene_symbol, gene_name, association_type, association_status,
+                      source_of_validation, entrez_id, ensembl_id, hgnc_id, omim_gene_id, source, raw_payload
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        disease_uid,
+                        clean_text(gene_symbol),
+                        None,
+                        clean_text(entry_type),
+                        None,
+                        None,
+                        clean_text(entrez_gene_id),
+                        clean_text(ensembl_id),
+                        None,
+                        mim_number,
+                        "omim_mim2gene",
+                        None,
+                    ),
+                )
+                rows += 1
+                if rows % 50000 == 0:
+                    self.conn.commit()
+                    print(f"  ... omim rows={rows}")
+
+        self.conn.execute(
+            """
+            INSERT OR REPLACE INTO source_meta(source_name, source_path, version, loaded_at, row_count)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("omim_mim2gene", str(path), None, int(time.time()), rows),
+        )
+        self.conn.commit()
+        print(f"[done] OMIM mim2gene rows loaded: {rows}")
+
+    def post_process(self):
+        print("[build] post-process derived links / labels")
+        # fill missing HPO labels in phenotype_assoc from hpo_terms
+        self.conn.execute(
+            """
+            UPDATE phenotype_assoc
+            SET hpo_term = (
+                SELECT label FROM hpo_terms t WHERE t.hpo_id = phenotype_assoc.hpo_id
+            )
+            WHERE (hpo_term IS NULL OR hpo_term = '')
+              AND hpo_id IS NOT NULL
+            """
+        )
+
+        # Derive reciprocal ORPHA links for OMIM entries when orphanet xref has OMIM
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO diseases(disease_uid, primary_source, primary_id)
+            SELECT DISTINCT 'OMIM:' || xref_id, 'derived_orphanet_omim', xref_id
+            FROM disease_xrefs
+            WHERE UPPER(xref_db) = 'OMIM' AND disease_uid LIKE 'ORPHA:%'
+            """
+        )
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO disease_xrefs(disease_uid, xref_db, xref_id, source)
+            SELECT DISTINCT 'OMIM:' || x.xref_id, 'ORPHA', substr(x.disease_uid, 7), 'derived_from_orphanet_xref'
+            FROM disease_xrefs x
+            WHERE UPPER(x.xref_db) = 'OMIM' AND x.disease_uid LIKE 'ORPHA:%'
+            """
+        )
+        self.conn.commit()
+        print("[done] post-process complete")
+
+    def print_stats(self):
+        cur = self.conn.cursor()
+        tables = [
+            "diseases",
+            "disease_aliases",
+            "disease_xrefs",
+            "hpo_terms",
+            "phenotype_assoc",
+            "gene_assoc",
+        ]
+        print("\n=== rd_ontology stats ===")
+        for t in tables:
+            n = cur.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0]
+            print(f"{t:16s}: {n}")
+
+        print("\nTop xref dbs:")
+        for row in cur.execute(
+            """
+            SELECT UPPER(xref_db) AS db, COUNT(*) AS n
+            FROM disease_xrefs GROUP BY UPPER(xref_db)
+            ORDER BY n DESC LIMIT 10
+            """
+        ):
+            print(f"  {row['db']}: {row['n']}")
+
+    def search(self, query: str, limit: int = 10):
+        cur = self.conn.cursor()
+        q = f"%{query}%"
+        rows = cur.execute(
+            """
+            SELECT d.disease_uid, d.canonical_name,
+                   (SELECT COUNT(*) FROM phenotype_assoc p WHERE p.disease_uid=d.disease_uid) AS phenotype_count,
+                   (SELECT COUNT(*) FROM gene_assoc g WHERE g.disease_uid=d.disease_uid) AS gene_count
+            FROM diseases d
+            WHERE d.canonical_name LIKE ?
+               OR EXISTS (
+                    SELECT 1 FROM disease_aliases a
+                    WHERE a.disease_uid = d.disease_uid
+                      AND a.alias LIKE ?
+               )
+            ORDER BY
+              CASE WHEN LOWER(d.canonical_name) = LOWER(?) THEN 0 ELSE 1 END,
+              LENGTH(COALESCE(d.canonical_name, '')),
+              d.disease_uid
+            LIMIT ?
+            """,
+            (q, q, query, limit),
+        ).fetchall()
+
+        if not rows:
+            print(f"No match for query={query!r}")
+            return
+
+        print(f"\nSearch results for {query!r}:")
+        for i, row in enumerate(rows, 1):
+            print(
+                f"{i:2d}. {row['disease_uid']} | {row['canonical_name'] or '<no_name>'} "
+                f"| phenotypes={row['phenotype_count']} genes={row['gene_count']}"
+            )
+            xrefs = cur.execute(
+                """
+                SELECT xref_db, xref_id
+                FROM disease_xrefs
+                WHERE disease_uid = ?
+                ORDER BY xref_db, xref_id
+                LIMIT 8
+                """,
+                (row["disease_uid"],),
+            ).fetchall()
+            if xrefs:
+                joined = ", ".join([f"{x['xref_db']}:{x['xref_id']}" for x in xrefs])
+                print(f"    xrefs: {joined}")
+
+
+def cmd_build(args: argparse.Namespace):
+    input_dir = Path(args.input_dir).expanduser().resolve()
+    out_db = Path(args.output_db).expanduser().resolve()
+    b = RdOntologyBuilder(out_db)
+    try:
+        if args.reset:
+            b.reset()
+        b.create_schema()
+
+        hp_obo = input_dir / "hpo" / "hp.obo"
+        hpoa = input_dir / "hpo" / "phenotype.hpoa"
+        p1 = input_dir / "orphanet" / "en_product1.xml"
+        p4 = input_dir / "orphanet" / "en_product4.xml"
+        p6 = input_dir / "orphanet" / "en_product6.xml"
+        mim2gene = input_dir / "omim" / "mim2gene.txt"
+
+        missing = [p for p in [hp_obo, hpoa, p1, p4, p6, mim2gene] if not p.exists()]
+        if missing:
+            print("[error] missing required input files:")
+            for p in missing:
+                print("  -", p)
+            raise SystemExit(1)
+
+        b.parse_hpo_obo(hp_obo)
+        b.parse_orphanet_product1(p1)
+        b.parse_orphanet_product4(p4)
+        b.parse_orphanet_product6(p6)
+        b.parse_hpoa(hpoa)
+        b.parse_omim_mim2gene(mim2gene)
+        b.post_process()
+        b.print_stats()
+
+        if args.smoke_query:
+            b.search(args.smoke_query, limit=10)
+
+        print(f"\n[DONE] rd_ontology db ready: {out_db}")
+    finally:
+        b.close()
+
+
+def cmd_stats(args: argparse.Namespace):
+    db = Path(args.output_db).expanduser().resolve()
+    if not db.exists():
+        print(f"[error] db not found: {db}")
+        raise SystemExit(1)
+    b = RdOntologyBuilder(db)
+    try:
+        b.print_stats()
+    finally:
+        b.close()
+
+
+def cmd_search(args: argparse.Namespace):
+    db = Path(args.output_db).expanduser().resolve()
+    if not db.exists():
+        print(f"[error] db not found: {db}")
+        raise SystemExit(1)
+    b = RdOntologyBuilder(db)
+    try:
+        b.search(args.query, limit=args.limit)
+    finally:
+        b.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Build/query local rare disease ontology SQLite")
+    sp = p.add_subparsers(dest="command", required=True)
+
+    p_build = sp.add_parser("build", help="Build rd_ontology SQLite from offline files")
+    p_build.add_argument("--input-dir", default=str(DEFAULT_INPUT_DIR))
+    p_build.add_argument("--output-db", default=str(DEFAULT_OUTPUT_DB))
+    p_build.add_argument("--reset", action="store_true")
+    p_build.add_argument("--smoke-query", default="Marfan syndrome")
+    p_build.set_defaults(func=cmd_build)
+
+    p_stats = sp.add_parser("stats", help="Show db stats")
+    p_stats.add_argument("--output-db", default=str(DEFAULT_OUTPUT_DB))
+    p_stats.set_defaults(func=cmd_stats)
+
+    p_search = sp.add_parser("search", help="Search disease by name/alias")
+    p_search.add_argument("query")
+    p_search.add_argument("--limit", type=int, default=10)
+    p_search.add_argument("--output-db", default=str(DEFAULT_OUTPUT_DB))
+    p_search.set_defaults(func=cmd_search)
+
+    return p
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pantheon/factory/templates/skills/rare_disease/scripts/query_rd_ontology.py
+++ b/pantheon/factory/templates/skills/rare_disease/scripts/query_rd_ontology.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Query helper for local rd_ontology SQLite.
+
+Default database path: ~/.pantheon/rd_ontology/rd_ontology.sqlite
+
+Examples:
+  python query_rd_ontology.py resolve "Marfan syndrome"
+  python query_rd_ontology.py resolve "your local alias"
+  python query_rd_ontology.py disease OMIM:154700
+  python query_rd_ontology.py find_by_hpo "HP:0001166,HP:0001250"
+  python query_rd_ontology.py hpo_term "HP:0001166"
+  python query_rd_ontology.py stats
+  python query_rd_ontology.py --db /custom/path/rd_ontology.sqlite resolve "term"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+
+DEFAULT_DB = Path.home() / ".pantheon" / "rd_ontology" / "rd_ontology.sqlite"
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# query helpers
+# ---------------------------------------------------------------------------
+
+def search(conn: sqlite3.Connection, query: str, limit: int = 10):
+    q = f"%{query}%"
+    rows = conn.execute(
+        """
+        SELECT d.disease_uid, d.canonical_name,
+               (SELECT COUNT(*) FROM phenotype_assoc p WHERE p.disease_uid=d.disease_uid) AS phenotype_count,
+               (SELECT COUNT(*) FROM gene_assoc g WHERE g.disease_uid=d.disease_uid) AS gene_count
+        FROM diseases d
+        WHERE d.canonical_name LIKE ?
+           OR EXISTS (
+                SELECT 1 FROM disease_aliases a
+                WHERE a.disease_uid = d.disease_uid
+                  AND a.alias LIKE ?
+           )
+        ORDER BY
+          CASE WHEN LOWER(d.canonical_name) = LOWER(?) THEN 0 ELSE 1 END,
+          LENGTH(COALESCE(d.canonical_name, '')),
+          d.disease_uid
+        LIMIT ?
+        """,
+        (q, q, query, limit),
+    ).fetchall()
+
+    out = []
+    for row in rows:
+        uid = row["disease_uid"]
+        xrefs = conn.execute(
+            """
+            SELECT xref_db, xref_id
+            FROM disease_xrefs
+            WHERE disease_uid=?
+            ORDER BY xref_db, xref_id
+            LIMIT 12
+            """,
+            (uid,),
+        ).fetchall()
+        out.append(
+            {
+                "disease_uid": uid,
+                "canonical_name": row["canonical_name"],
+                "phenotype_count": row["phenotype_count"],
+                "gene_count": row["gene_count"],
+                "xrefs": [f"{x['xref_db']}:{x['xref_id']}" for x in xrefs],
+            }
+        )
+    return out
+
+
+def disease_detail(conn: sqlite3.Connection, disease_uid: str):
+    d = conn.execute(
+        "SELECT disease_uid, canonical_name, primary_source, primary_id, definition, expert_link FROM diseases WHERE disease_uid=?",
+        (disease_uid,),
+    ).fetchone()
+    if not d:
+        return None
+
+    aliases = conn.execute(
+        "SELECT alias, alias_type, source FROM disease_aliases WHERE disease_uid=? ORDER BY alias_type, alias LIMIT 80",
+        (disease_uid,),
+    ).fetchall()
+    xrefs = conn.execute(
+        "SELECT xref_db, xref_id, source FROM disease_xrefs WHERE disease_uid=? ORDER BY xref_db, xref_id LIMIT 120",
+        (disease_uid,),
+    ).fetchall()
+    phenotypes = conn.execute(
+        "SELECT hpo_id, hpo_term, frequency_label, evidence, source FROM phenotype_assoc WHERE disease_uid=? ORDER BY hpo_id LIMIT 50",
+        (disease_uid,),
+    ).fetchall()
+    genes = conn.execute(
+        "SELECT gene_symbol, gene_name, association_type, source, omim_gene_id FROM gene_assoc WHERE disease_uid=? ORDER BY gene_symbol LIMIT 40",
+        (disease_uid,),
+    ).fetchall()
+
+    return {
+        "disease_uid": d["disease_uid"],
+        "canonical_name": d["canonical_name"],
+        "primary_source": d["primary_source"],
+        "primary_id": d["primary_id"],
+        "definition": d["definition"],
+        "expert_link": d["expert_link"],
+        "aliases": [dict(a) for a in aliases],
+        "xrefs": [dict(x) for x in xrefs],
+        "phenotypes": [dict(p) for p in phenotypes],
+        "genes": [dict(g) for g in genes],
+    }
+
+
+# ---------------------------------------------------------------------------
+# sub-commands
+# ---------------------------------------------------------------------------
+
+def cmd_resolve(args: argparse.Namespace):
+    db = Path(args.db).expanduser().resolve()
+    conn = connect(db)
+    try:
+        original = args.query
+        normalized = original.strip()
+        results = search(conn, normalized, limit=args.limit)
+        print(json.dumps(
+            {"query_original": original, "query_normalized": normalized, "matched_count": len(results), "results": results},
+            ensure_ascii=False, indent=2,
+        ))
+    finally:
+        conn.close()
+
+
+def cmd_disease(args: argparse.Namespace):
+    db = Path(args.db).expanduser().resolve()
+    conn = connect(db)
+    try:
+        detail = disease_detail(conn, args.disease_uid)
+        if not detail:
+            print(json.dumps({"error": f"not found: {args.disease_uid}"}, ensure_ascii=False, indent=2))
+            raise SystemExit(1)
+        print(json.dumps(detail, ensure_ascii=False, indent=2))
+    finally:
+        conn.close()
+
+
+def cmd_find_by_hpo(args: argparse.Namespace):
+    db = Path(args.db).expanduser().resolve()
+    conn = connect(db)
+    try:
+        hpo_ids = [x.strip() for x in (args.hpo_ids or "").split(",") if x.strip()]
+        if not hpo_ids:
+            print(json.dumps({"error": "at least one HPO ID required"}, ensure_ascii=False, indent=2))
+            raise SystemExit(1)
+        placeholders = ",".join("?" * len(hpo_ids))
+        rows = conn.execute(
+            f"""
+            SELECT p.disease_uid, d.canonical_name,
+                   COUNT(DISTINCT p.hpo_id) AS matched_hpo_count
+            FROM phenotype_assoc p
+            JOIN diseases d ON d.disease_uid = p.disease_uid
+            WHERE p.hpo_id IN ({placeholders})
+            GROUP BY p.disease_uid, d.canonical_name
+            ORDER BY matched_hpo_count DESC, d.canonical_name
+            LIMIT ?
+            """,
+            (*hpo_ids, args.limit),
+        ).fetchall()
+        out = [dict(r) for r in rows]
+        print(json.dumps({"hpo_ids": hpo_ids, "matched_count": len(out), "results": out}, ensure_ascii=False, indent=2))
+    finally:
+        conn.close()
+
+
+def cmd_hpo_term(args: argparse.Namespace):
+    db = Path(args.db).expanduser().resolve()
+    conn = connect(db)
+    try:
+        row = conn.execute(
+            "SELECT hpo_id, label, definition, synonyms_json, parents_json FROM hpo_terms WHERE hpo_id=?",
+            (args.hpo_id.strip(),),
+        ).fetchone()
+        if not row:
+            print(json.dumps({"error": f"HPO term not found: {args.hpo_id}"}, ensure_ascii=False, indent=2))
+            raise SystemExit(1)
+        print(json.dumps({
+            "hpo_id": row["hpo_id"], "label": row["label"],
+            "definition": row["definition"],
+            "synonyms": json.loads(row["synonyms_json"] or "[]"),
+            "parents": json.loads(row["parents_json"] or "[]"),
+        }, ensure_ascii=False, indent=2))
+    finally:
+        conn.close()
+
+
+def cmd_stats(args: argparse.Namespace):
+    db = Path(args.db).expanduser().resolve()
+    conn = connect(db)
+    try:
+        tables = ["diseases", "disease_aliases", "disease_xrefs", "hpo_terms", "phenotype_assoc", "gene_assoc"]
+        counts = {t: conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0] for t in tables}
+        print(json.dumps({"db_path": str(db), "counts": counts}, ensure_ascii=False, indent=2))
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Query helper for rd_ontology SQLite")
+    p.add_argument("--db", default=str(DEFAULT_DB), help="Path to rd_ontology.sqlite")
+    sp = p.add_subparsers(dest="command")
+
+    p_resolve = sp.add_parser("resolve", help="Normalize query + search")
+    p_resolve.add_argument("query")
+    p_resolve.add_argument("--limit", type=int, default=10)
+    p_resolve.set_defaults(func=cmd_resolve)
+
+    p_disease = sp.add_parser("disease", help="Get detailed disease record")
+    p_disease.add_argument("disease_uid")
+    p_disease.set_defaults(func=cmd_disease)
+
+    p_find = sp.add_parser("find_by_hpo", help="Find diseases by HPO IDs (comma-separated)")
+    p_find.add_argument("hpo_ids")
+    p_find.add_argument("--limit", type=int, default=20)
+    p_find.set_defaults(func=cmd_find_by_hpo)
+
+    p_hpo = sp.add_parser("hpo_term", help="Get HPO term detail")
+    p_hpo.add_argument("hpo_id")
+    p_hpo.set_defaults(func=cmd_hpo_term)
+
+    p_stats = sp.add_parser("stats", help="Show table counts")
+    p_stats.set_defaults(func=cmd_stats)
+    return p
+
+
+def main():
+    args = parser().parse_args()
+    if not hasattr(args, "func"):
+        parser().print_help()
+        raise SystemExit(1)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pantheon/factory/templates/teams/rare_disease_team.md
+++ b/pantheon/factory/templates/teams/rare_disease_team.md
@@ -1,0 +1,87 @@
+---
+category: rare_disease
+description: |
+  Specialized team for rare disease case support and evidence-backed differential reasoning.
+  Uses PantheonTeam-style orchestration for case flow control, Sequential-style fixed tail
+  for audit and report convergence, and reserves MoA only for difficult or conflicting cases.
+icon: 🧬
+id: rare_disease_team
+name: Rare Disease MDT Copilot
+type: team
+version: 0.1.0
+agents:
+  - rare_disease/leader
+  - rare_disease/phenotype_structurer
+  - rare_disease/evidence_researcher
+  - rare_disease/auditor
+  - rare_disease/reporter
+  - rare_disease/genotype_analyst
+---
+
+# Rare Disease MDT Copilot
+
+A specialized AI team for complex rare disease case intake, phenotype standardization,
+evidence retrieval, candidate generation, clarification, audit, and structured reporting.
+
+## Team Structure
+
+| Agent | Role | Responsibility |
+|-------|------|----------------|
+| **leader** | Coordinator | Controls the full case workflow, delegates tasks, tracks missing information, and synthesizes candidate diseases |
+| **phenotype_structurer** | Standardization specialist | Converts free text into structured phenotype schema, HPO terms, symptom timeline, and ontology-aligned disease mentions |
+| **evidence_researcher** | Evidence specialist | Retrieves literature, database evidence, guideline-like references, and citation-ready support snippets |
+| **auditor** | Quality reviewer | Checks contradictions, weak evidence, citation grounding, missing critical data, and over-claiming |
+| **reporter** | Report writer | Produces clinician-facing case summary, MDT discussion draft, and structured evidence report |
+| **genotype_analyst** | Optional genetics specialist | Interprets VCF or test-report-derived genotype evidence when genomic input is available |
+
+## Core Rule
+
+This team does not provide an automatic final diagnosis or treatment decision.
+It supports clinicians by producing a reviewable candidate set, evidence chain,
+missing-information checklist, and discussion-ready summary.
+
+## Hard Workflow Contract
+
+1. `leader` must call `phenotype_structurer`.
+2. `leader` must call `evidence_researcher`.
+3. If genotype exists, `leader` must call `genotype_analyst`.
+4. `leader` must call `auditor`.
+5. `leader` must call `reporter`.
+6. Leader-only finalization is not an acceptable normal-path product behavior.
+7. If external dependencies fail, the run may degrade, but the output must explicitly record the missing agents and degradation reason.
+
+The team must always:
+1. Build a structured case object before deep reasoning.
+2. Standardize phenotype and disease names before retrieval.
+3. Separate evidence-backed facts from model-generated hypotheses.
+4. Ask targeted follow-up questions when the candidate pool remains too broad.
+5. Run audit before final reporting.
+6. Escalate to multi-view re-ranking only for difficult or conflicting cases.
+
+## Recommended Workflow
+
+1. Intake the case and build a structured case object.
+2. Delegate phenotype and ontology normalization to `phenotype_structurer`.
+3. Delegate evidence retrieval to `evidence_researcher`.
+4. If genomic input exists, delegate genotype interpretation to `genotype_analyst`.
+5. Synthesize a reviewable candidate set with explicit reasons and uncertainty notes.
+6. If evidence is insufficient or the candidate pool is too broad, ask focused follow-up questions.
+7. Re-rank candidates after new information is added.
+8. Delegate contradiction and citation review to `auditor`.
+9. Delegate final structured delivery to `reporter`.
+
+## Escalation Policy
+
+Use a harder, multi-view re-ranking path only when:
+- more than 3 plausible candidates remain,
+- evidence sources conflict,
+- phenotype coverage is partial,
+- or genomic and phenotype evidence disagree.
+
+## Team Guidance
+
+- Prefer standardization before search, not after search.
+- Prefer evidence-linked support over fluent but weak answers.
+- Keep a stable case object throughout the workflow.
+- Clearly label: confirmed inputs, inferred hypotheses, missing information, and next recommended checks.
+- Final outputs should be discussion-ready and reviewable, not definitive clinical conclusions.


### PR DESCRIPTION
## Summary

Add a rare disease ontology-first skill with self-contained CLI scripts shipped inside the skill directory. Uses `~/.pantheon/rd_ontology/` as the global shared database path. No framework-level changes — agents invoke scripts via the `shell` toolset.

Supersedes #99.

## What changed from v1

| v1 (closed) | v2 (this PR) |
|---|---|
| `rd_ontology` ToolSet registered in framework | Scripts live in `skills/rare_disease/scripts/` |
| Changed `pantheon/toolsets/__init__.py` | No framework changes |
| Changed `pantheon/endpoint/toolsets.py` | No framework changes |
| DB at `data/rd_ontology_store/` (project-local) | DB at `~/.pantheon/rd_ontology/` (global, shared) |
| Agents use toolset API calls | Agents use `shell` to invoke Python CLI |

## Files

### New
- `skills/rare_disease/scripts/build_rd_ontology.py` — ETL pipeline (Orphanet/OMIM/HPO → SQLite)
- `skills/rare_disease/scripts/query_rd_ontology.py` — CLI: resolve, disease, find_by_hpo, hpo_term, stats

### Modified
- `skills/rare_disease/rd_ontology_first.md` — updated for shell-based usage, global DB path
- `agents/rare_disease/evidence_researcher.md` — `rd_ontology` → `shell` toolset
- `agents/rare_disease/phenotype_structurer.md` — `rd_ontology` → `shell` toolset

### Unchanged from upstream
- `agents/rare_disease/leader.md`, `auditor.md`, `genotype_analyst.md`, `reporter.md`
- `teams/rare_disease_team.md`
- All framework code

🤖 Generated with [Claude Code](https://claude.com/claude-code)