### PR TITLE
docs: add architecture guide and expand paper writing skill suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ workdir**
 # Ignore all markdown files in root except README.md
 /*.md
 !/README.md
+!/architecture.md
 
 # Ignore all JSON files in root (configs, session data, etc.)
 /*.json

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,441 @@
+# PantheonOS 代码库导览
+
+## 项目总览
+
+PantheonOS 是一个面向多智能体协作、可演化工作流和分布式工具调用的 Python 框架；这份文档关注“仓库怎么读”，不是替代现有 [`docs/source/architecture.rst`](/Users/tampouseng/Desktop/PantheonOS-main/docs/source/architecture.rst) 的系统级架构说明。
+
+如果你第一次进入这个仓库，建议按下面的顺序读：
+
+1. [`README.md`](/Users/tampouseng/Desktop/PantheonOS-main/README.md)：先看产品定位、安装方式和主要使用入口。
+2. [`pantheon/agent.py`](/Users/tampouseng/Desktop/PantheonOS-main/pantheon/agent.py)：理解单个 Agent 的运行模型、消息流和模型调用。
+3. [`pantheon/team/pantheon.py`](/Users/tampouseng/Desktop/PantheonOS-main/pantheon/team/pantheon.py)：理解多 Agent 编排、委派和插件装配。
+4. [`pantheon/toolset.py`](/Users/tampouseng/Desktop/PantheonOS-main/pantheon/toolset.py)：理解工具如何被声明、注入上下文并暴露给 Agent。
+5. [`pantheon/chatroom/start.py`](/Users/tampouseng/Desktop/PantheonOS-main/pantheon/chatroom/start.py) 与 [`pantheon/endpoint/core.py`](/Users/tampouseng/Desktop/PantheonOS-main/pantheon/endpoint/core.py)：理解本地 UI/服务启动和远程工具端点。
+
+## 阅读约定
+
+- 树里的每一行都采用 `path  # 简短说明`。
+- 目录行说明“这一组文件解决什么问题”，文件行说明“职责 / 入口 / 被谁调用”。
+- 同级节点按字母序排列，便于你直接在编辑器里对照跳转。
+- `pantheon/` 是主体代码区，原则上展开到 tracked 文件；`pantheon/factory/templates/` 只保留关键层级，不把所有模板全文铺开。
+- `tests/`、`examples/`、`docs/` 只做目录级摘要，避免把这份导览写成近千行的文件清单。
+- 明确排除：`.git/`、`.venv/`、`.pantheon/`、`.executor/`、`jetstream_storage/`、`pantheon_agents.egg-info/` 以及其他本地缓存和运行产物。
+
+## 核心仓库树
+
+```text
+./                                                                            # 仓库根目录；这里只展示 tracked 的核心结构与主要入口
+├── .agents/                                                                  # 给协作代理的背景资料、仓库约定和补充说明
+│   ├── .agents/README.md                                                     # 代理协作说明的入口文档
+│   ├── .agents/conventions.md                                                # 面向代理的编码与协作约定
+│   ├── .agents/memory-learning-systems.md                                    # 记忆与学习系统的背景说明
+│   └── .agents/overview.md                                                   # 仓库全局概览与高层脉络
+├── .claude/                                                                  # Claude/Codex 一类代理的本地行为配置
+│   └── .claude/settings.local.json                                           # 本地代理偏好与工具行为设置
+├── .dockerignore                                                             # 仓库根目录的 Docker 构建忽略规则
+├── .env.test                                                                 # 测试环境变量样例
+├── .github/                                                                  # CI/CD 工作流定义
+│   └── .github/workflows/                                                    # GitHub Actions 工作流目录
+│       ├── .github/workflows/docker-build.yml                                # Docker 镜像构建流程
+│       ├── .github/workflows/publish_pypi.yml                                # PyPI 发布流程
+│       └── .github/workflows/test.yml                                        # 主测试流水线
+├── .gitignore                                                                # Git 忽略规则
+├── .python-version                                                           # 本地 Python 版本提示
+├── .readthedocs.yaml                                                         # Read the Docs 构建配置
+├── CLAUDE.md                                                                 # 面向 Claude 类代理的仓库级说明
+├── LICENSE                                                                   # 开源许可证文本
+├── MANIFEST.in                                                               # Python 打包时的附带文件清单
+├── README.md                                                                 # 项目总入口：定位、安装、使用方式与外部链接
+├── build_backend.spec                                                        # 桌面/后端打包规格文件
+├── docker/                                                                   # 容器化运行与双模式启动支持
+│   ├── docker/.dockerignore                                                  # Docker 子目录的额外忽略规则
+│   ├── docker/Dockerfile                                                     # Pantheon 容器镜像定义
+│   ├── docker/README.md                                                      # Docker 使用与部署说明
+│   ├── docker/docker-compose.yml                                             # 本地容器编排示例
+│   ├── docker/docker-entrypoint-dual-mode.sh                                 # 同时拉起服务组件的容器入口脚本
+│   └── docker/nats-ws.conf                                                   # 容器内 NATS WebSocket 配置
+├── nats-ws.conf                                                              # 仓库根目录下的 NATS WebSocket 配置样例
+├── pantheon/                                                                 # 核心 Python 包：Agent、Team、ToolSet、Chatroom、Endpoint 都在这里
+│   ├── pantheon/__init__.py                                                  # 包版本与顶层导出
+│   ├── pantheon/__main__.py                                                  # 统一 CLI 入口，分发到不同子命令
+│   ├── pantheon/agent.py                                                     # Agent 核心实现：消息、模型、工具调用与上下文管理
+│   ├── pantheon/background.py                                                # 后台任务支持，处理长耗时工具调用的异步反馈
+│   ├── pantheon/chatroom/                                                    # 多智能体会话服务层，对接 UI、会话线程与流式输出
+│   │   ├── pantheon/chatroom/__init__.py                                     # chatroom 包命名空间
+│   │   ├── pantheon/chatroom/__main__.py                                     # chatroom 子命令与 OAuth 相关入口
+│   │   ├── pantheon/chatroom/export.py                                       # 聊天记录导出与导入工具
+│   │   ├── pantheon/chatroom/nats-ws.conf                                    # chatroom 内置使用的 NATS WebSocket 配置
+│   │   ├── pantheon/chatroom/nats_manager.py                                 # 本地 NATS 服务的自动启动与管理
+│   │   ├── pantheon/chatroom/projects.py                                     # 项目目录注册表与项目切换逻辑
+│   │   ├── pantheon/chatroom/room.py                                         # ChatRoom 主服务，实现会话编排和前后端桥接
+│   │   ├── pantheon/chatroom/special_agents.py                               # 摘要、建议问题、会话命名等特殊用途 Agent
+│   │   ├── pantheon/chatroom/start.py                                        # 本地启动 chatroom、endpoint 与浏览器入口的总控脚本
+│   │   ├── pantheon/chatroom/stream.py                                       # NATS 流式消息适配器
+│   │   └── pantheon/chatroom/thread.py                                       # 单条会话线程的数据模型与状态容器
+│   ├── pantheon/claw/                                                        # PantheonClaw 多渠道网关，把 chatroom 暴露到聊天平台
+│   │   ├── pantheon/claw/__init__.py                                         # claw 包命名空间
+│   │   ├── pantheon/claw/__main__.py                                         # claw 命令行入口，负责网关模式切换
+│   │   ├── pantheon/claw/bridge.py                                           # chatroom 与外部聊天渠道之间的桥接层
+│   │   ├── pantheon/claw/channels/                                           # 各聊天平台的适配实现
+│   │   │   ├── pantheon/claw/channels/__init__.py                            # 渠道模块的延迟导入入口
+│   │   │   ├── pantheon/claw/channels/discord.py                             # Discord 渠道适配器
+│   │   │   ├── pantheon/claw/channels/feishu.py                              # 飞书渠道适配器
+│   │   │   ├── pantheon/claw/channels/imessage.py                            # iMessage 渠道适配器
+│   │   │   ├── pantheon/claw/channels/qq.py                                  # QQ 渠道适配器
+│   │   │   ├── pantheon/claw/channels/slack.py                               # Slack 渠道适配器
+│   │   │   ├── pantheon/claw/channels/telegram.py                            # Telegram 渠道适配器
+│   │   │   └── pantheon/claw/channels/wechat.py                              # 微信渠道适配器
+│   │   ├── pantheon/claw/config.py                                           # claw 配置的默认值、读写与脱敏逻辑
+│   │   ├── pantheon/claw/manager.py                                          # 多渠道网关的统一生命周期管理
+│   │   ├── pantheon/claw/registry.py                                         # 渠道路由注册表，记录会话与目标平台的映射
+│   │   └── pantheon/claw/runtime.py                                          # 渠道共享运行时，处理去重、格式转换和进度文本
+│   ├── pantheon/constant.py                                                  # 跨模块共享常量
+│   ├── pantheon/endpoint/                                                    # 远程工具端点：把 ToolSet 与 MCP 服务暴露成后端能力
+│   │   ├── pantheon/endpoint/__init__.py                                     # endpoint 包命名空间
+│   │   ├── pantheon/endpoint/__main__.py                                     # endpoint 命令行入口与配置生成器
+│   │   ├── pantheon/endpoint/core.py                                         # Endpoint 主类，装配工具、文件传输与 MCP 管理
+│   │   ├── pantheon/endpoint/gateway.py                                      # 统一 MCP 网关，把多个 MCP server 聚合成单入口
+│   │   ├── pantheon/endpoint/hub.py                                          # 多 endpoint 实例的聚合与发现层
+│   │   ├── pantheon/endpoint/mcp.py                                          # MCP 进程池与 server 生命周期管理
+│   │   ├── pantheon/endpoint/toolset_proxy.py                                # 远程 ToolSet 代理，供 Agent 透明调用
+│   │   └── pantheon/endpoint/toolsets.py                                     # ToolSet 生命周期管理器
+│   ├── pantheon/evolution/                                                   # 代码演化框架，用多 Agent 和评估器迭代改进程序
+│   │   ├── pantheon/evolution/__init__.py                                    # evolution 包命名空间
+│   │   ├── pantheon/evolution/__main__.py                                    # evolution CLI 入口
+│   │   ├── pantheon/evolution/config.py                                      # 演化流程的配置对象与预设策略
+│   │   ├── pantheon/evolution/database.py                                    # 演化结果数据库与 MAP-Elites 存储
+│   │   ├── pantheon/evolution/evaluator.py                                   # 候选程序的混合评估系统
+│   │   ├── pantheon/evolution/program.py                                     # 演化中的程序与代码快照数据结构
+│   │   ├── pantheon/evolution/prompt_builder.py                              # 生成变异提示词与评估上下文
+│   │   ├── pantheon/evolution/result.py                                      # 演化过程结果对象
+│   │   ├── pantheon/evolution/team.py                                        # 协调多 Agent 执行代码演化的 Team
+│   │   ├── pantheon/evolution/utils/                                         # 演化流程的底层辅助函数
+│   │   │   ├── pantheon/evolution/utils/__init__.py                          # utils 子包命名空间
+│   │   │   ├── pantheon/evolution/utils/diff.py                              # diff 解析、补丁应用与搜索替换工具
+│   │   │   └── pantheon/evolution/utils/metrics.py                           # 代码复杂度、多样性等度量计算
+│   │   └── pantheon/evolution/visualizer.py                                  # 演化结果可视化与 HTML 报告生成
+│   ├── pantheon/factory/                                                     # 模板工厂：把 markdown/json 模板装配成 Agent、Team 与技能包
+│   │   ├── pantheon/factory/__init__.py                                      # 暴露按模板创建 Agent/Team 的便捷函数
+│   │   ├── pantheon/factory/models.py                                        # 模板配置的数据模型
+│   │   ├── pantheon/factory/template_io.py                                   # 模板解析、prompt 解析与文件型模板管理
+│   │   ├── pantheon/factory/template_manager.py                              # 模板发现、加载与缓存入口
+│   │   └── pantheon/factory/templates/                                       # 预置模板仓库；这里只保留关键层级，不展开所有模板文件
+│   │       ├── pantheon/factory/templates/.env.example                       # 模板环境变量样例
+│   │       ├── pantheon/factory/templates/agents/                            # 预置 Agent 模板目录，覆盖 graph maker、single-cell、rare-disease 等场景
+│   │       │   ├── pantheon/factory/templates/agents/graph_maker/            # 生成图表团队的角色模板目录
+│   │       │   ├── pantheon/factory/templates/agents/paper_write/            # 论文写作团队的角色模板目录
+│   │       │   ├── pantheon/factory/templates/agents/rare_disease/           # 罕见病分析团队的角色模板目录
+│   │       │   └── pantheon/factory/templates/agents/single_cell/            # 单细胞分析团队的角色模板目录
+│   │       ├── pantheon/factory/templates/mcp.json                           # 默认 MCP 模板配置
+│   │       ├── pantheon/factory/templates/prompts/                           # 通用 prompt 模板目录，供 agent/team 组装系统提示词
+│   │       ├── pantheon/factory/templates/settings.json                      # 工厂默认设置与模板注册表
+│   │       ├── pantheon/factory/templates/skills/                            # 预置技能模板目录
+│   │       │   ├── pantheon/factory/templates/skills/SKILLS.md               # 技能目录索引
+│   │       │   ├── pantheon/factory/templates/skills/bio_image_processing/   # 生物图像处理技能族
+│   │       │   ├── pantheon/factory/templates/skills/figure_styling/         # 论文图风格化技能族
+│   │       │   ├── pantheon/factory/templates/skills/omics/                  # omics / single-cell / spatial 技能族
+│   │       │   ├── pantheon/factory/templates/skills/paper_writing/          # 论文写作技能族
+│   │       │   ├── pantheon/factory/templates/skills/presentation/           # 幻灯片与演示文稿技能族
+│   │       │   └── pantheon/factory/templates/skills/rare_disease/           # 罕见病知识与本体技能族
+│   │       └── pantheon/factory/templates/teams/                             # 预置 Team 模板目录，包含 default、evolution、single_cell 等组合
+│   ├── pantheon/internal/                                                    # 内部插件与共享运行时：压缩、记忆、学习、任务系统都挂在这里
+│   │   ├── pantheon/internal/__init__.py                                     # internal 包命名空间
+│   │   ├── pantheon/internal/background_agent.py                             # 轻量后台 Agent 工厂，用于多轮后台推理
+│   │   ├── pantheon/internal/compression/                                    # 上下文压缩子系统
+│   │   │   ├── pantheon/internal/compression/__init__.py                     # compression 子包命名空间
+│   │   │   ├── pantheon/internal/compression/compressor.py                   # 对话历史压缩器与状态模型
+│   │   │   ├── pantheon/internal/compression/plugin.py                       # 把压缩器接入 PantheonTeam 的插件
+│   │   │   └── pantheon/internal/compression/prompts.py                      # 压缩相关 prompt 模板
+│   │   ├── pantheon/internal/learning_system/                                # 技能学习系统，从对话中提炼技能并注入 prompt
+│   │   │   ├── pantheon/internal/learning_system/__init__.py                 # learning_system 子包命名空间
+│   │   │   ├── pantheon/internal/learning_system/config.py                   # 学习系统配置解析
+│   │   │   ├── pantheon/internal/learning_system/extractor.py                # 从对话中抽取技能的后台提取器
+│   │   │   ├── pantheon/internal/learning_system/injector.py                 # 把技能索引注入系统提示词
+│   │   │   ├── pantheon/internal/learning_system/plugin.py                   # 学习系统的 Team 插件适配层
+│   │   │   ├── pantheon/internal/learning_system/prompts.py                  # 学习系统 prompt 模板
+│   │   │   ├── pantheon/internal/learning_system/runtime.py                  # 学习系统共享运行时
+│   │   │   ├── pantheon/internal/learning_system/store.py                    # 技能文件的持久化与原子写入
+│   │   │   ├── pantheon/internal/learning_system/toolset.py                  # 面向 Agent 的技能管理 ToolSet
+│   │   │   └── pantheon/internal/learning_system/types.py                    # 技能 frontmatter 与校验类型定义
+│   │   ├── pantheon/internal/memory/                                         # 旧版/基础内存抽象与存储后端
+│   │   │   ├── pantheon/internal/memory/__init__.py                          # memory 子包命名空间
+│   │   │   ├── pantheon/internal/memory/memory.py                            # Memory 与 MemoryManager 实现
+│   │   │   └── pantheon/internal/memory/storage.py                           # JSON / JSONL 存储后端
+│   │   ├── pantheon/internal/memory_system/                                  # 统一长期记忆系统
+│   │   │   ├── pantheon/internal/memory_system/__init__.py                   # memory_system 子包命名空间
+│   │   │   ├── pantheon/internal/memory_system/chatroom.py                   # ChatRoom 与共享记忆运行时的适配层
+│   │   │   ├── pantheon/internal/memory_system/config.py                     # 长期记忆系统配置解析
+│   │   │   ├── pantheon/internal/memory_system/dream.py                      # dream/consolidation 记忆整合逻辑
+│   │   │   ├── pantheon/internal/memory_system/extract_memories.py           # 每轮自动抽取长期记忆
+│   │   │   ├── pantheon/internal/memory_system/flush.py                      # 压缩前刷新重要信息到长期记忆
+│   │   │   ├── pantheon/internal/memory_system/freshness.py                  # 记忆新鲜度与过期提示
+│   │   │   ├── pantheon/internal/memory_system/plugin.py                     # 记忆系统接入 PantheonTeam 的插件
+│   │   │   ├── pantheon/internal/memory_system/prompts.py                    # 记忆系统 prompt 模板
+│   │   │   ├── pantheon/internal/memory_system/retrieval.py                  # 基于 LLM 的记忆检索器
+│   │   │   ├── pantheon/internal/memory_system/runtime.py                    # 统一记忆运行时的核心协调器
+│   │   │   ├── pantheon/internal/memory_system/session_log.py                # 会话日志管理
+│   │   │   ├── pantheon/internal/memory_system/session_note.py               # 持续更新的会话摘要/速记抽取器
+│   │   │   ├── pantheon/internal/memory_system/store.py                      # 基于文件的长期记忆存储
+│   │   │   └── pantheon/internal/memory_system/types.py                      # 记忆 frontmatter、类型和序列化约定
+│   │   ├── pantheon/internal/message/                                        # 消息附件检测与处理流水线
+│   │   │   ├── pantheon/internal/message/attachment_detection.py             # 自动识别图片、路径、链接等附件
+│   │   │   └── pantheon/internal/message/attachment_pipeline.py              # 附件处理总流水线与消息预处理器
+│   │   ├── pantheon/internal/package_runtime/                                # 运行时 package 上下文导出、发现和代理
+│   │   │   ├── pantheon/internal/package_runtime/__init__.py                 # package runtime 包入口与管理器装配
+│   │   │   ├── pantheon/internal/package_runtime/context.py                  # 导出/加载包上下文到子进程或解释器
+│   │   │   ├── pantheon/internal/package_runtime/manager.py                  # 运行时 package 发现与调用管理
+│   │   │   └── pantheon/internal/package_runtime/runtime.py                  # 在解释器里暴露给用户代码的 package runtime
+│   │   ├── pantheon/internal/system_prompt.py                                # 系统提示词渲染与上下文块拼装
+│   │   ├── pantheon/internal/task_system/                                    # 任务状态机与任务工具接入层
+│   │   │   ├── pantheon/internal/task_system/__init__.py                     # task_system 子包入口
+│   │   │   └── pantheon/internal/task_system/plugin.py                       # 把任务系统挂入 PantheonTeam 的插件
+│   │   └── pantheon/internal/think_plugin.py                                 # leader-only think 工具与相关 prompt 注入
+│   ├── pantheon/packages.py                                                  # 面向用户的 package runtime 兼容入口
+│   ├── pantheon/providers.py                                                 # Tool provider 抽象，连接本地、MCP 与 ToolSet provider
+│   ├── pantheon/remote/                                                      # 分布式远程后端抽象；当前以 NATS 为主
+│   │   ├── pantheon/remote/__init__.py                                       # remote 包命名空间
+│   │   ├── pantheon/remote/backend/                                          # 远程通信后端实现
+│   │   │   ├── pantheon/remote/backend/__init__.py                           # backend 子包命名空间
+│   │   │   ├── pantheon/remote/backend/base.py                               # 远程 backend、service、worker 的基础抽象
+│   │   │   ├── pantheon/remote/backend/nats.py                               # NATS 后端实现与远程 worker 协议
+│   │   │   └── pantheon/remote/backend/registry.py                           # 可用 backend 的注册表
+│   │   ├── pantheon/remote/factory.py                                        # 远程 backend 配置解析与连接工厂
+│   │   └── pantheon/remote/remote.py                                         # 远程连接的轻量便捷入口
+│   ├── pantheon/repl/                                                        # 交互式命令行界面与文本 UI
+│   │   ├── pantheon/repl/__init__.py                                         # repl 包命名空间
+│   │   ├── pantheon/repl/__main__.py                                         # REPL 命令行启动入口
+│   │   ├── pantheon/repl/conversationRecovery.py                             # 会话恢复与中断检测逻辑
+│   │   ├── pantheon/repl/core.py                                             # REPL 主循环，连接 Agent/Team 与文本交互
+│   │   ├── pantheon/repl/handlers/                                           # REPL 命令处理器
+│   │   │   ├── pantheon/repl/handlers/__init__.py                            # handlers 命名空间
+│   │   │   ├── pantheon/repl/handlers/base.py                                # 命令处理器基类
+│   │   │   ├── pantheon/repl/handlers/builtin/                               # 内置斜杠命令处理器
+│   │   │   │   ├── pantheon/repl/handlers/builtin/__init__.py                # builtin handlers 命名空间
+│   │   │   │   ├── pantheon/repl/handlers/builtin/bash.py                    # `/bash` 命令处理器
+│   │   │   │   ├── pantheon/repl/handlers/builtin/edit.py                    # `/edit` 命令处理器，调用外部编辑器
+│   │   │   │   ├── pantheon/repl/handlers/builtin/mcp.py                     # MCP 管理命令处理器
+│   │   │   │   ├── pantheon/repl/handlers/builtin/revert.py                  # 回滚/恢复类命令处理器
+│   │   │   │   └── pantheon/repl/handlers/builtin/view.py                    # 文件查看命令处理器
+│   │   │   └── pantheon/repl/handlers/template_handler.py                    # 基于模板的通用命令处理器
+│   │   ├── pantheon/repl/prompt_app.py                                       # prompt_toolkit 驱动的输入框、补全和按键绑定
+│   │   ├── pantheon/repl/renderers.py                                        # 工具调用与工具结果的终端渲染器
+│   │   ├── pantheon/repl/sessionRestore.py                                   # 从日志和 worktree 恢复旧会话
+│   │   ├── pantheon/repl/sessionStorage.py                                   # REPL 会话元数据与恢复状态持久化
+│   │   ├── pantheon/repl/setup_wizard.py                                     # 首次使用时的 provider/API key 配置向导
+│   │   ├── pantheon/repl/task_renderers.py                                   # 任务型 UI 的渲染器
+│   │   ├── pantheon/repl/ui.py                                               # REPL 文本界面外观与输出封装
+│   │   ├── pantheon/repl/user_response.py                                    # 面向用户的统一响应格式化
+│   │   ├── pantheon/repl/utils.py                                            # REPL 共享辅助函数与样式片段
+│   │   └── pantheon/repl/viewers/                                            # 全屏查看器与交互对话框
+│   │       ├── pantheon/repl/viewers/__init__.py                             # viewers 命名空间
+│   │       ├── pantheon/repl/viewers/file_viewer_ptk.py                      # 基于 prompt_toolkit 的文件查看器
+│   │       ├── pantheon/repl/viewers/notify_dialog.py                        # 需要用户确认时的交互对话框
+│   │       └── pantheon/repl/viewers/unified_dialog.py                       # 统一的文件审阅/提问对话框
+│   ├── pantheon/settings.py                                                  # 全局配置加载、JSONC 解析与 Settings 单例
+│   ├── pantheon/slack/                                                       # Slack 集成入口
+│   │   ├── pantheon/slack/__init__.py                                        # slack 包命名空间
+│   │   ├── pantheon/slack/__main__.py                                        # Slack 子命令入口
+│   │   └── pantheon/slack/app.py                                             # Slack 应用启动器
+│   ├── pantheon/smart_func.py                                                # 把普通函数包装成更易被 Agent 调用的 smart_func
+│   ├── pantheon/store/                                                       # Pantheon Store 的 CLI、安装、发布与批量播种
+│   │   ├── pantheon/store/__init__.py                                        # store 包命名空间
+│   │   ├── pantheon/store/auth.py                                            # Store JWT 鉴权与本地 token 存储
+│   │   ├── pantheon/store/cli.py                                             # Store 命令行子命令集合
+│   │   ├── pantheon/store/client.py                                          # Store HTTP API 客户端
+│   │   ├── pantheon/store/installer.py                                       # 从 Store 下载并安装 package
+│   │   ├── pantheon/store/publisher.py                                       # 收集并发布 agent/team/skill 到 Store
+│   │   └── pantheon/store/seed.py                                            # 批量向 Store 预灌模板与外部技能
+│   ├── pantheon/team/                                                        # 多 Agent 编排模式：顺序、群聊、MoA、Agent-as-Tool 等
+│   │   ├── pantheon/team/__init__.py                                         # team 包导出
+│   │   ├── pantheon/team/aat.py                                              # Agent-as-Tool 团队模式
+│   │   ├── pantheon/team/base.py                                             # Team 抽象基类
+│   │   ├── pantheon/team/moa.py                                              # Mixture-of-Agents 团队模式
+│   │   ├── pantheon/team/pantheon.py                                         # PantheonTeam 主实现，负责委派、插件与上下文继承
+│   │   ├── pantheon/team/plugin.py                                           # Team 插件协议与紧凑提示接口
+│   │   ├── pantheon/team/plugin_registry.py                                  # 插件注册与装配中心
+│   │   ├── pantheon/team/sequential.py                                       # 顺序执行型团队模式
+│   │   └── pantheon/team/swarm.py                                            # Swarm 与 SwarmCenter 团队模式
+│   ├── pantheon/toolset.py                                                   # ToolSet 基础设施：`@tool` 装饰器、上下文注入与执行编排
+│   ├── pantheon/toolsets/                                                    # 内置工具箱集合
+│   │   ├── pantheon/toolsets/__init__.py                                     # ToolSet 模块的懒加载入口
+│   │   ├── pantheon/toolsets/__main__.py                                     # 列出、检查和启动 ToolSet 的 CLI 入口
+│   │   ├── pantheon/toolsets/code/                                           # 静态代码浏览与语法树分析工具
+│   │   │   ├── pantheon/toolsets/code/__init__.py                            # code toolset 包入口
+│   │   │   ├── pantheon/toolsets/code/code_toolset.py                        # 代码导航 ToolSet
+│   │   │   └── pantheon/toolsets/code/tree_sitter_parser.py                  # 基于 tree-sitter 的多语言代码解析器
+│   │   ├── pantheon/toolsets/database_api/                                   # 生物数据库查询 ToolSet
+│   │   │   ├── pantheon/toolsets/database_api/README.md                      # 数据库查询工具说明
+│   │   │   ├── pantheon/toolsets/database_api/__init__.py                    # database_api 包入口
+│   │   │   ├── pantheon/toolsets/database_api/database_api_query.py          # 数据库查询 ToolSet 主实现
+│   │   │   ├── pantheon/toolsets/database_api/schema_manager.py              # 数据库 schema 加载与管理
+│   │   │   └── pantheon/toolsets/database_api/schemas/                       # 各数据库 API schema 定义
+│   │   │       ├── pantheon/toolsets/database_api/schemas/cbioportal.json    # cBioPortal 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/clinvar.json       # ClinVar 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/dbsnp.json         # dbSNP 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/emdb.json          # EMDB 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/ensembl.json       # Ensembl 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/geo.json           # GEO 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/gnomad.json        # gnomAD 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/gtopdb.json        # Guide to Pharmacology 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/gwas_catalog.json  # GWAS Catalog 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/interpro.json      # InterPro 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/iucn.json          # IUCN 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/jaspar.json        # JASPAR 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/kegg.json          # KEGG 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/monarch.json       # Monarch Initiative 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/mpd.json           # Mouse Phenome Database 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/openfda.json       # OpenFDA 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/opentarget.json    # Open Targets 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/paleobiology.json  # Paleobiology Database 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/pdb.json           # Protein Data Bank 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/pride.json         # PRIDE 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/reactome.json      # Reactome 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/remap.json         # ReMap 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/stringdb.json      # STRING DB 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/ucsc.json          # UCSC Genome Browser 查询 schema
+│   │   │       ├── pantheon/toolsets/database_api/schemas/uniprot.json       # UniProt 查询 schema
+│   │   │       └── pantheon/toolsets/database_api/schemas/worms.json         # WoRMS 查询 schema
+│   │   ├── pantheon/toolsets/evolution/                                      # 把演化能力暴露给 Agent 的工具箱
+│   │   │   ├── pantheon/toolsets/evolution/__init__.py                       # evolution toolset 包入口
+│   │   │   ├── pantheon/toolsets/evolution/evaluator_toolset.py              # 代码评估工具
+│   │   │   └── pantheon/toolsets/evolution/evolution_toolset.py              # 演化会话与控制工具
+│   │   ├── pantheon/toolsets/file/                                           # 文件编辑与搜索工具
+│   │   │   ├── pantheon/toolsets/file/__init__.py                            # file toolset 包入口
+│   │   │   ├── pantheon/toolsets/file/apply_patch.py                         # patch 解析与应用工具
+│   │   │   ├── pantheon/toolsets/file/file_manager.py                        # 读写、替换、图像识别等文件管理工具
+│   │   │   └── pantheon/toolsets/file/grep_glob.py                           # glob / grep 搜索实现
+│   │   ├── pantheon/toolsets/file_transfer/                                  # 文件传输服务
+│   │   │   ├── pantheon/toolsets/file_transfer/__init__.py                   # file_transfer 包入口
+│   │   │   ├── pantheon/toolsets/file_transfer/client.py                     # 文件传输客户端
+│   │   │   └── pantheon/toolsets/file_transfer/worker.py                     # 文件传输 ToolSet 与服务端逻辑
+│   │   ├── pantheon/toolsets/image/                                          # 图像生成工具
+│   │   │   ├── pantheon/toolsets/image/__init__.py                           # image toolset 包入口
+│   │   │   └── pantheon/toolsets/image/image_gen.py                          # 图像生成 ToolSet
+│   │   ├── pantheon/toolsets/julia/                                          # Julia 解释器工具
+│   │   │   ├── pantheon/toolsets/julia/__init__.py                           # julia toolset 包入口
+│   │   │   ├── pantheon/toolsets/julia/_julia.py                             # Julia 子进程解释器实现
+│   │   │   └── pantheon/toolsets/julia/julia_interpreter.py                  # JuliaInterpreter ToolSet
+│   │   ├── pantheon/toolsets/knowledge/                                      # 向量知识库与 RAG 配置
+│   │   │   ├── pantheon/toolsets/knowledge/__init__.py                       # knowledge toolset 包入口
+│   │   │   ├── pantheon/toolsets/knowledge/config.py                         # 知识库配置解析
+│   │   │   ├── pantheon/toolsets/knowledge/config.yaml                       # 知识库默认配置文件
+│   │   │   ├── pantheon/toolsets/knowledge/knowledge_manager.py              # 知识库管理 ToolSet
+│   │   │   ├── pantheon/toolsets/knowledge/models.py                         # 知识库数据模型
+│   │   │   └── pantheon/toolsets/knowledge/vector_store.py                   # 向量存储后端抽象
+│   │   ├── pantheon/toolsets/notebook/                                       # Jupyter/Notebook 集成工具
+│   │   │   ├── pantheon/toolsets/notebook/__init__.py                        # notebook toolset 包入口
+│   │   │   ├── pantheon/toolsets/notebook/handlers.py                        # Jupyter IOPub 事件处理器
+│   │   │   ├── pantheon/toolsets/notebook/integrated_notebook.py             # 集成式 Notebook ToolSet
+│   │   │   ├── pantheon/toolsets/notebook/jedi_integration.py                # Jedi 代码补全与智能提示集成
+│   │   │   ├── pantheon/toolsets/notebook/jupyter_kernel.py                  # Jupyter kernel 控制 ToolSet
+│   │   │   └── pantheon/toolsets/notebook/notebook_contents.py               # Notebook 文件内容管理 ToolSet
+│   │   ├── pantheon/toolsets/package.py                                      # package 安装、发现与调用的统一 ToolSet
+│   │   ├── pantheon/toolsets/python/                                         # Python 解释器工具
+│   │   │   ├── pantheon/toolsets/python/__init__.py                          # python toolset 包入口
+│   │   │   └── pantheon/toolsets/python/python_interpreter.py                # PythonInterpreter ToolSet
+│   │   ├── pantheon/toolsets/r/                                              # R 解释器工具
+│   │   │   ├── pantheon/toolsets/r/__init__.py                               # r toolset 包入口
+│   │   │   ├── pantheon/toolsets/r/_rinter.py                                # R 子进程解释器实现
+│   │   │   └── pantheon/toolsets/r/r_interpreter.py                          # RInterpreter ToolSet
+│   │   ├── pantheon/toolsets/rag/                                            # 旧版/通用向量 RAG 工具链
+│   │   │   ├── pantheon/toolsets/rag/__init__.py                             # rag toolset 包入口
+│   │   │   ├── pantheon/toolsets/rag/__main__.py                             # rag 子命令入口
+│   │   │   ├── pantheon/toolsets/rag/build.py                                # 构建向量库与抓取文档
+│   │   │   ├── pantheon/toolsets/rag/text.py                                 # 文本切分辅助函数
+│   │   │   ├── pantheon/toolsets/rag/toolset.py                              # VectorRAG ToolSet
+│   │   │   ├── pantheon/toolsets/rag/vectordb.py                             # 向量数据库封装
+│   │   │   └── pantheon/toolsets/rag/wrap.py                                 # RAG 调用包装器
+│   │   ├── pantheon/toolsets/scfm/                                           # single-cell foundation model 路由与适配层
+│   │   │   ├── pantheon/toolsets/scfm/__init__.py                            # scfm toolset 包入口
+│   │   │   ├── pantheon/toolsets/scfm/_conda_runner.py                       # 在独立 conda 环境里执行 SCFM 适配器
+│   │   │   ├── pantheon/toolsets/scfm/adapters/                              # 各单细胞基础模型的适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/__init__.py               # adapters 命名空间
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/aidocell.py               # AIDO.Cell 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/atacformer.py             # Atacformer 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/base.py                   # SCFM 适配器基类
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/cell2sentence.py          # Cell2Sentence 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/cellfm.py                 # CellFM 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/cellplm.py                # CellPLM 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/chatcell.py               # CHATCELL 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/genecompass.py            # GeneCompass 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/geneformer.py             # Geneformer 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/genept.py                 # GenePT 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/langcell.py               # LangCell 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/nicheformer.py            # Nicheformer 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/pulsar.py                 # PULSAR 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/scbert.py                 # scBERT 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/sccello.py                # scCello 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/scfoundation.py           # scFoundation / xTrimoGene 适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/scgpt.py                  # scGPT 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/scmulan.py                # scMulan 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/scplantllm.py             # scPlantLLM 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/scprint.py                # scPRINT 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/tabula.py                 # Tabula 模型适配器
+│   │   │   │   ├── pantheon/toolsets/scfm/adapters/tgpt.py                   # tGPT 模型适配器
+│   │   │   │   └── pantheon/toolsets/scfm/adapters/uce.py                    # UCE 模型适配器
+│   │   │   ├── pantheon/toolsets/scfm/registry.py                            # SCFM 模型注册表与能力元数据
+│   │   │   ├── pantheon/toolsets/scfm/router.py                              # 基于 LLM 的 SCFM 路由器
+│   │   │   └── pantheon/toolsets/scfm/toolset.py                             # SCFM ToolSet 主入口
+│   │   ├── pantheon/toolsets/scraper.py                                      # 通用网页抓取 ToolSet
+│   │   ├── pantheon/toolsets/shell/                                          # Shell 命令执行工具
+│   │   │   ├── pantheon/toolsets/shell/__init__.py                           # shell toolset 包入口
+│   │   │   ├── pantheon/toolsets/shell/_shell.py                             # shell 子进程执行核心
+│   │   │   └── pantheon/toolsets/shell/shell.py                              # ShellToolSet 封装
+│   │   ├── pantheon/toolsets/task/                                           # 任务状态与工作流工具
+│   │   │   ├── pantheon/toolsets/task/__init__.py                            # task toolset 包入口
+│   │   │   ├── pantheon/toolsets/task/ephemeral.py                           # 生成临时状态消息
+│   │   │   ├── pantheon/toolsets/task/task_state.py                          # 任务状态、角色与会话状态模型
+│   │   │   └── pantheon/toolsets/task/task_toolset.py                        # TaskToolSet 主实现
+│   │   ├── pantheon/toolsets/web.py                                          # 面向 Agent 的网页搜索/抓取 ToolSet
+│   │   └── pantheon/toolsets/web_urllib.py                                   # 基于 DDGS/urllib 的轻量网页 ToolSet 备选实现
+│   └── pantheon/utils/                                                       # 跨模块共享的 LLM、日志、模板、视觉与工具辅助函数
+│       ├── pantheon/utils/__init__.py                                        # utils 包命名空间
+│       ├── pantheon/utils/adapters/                                          # 各 LLM provider 的统一适配层
+│       │   ├── pantheon/utils/adapters/__init__.py                           # adapter 工厂入口
+│       │   ├── pantheon/utils/adapters/anthropic_adapter.py                  # Anthropic / Claude 适配器
+│       │   ├── pantheon/utils/adapters/base.py                               # provider adapter 基类与统一异常
+│       │   ├── pantheon/utils/adapters/codex_adapter.py                      # 基于 OAuth 的 Codex / ChatGPT backend 适配器
+│       │   ├── pantheon/utils/adapters/gemini_adapter.py                     # Gemini REST API 适配器
+│       │   ├── pantheon/utils/adapters/gemini_cli_adapter.py                 # Gemini CLI 风格 REST 适配器
+│       │   ├── pantheon/utils/adapters/image_blocks.py                       # 多模态消息里的图片块转换与缩放
+│       │   └── pantheon/utils/adapters/openai_adapter.py                     # OpenAI 及 OpenAI-compatible provider 适配器
+│       ├── pantheon/utils/display.py                                         # 富文本终端输出与工具结果打印辅助
+│       ├── pantheon/utils/image_detection.py                                 # 运行前后快照比对，识别新生成的图片文件
+│       ├── pantheon/utils/llm.py                                             # LLM 调用封装与 OpenAI Responses/Chat Completions 兼容层
+│       ├── pantheon/utils/llm_catalog.json                                   # 模型目录与 provider 元数据
+│       ├── pantheon/utils/llm_providers.py                                   # provider 识别、Responses API 策略与基础配置工具
+│       ├── pantheon/utils/log.py                                             # 日志配置与临时日志级别控制
+│       ├── pantheon/utils/memory_compress.py                                 # 旧版记忆压缩辅助函数
+│       ├── pantheon/utils/message_formatter.py                               # 会话消息转文本的统一格式化器
+│       ├── pantheon/utils/misc.py                                            # 常用杂项工具：调用、端口、描述解析等
+│       ├── pantheon/utils/model_discovery.py                                 # 动态探测 provider 可用模型列表
+│       ├── pantheon/utils/model_selector.py                                  # 默认模型选择、provider 排序与 Ollama 状态缓存
+│       ├── pantheon/utils/oauth/                                             # provider OAuth 登录支持
+│       │   ├── pantheon/utils/oauth/__init__.py                              # OAuth 包入口
+│       │   ├── pantheon/utils/oauth/codex.py                                 # OpenAI Codex / ChatGPT OAuth 流程
+│       │   └── pantheon/utils/oauth/gemini.py                                # Gemini CLI OAuth 流程
+│       ├── pantheon/utils/process.py                                         # 跨平台子进程生命周期辅助函数
+│       ├── pantheon/utils/provider_registry.py                               # 从模型目录加载 provider 元数据并提供查询接口
+│       ├── pantheon/utils/template.py                                        # 模板项解析与模板加载工具
+│       ├── pantheon/utils/token_optimization.py                              # 对话上下文折叠与 token 优化逻辑
+│       ├── pantheon/utils/tool_pairing.py                                    # 工具调用消息与结果消息配对修复
+│       ├── pantheon/utils/truncate.py                                        # 大体积工具输出截断与预览辅助函数
+│       ├── pantheon/utils/vision.py                                          # 多模态图片输入封装与引用展开
+│       └── pantheon/utils/vision_capability.py                               # 检测模型是否支持视觉/图片结果能力
+├── pyproject.toml                                                            # Python 包元数据、依赖、入口点和 pytest 配置
+├── runtime_hook_tiktoken.py                                                  # 打包环境里为 tiktoken 注入运行时 hook
+├── scripts/                                                                  # 维护、基准测试与批量导入脚本
+│   ├── scripts/benchmark_multi_provider.py                                   # 多 provider 响应/成本基准脚本
+│   ├── scripts/benchmark_prompt_cache.py                                     # prompt cache 基准脚本
+│   ├── scripts/benchmark_token_optimization_live.py                          # 在线 token 优化基准脚本
+│   ├── scripts/benchmark_token_optimizations.py                              # token 优化离线比较脚本
+│   ├── scripts/seed_omicclaw.py                                              # 为 OmicClaw / Store 批量播种数据
+│   └── scripts/test_two_phase_live.py                                        # 双阶段流程的在线测试脚本
+└── uv.lock                                                                   # uv 解析出的锁文件，固定依赖版本
+```
+
+## 支撑目录摘要
+
+- `tests/`：自动化测试总入口。这里重点覆盖 `agent/team` 编排、`chatroom` 与 NATS 流、`memory_system` 与 `learning_system`、`toolsets`、provider/OAuth/model selection、REPL 恢复与 UI 渲染等核心行为；其中 `tests/test_learning_system/`、`tests/test_memory_system/`、`tests/test_task_system/` 是按子系统分组的测试目录。
+- `examples/`：示例与实验工作流。主要分成演化类示例（`evolution_batch_correction`、`evolution_gene_panel`、`evolution_topact`）、报告生成示例（`paper_reporter`、`paper_reporter_v2`）、上游流程/技能样例（`fastq_processing`）以及单细胞空间分析完整示例（`single_cell_spatial_analysis`）。
+- `docs/`：用户文档与开发者文档。`docs/source/` 是 Sphinx 主文档树，`docs/source/architecture.rst` 讲系统级架构，`docs/scfm/` 收纳单细胞基础模型专题材料，`docs/images/` 存放文档图片资源，其余脚本和配置用于本地构建与文档测试。

--- a/pantheon/factory/templates/skills/paper_writing/SKILL.md
+++ b/pantheon/factory/templates/skills/paper_writing/SKILL.md
@@ -2,46 +2,90 @@
 id: paper_writing_skills_index
 name: Paper Writing Skills Index
 description: |
-  Skills for the Paper Write Team: report and academic templates for
-  HTML/PDF rendering. Each template file is self-contained (HTML + CSS
-  or LaTeX in a single markdown file).
+  Routing and workflow skills for the Paper Write Team. Use when users ask for
+  manuscript drafting, journal or conference papers, grant proposals, lab
+  reports, group-meeting reports, talks, workshop notes, reviewer rebuttals,
+  academic HTML/PDF/LaTeX output, citation grounding, evidence checking, or
+  paper-writing quality review.
+tags: [paper_writing, manuscript, grant, rebuttal, citation, html, latex]
 ---
 
 # Paper Writing Skills
 
-Resources for the Paper Write Team's reporter agent. Each template is a
-self-contained markdown file with the full HTML+CSS or LaTeX content.
+This skill is the only paper-writing entry point. Keep `paper_write_team` as the
+team interface; route inside this skill family instead of adding new teams.
 
-## Templates
+## Routing + Sequential Pipeline
 
-| Template | File | Style | Use Case |
-|----------|------|-------|----------|
-| `report_standard` | [report_standard.md](./report_standard.md) | Professional report (Manus-style), HTML+CSS | Default for all reports |
-| `report_academic` | [report_academic.md](./report_academic.md) | Formal academic paper, HTML+CSS | HTML preview for academic papers |
-| `latex_cn` | [latex_cn.md](./latex_cn.md) | Chinese academic paper, LaTeX | Chinese academic PDF via Tectonic |
-| `latex_en` | [latex_en.md](./latex_en.md) | English academic paper, LaTeX | English academic PDF via Tectonic |
+Always run these phases in order. Load only the referenced files needed for the
+current scenario.
 
-## How to Use
+| Phase | Entry criteria | Actions | Exit criteria |
+|---|---|---|---|
+| 0. Triage | User request and any UI scenario labels | Read [workflow/triage.md](./workflow/triage.md), choose `scenario_id`, `format_id`, `theme_id`, language, audience, outputs, constraints | `triage.md` exists or is updated |
+| 1. Materials and evidence | Triage is known | Read relevant scenario skill, inventory materials, fetch/search papers only when needed, build evidence registry | `materials/inventory.md` and/or `claim_evidence_map.md` |
+| 2. Outline and claim boundary | Evidence and materials are known | Read [workflow/paper_outline.md](./workflow/paper_outline.md), add figure storyline or knowledge lineage when needed | `paper_view` and `evidence_view` outline |
+| 3. Section drafting | Outline and evidence boundary exist | Read [writing/SKILL.md](./writing/SKILL.md), draft Markdown only within evidence bounds | `draft/paper.md` |
+| 4. Quality gates | Draft exists | Read [quality/SKILL.md](./quality/SKILL.md), run scenario-specific gates | quality reports under `quality/` |
+| 5. Editable output | Draft and quality notes exist | Read [formats/html_editable_contract.md](./formats/html_editable_contract.md), use the selected template/theme | `report/<slug>_preview.html` and final resume packet |
 
-### Report style (default)
+## Scenario Routing
 
-1. Reporter reads this skill index
-2. Reporter reads `report_standard.md` — contains both the HTML template and CSS
-3. Reporter reads paper.md, parses frontmatter, converts Markdown body to HTML
-4. Reporter fills the HTML template with metadata + CSS + content
-5. Reporter writes the final HTML file
-6. The UI exports the HTML to PDF on user request (browser print-to-PDF using the `@media print` CSS rules)
+| User intent | `scenario_id` | Required skill | Format/theme | Quality gates |
+|---|---|---|---|---|
+| manuscript, paper submission, write a paper | `paper_submission` | [scenarios/paper_submission.md](./scenarios/paper_submission.md) | `conference_paper` or `journal_article`, `editable_article` | claim evidence, reviewer rubric, format lint |
+| journal article, SCI, Nature-style paper | `journal_article` | [scenarios/journal_article.md](./scenarios/journal_article.md) | `journal_article`, `journal_article` | data availability, citation, reviewer rubric |
+| conference paper, workshop paper, double column | `conference_paper` | [scenarios/conference_paper.md](./scenarios/conference_paper.md) | `conference_paper`, `conference_paper` | page limit, baseline/evaluation, reviewer rubric |
+| grant, proposal, funding application | `grant_proposal` | [scenarios/grant_proposal.md](./scenarios/grant_proposal.md) | `grant_application`, `grant_form` | gap-aim-route feasibility, word limits |
+| lab report, experiment report | `lab_report` | [scenarios/lab_report.md](./scenarios/lab_report.md) | `lab_report`, `lab_report` | reproducibility, raw observation/result separation |
+| group meeting, weekly report | `group_report` | [scenarios/group_report.md](./scenarios/group_report.md) | `group_report`, `group_report` | evidence summary, discussion questions |
+| conference talk, workshop sharing | `conference_talk` or `workshop_share` | [scenarios/conference_talk.md](./scenarios/conference_talk.md) or [scenarios/workshop_share.md](./scenarios/workshop_share.md) | `conference_talk`, `group_report` | storyline, speaker notes |
+| reviewer comments, rebuttal, revision response | `revision_response` | [scenarios/revision_response.md](./scenarios/revision_response.md) | `revision_response`, `revision_response` | every-comment response, manuscript consistency |
 
-### Academic style
+## Required Outputs
 
-1. Reporter reads this skill index
-2. Reporter reads the LaTeX template (`latex_cn.md` or `latex_en.md` based on lang)
-3. Reporter reads paper.md, parses frontmatter, converts Markdown body to LaTeX
-4. Reporter fills the LaTeX template with metadata + content, writes .tex file
-5. Reporter runs Tectonic to compile PDF
-6. Reporter also reads `report_academic.md` to generate an HTML preview
+For full paper-writing tasks, default to these artifacts unless the user narrows
+the request:
 
-### Custom templates
+- `triage.md`
+- `draft/paper.md`
+- `report/<slug>_preview.html`
+- `quality/claim_evidence_report.md`
+- `quality/reviewer_report.md` for submissions, grants, rebuttals, or high-risk tasks
 
-Users can add their own `.md` template files to this directory following the
-same format (frontmatter + HTML/CSS or LaTeX in code blocks).
+## Template And Protocol Files
+
+| Purpose | File |
+|---|---|
+| Standard HTML report compatibility | [report_standard.md](./report_standard.md) |
+| Academic HTML preview compatibility | [report_academic.md](./report_academic.md) |
+| Chinese LaTeX compatibility | [latex_cn.md](./latex_cn.md) |
+| English LaTeX compatibility | [latex_en.md](./latex_en.md) |
+| Editable HTML block contract | [formats/html_editable_contract.md](./formats/html_editable_contract.md) |
+| Scenario format contracts | [formats/scenario_formats.md](./formats/scenario_formats.md) |
+| Kami-style academic theme | [themes/kami_academic.md](./themes/kami_academic.md) |
+
+## Non-Negotiable Rules
+
+- Do not write unsupported claims. Mark missing evidence and downgrade or remove
+  the claim.
+- Do not invent citations, DOI, accession IDs, page numbers, data repositories,
+  reviewer changes, or experimental results.
+- Do not let a search result become evidence until it is summarized, attributed,
+  and bound to a specific claim.
+- Do not use Sci-Hub or any access-control bypass. Open PDF fetching may use only
+  legal OA routes described in [evidence/paper_fetch.md](./evidence/paper_fetch.md).
+- Do not output screenshot-like reports. Main text must remain semantic and
+  editable HTML.
+- Keep each `SKILL.md` below 500 lines. Put long templates, guidelines, and
+  examples in adjacent one-hop files.
+
+## Sources Used To Shape This Skill Family
+
+- Anthropic skill design: <https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md>
+- Anthropic doc coauthoring: <https://github.com/anthropics/skills/blob/main/skills/doc-coauthoring/SKILL.md>
+- Trail of Bits workflow skill design: <https://github.com/trailofbits/skills/blob/main/plugins/workflow-skill-design/skills/designing-workflow-skills/SKILL.md>
+- PaperQA evidence RAG: <https://github.com/Future-House/paper-qa/blob/main/README.md>
+- OpenScholar attribution: <https://github.com/akariasai/openscholar/blob/main/src/open_scholar.py>
+- Nature-style response/figure/citation/data skills: <https://github.com/Yuan1z0825/nature-skills>
+- DeepScientist outline/review/rebuttal/writer skills: <https://github.com/ResearAI/DeepScientist>

--- a/pantheon/factory/templates/skills/paper_writing/evidence/SKILL.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/SKILL.md
@@ -1,0 +1,24 @@
+---
+id: paper_writing_evidence
+name: Paper Writing Evidence Layer
+description: Evidence layer for paper search, OA paper fetch, claim-evidence maps, citation grounding, evidence summaries, reranking, and context-bound answers.
+tags: [paper_writing, evidence, citations, rag]
+---
+
+# Evidence Skills
+
+Evidence skills decide where facts come from. Writers may not invent facts or
+use model memory as support for manuscript claims.
+
+| Need | File |
+|---|---|
+| Search candidate papers | [paper_search.md](./paper_search.md) |
+| Fetch an open-access PDF by identifier | [paper_fetch.md](./paper_fetch.md) |
+| Register claims and support | [evidence_registry.md](./evidence_registry.md) |
+| Ground citations for text segments | [citation_grounding.md](./citation_grounding.md) |
+| Summarize retrieved evidence | [evidence_summary.md](./evidence_summary.md) |
+| Rerank and attribute sentences | [rerank_and_attribution.md](./rerank_and_attribution.md) |
+| Answer only from provided context | [context_answering.md](./context_answering.md) |
+| Write data/code availability | [data_availability.md](./data_availability.md) |
+
+Default order: search/fetch -> summarize -> register evidence -> draft -> check.

--- a/pantheon/factory/templates/skills/paper_writing/evidence/citation_grounding.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/citation_grounding.md
@@ -1,0 +1,31 @@
+---
+id: paper_writing_citation_grounding
+name: Citation Grounding
+description: Ground manuscript segments to citation candidates with support grades and no invented metadata.
+tags: [paper_writing, citation, grounding]
+---
+
+# Citation Grounding
+
+Use when drafting related work, introduction, discussion, or any claim needing
+published support.
+
+## Output
+
+| Segment/claim | Query | Candidate paper | Support grade | Evidence note | Citation metadata |
+|---|---|---|---|---|---|
+
+Support grades:
+
+- `strong`: directly supports the claim.
+- `partial`: supports a narrower version.
+- `background`: relevant context only.
+- `conflicting`: contradicts or complicates the claim.
+
+## Rules
+
+- Do not cite a paper only because it shares keywords.
+- Do not invent DOI, PMID, venue, pages, or year.
+- Prefer exact claim support over famous or high-citation background papers.
+
+Sources: nature-citation/SKILL.md, PaperQA prompts.py.

--- a/pantheon/factory/templates/skills/paper_writing/evidence/context_answering.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/context_answering.md
@@ -1,0 +1,20 @@
+---
+id: paper_writing_context_answering
+name: Context Answering
+description: Answer only from supplied context and return cannot-answer when evidence is insufficient.
+tags: [paper_writing, context, qa]
+---
+
+# Context Answering
+
+Use when deciding whether a supplied paper, PDF chunk, figure, or user material
+supports a claim.
+
+## Rules
+
+- Answer only from the provided context.
+- Cite context keys, evidence IDs, pages, or material IDs.
+- If the context is insufficient, write `I cannot answer from the provided context`
+  and list what is missing.
+
+Sources: PaperQA prompts.py.

--- a/pantheon/factory/templates/skills/paper_writing/evidence/data_availability.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/data_availability.md
@@ -1,0 +1,25 @@
+---
+id: paper_writing_data_availability
+name: Data And Code Availability
+description: Data/code availability protocol for journal papers and reproducible reports.
+tags: [paper_writing, data_availability, reproducibility]
+---
+
+# Data And Code Availability
+
+Use for journal articles, datasets, code releases, or any task that needs
+availability statements.
+
+## Output
+
+| Asset | Type | Repository/access | Identifier | Restrictions | Status |
+|---|---|---|---|---|---|
+
+## Rules
+
+- Do not invent repository links, accession IDs, DOIs, or licenses.
+- If data/code is unavailable, state why and what the reader can request.
+- Keep generated statement consistent with methods, ethics, and supplementary
+  material sections.
+
+Sources: nature-data/SKILL.md, K-Dense citation-management/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/evidence/evidence_registry.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/evidence_registry.md
@@ -1,0 +1,28 @@
+---
+id: paper_writing_evidence_registry
+name: Evidence Registry
+description: Claim-evidence map protocol for binding every core claim to citation, figure, table, data, user material, or missing evidence.
+tags: [paper_writing, evidence, claims]
+---
+
+# Evidence Registry
+
+Use before and after drafting. The registry is the source of truth for what the
+paper may claim.
+
+## Output
+
+Create `claim_evidence_map.md`:
+
+| Claim ID | Claim | Evidence type | Source | Strength | Risk | Action |
+|---|---|---|---|---|---|---|
+| C1 | ... | citation/figure/table/data/user_material/missing | S001 | strong | low | keep |
+
+## Rules
+
+- Evidence types are only `citation`, `figure`, `table`, `experimental_data`,
+  `statistical_result`, `user_material`, or `missing`.
+- Claims with `missing` evidence cannot appear as firm conclusions.
+- If support is partial, narrow the wording.
+
+Sources: DeepScientist paper-outline/SKILL.md, paper-review.md.

--- a/pantheon/factory/templates/skills/paper_writing/evidence/evidence_summary.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/evidence_summary.md
@@ -1,0 +1,23 @@
+---
+id: paper_writing_evidence_summary
+name: Evidence Summary
+description: Summarize paper chunks and retrieved contexts before using them in writing.
+tags: [paper_writing, evidence_summary, rag]
+---
+
+# Evidence Summary
+
+Use after retrieval and before writing from papers or notes.
+
+## Output
+
+| Evidence ID | Source | Passage/page | Query answered | Summary | Score | Claim IDs |
+|---|---|---|---|---|---|---|
+
+## Rules
+
+- Preserve enough locator detail for later attribution.
+- Separate the source's statement from the agent's interpretation.
+- If evidence does not answer the query, say so; do not force fit.
+
+Sources: Future-House/paper-qa README.md, paperqa/prompts.py.

--- a/pantheon/factory/templates/skills/paper_writing/evidence/paper_fetch.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/paper_fetch.md
@@ -1,0 +1,55 @@
+---
+id: paper_writing_paper_fetch
+name: Paper Fetch
+description: Legal open-access paper PDF fetching protocol using DOI/title/PMID/arXiv identifiers with JSON envelopes and idempotency.
+tags: [paper_writing, paper_fetch, open_access]
+---
+
+# Paper Fetch
+
+Use when the user provides DOI, PMID, arXiv ID, title, or asks to retrieve a
+paper PDF for evidence review.
+
+## Allowed Routes
+
+Only use legal open paths:
+
+- Unpaywall
+- Semantic Scholar
+- arXiv
+- PubMed Central
+- bioRxiv / medRxiv
+- publisher direct OA link
+- user-provided licensed/local PDF
+
+Do not use Sci-Hub or any access-control bypass.
+
+## Output Envelope
+
+Return or record:
+
+```json
+{
+  "ok": true,
+  "input": {"doi": "...", "title": "..."},
+  "source": "unpaywall|semantic_scholar|arxiv|pmc|biorxiv|publisher|user_file",
+  "pdf_path": "materials/papers/<slug>.pdf",
+  "metadata": {"title": "...", "doi": "...", "year": 2026},
+  "idempotency_key": "doi-or-title-hash"
+}
+```
+
+Failure envelope:
+
+```json
+{
+  "ok": false,
+  "input": {"title": "..."},
+  "error_type": "not_found|not_oa|ambiguous|network|blocked",
+  "retryable": false,
+  "next_action": "ask_user_for_pdf_or_identifier"
+}
+```
+
+Sources: Agents365-ai/paper-fetch/skills/paper-fetch/SKILL.md,
+K-Dense citation-management/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/evidence/paper_search.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/paper_search.md
@@ -1,0 +1,25 @@
+---
+id: paper_writing_paper_search
+name: Paper Search
+description: Search and rank candidate papers for claims, topics, and related work before evidence grounding.
+tags: [paper_writing, literature_search, evidence]
+---
+
+# Paper Search
+
+Use when the draft lacks literature, citations, or related-work positioning.
+
+## Output
+
+| Candidate ID | Query | Title | Authors/year | Source | Why candidate | Next action |
+|---|---|---|---|---|---|---|
+
+## Rules
+
+- A search result is a candidate, not evidence.
+- Record query, source, and reason for inclusion.
+- Route promising candidates to `evidence_summary.md` or `citation_grounding.md`.
+- Prefer primary sources for factual claims and recent/foundational balance for
+  related work.
+
+Sources: PaperQA tools.py, OpenScholar README.md.

--- a/pantheon/factory/templates/skills/paper_writing/evidence/rerank_and_attribution.md
+++ b/pantheon/factory/templates/skills/paper_writing/evidence/rerank_and_attribution.md
@@ -1,0 +1,24 @@
+---
+id: paper_writing_rerank_and_attribution
+name: Rerank And Attribution
+description: Rerank candidate evidence and attribute draft sentences back to exact sources.
+tags: [paper_writing, attribution, rerank]
+---
+
+# Rerank And Attribution
+
+Use when multiple contexts compete, when an answer lacks citations, or before
+final citation checks.
+
+## Output
+
+| Draft sentence | Source ID | Passage locator | Attribution strength | Risk |
+|---|---|---|---|---|
+
+## Rules
+
+- Sentence-level scientific claims need source-level attribution.
+- If the best source only supports part of the sentence, split or narrow it.
+- Do not keep unattributed conclusion sentences in high-stakes drafts.
+
+Sources: OpenScholar open_scholar.py, PaperQA tools.py.

--- a/pantheon/factory/templates/skills/paper_writing/formats/html_editable_contract.md
+++ b/pantheon/factory/templates/skills/paper_writing/formats/html_editable_contract.md
@@ -1,0 +1,47 @@
+---
+id: paper_writing_html_editable_contract
+name: Editable HTML Contract
+description: Contract for standalone, semantic, editable HTML outputs with inline CSS, print CSS, and data block attributes.
+tags: [paper_writing, html, editable]
+---
+
+# Editable HTML Contract
+
+All paper-writing HTML outputs must be standalone working files, not app-only
+previews or screenshots.
+
+## Required Block Shape
+
+```html
+<section
+  class="editable-block"
+  data-block-id="abstract-001"
+  data-section="abstract"
+  data-source="draft/paper.md"
+  data-format-role="summary"
+  contenteditable="true">
+  <h2>Abstract</h2>
+  <p>...</p>
+</section>
+```
+
+## Required Properties
+
+- Single file with embedded CSS.
+- Main content remains text HTML.
+- Use semantic tags: `section`, `figure`, `figcaption`, `table`, `caption`,
+  `ol`, `ul`, `aside` where appropriate.
+- Include `@page` or `@media print`.
+- Do not require frontend runtime to display the report body.
+- Avoid absolute positioning for body layout.
+
+## Block Attributes
+
+| Attribute | Meaning |
+|---|---|
+| `data-block-id` | stable local block identifier |
+| `data-section` | manuscript/report section |
+| `data-source` | source file, usually `draft/paper.md` |
+| `data-format-role` | role such as `summary`, `claim`, `evidence`, `method`, `response` |
+
+Sources: Anthropic pdf/SKILL.md, Kami design.md/CHEATSHEET.md, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/formats/scenario_formats.md
+++ b/pantheon/factory/templates/skills/paper_writing/formats/scenario_formats.md
@@ -1,0 +1,22 @@
+---
+id: paper_writing_scenario_formats
+name: Scenario Format Contracts
+description: Format contracts for journal articles, conference papers, grants, lab reports, group reports, talks, workshops, and revision responses.
+tags: [paper_writing, formats]
+---
+
+# Scenario Format Contracts
+
+| Format | Required structure | Special constraints |
+|---|---|---|
+| `journal_article` | Title, Abstract, Keywords, Introduction, Results, Discussion, Methods, Data Availability, Code Availability, Acknowledgements, References, SI note | figure/table numbering, data/code statements, guideline checks when applicable |
+| `conference_paper` | Title, Abstract, Introduction, Related Work, Method, Experiments, Results, Discussion, Conclusion, References, Appendix | page limit, baseline and ablation completeness, optional LaTeX |
+| `grant_application` | title, abstract, background, gap, aims, research content, key scientific questions, technical route, innovation, feasibility, plan, expected outcomes, team, budget, references | form-like blocks, word limits, aim-route consistency |
+| `lab_report` | experiment name, date, operator, purpose, materials, steps, raw observations, data processing, results, abnormal events, conclusion, next step | raw observation separated from interpretation |
+| `group_report` | progress, core question, evidence, current conclusion, blockers, discussion questions, next plan | scan-friendly, short sections |
+| `conference_talk` | opening, audience context, problem, key idea, evidence sequence, takeaway, Q&A, speaker notes | every figure has spoken takeaway |
+| `workshop_share` | prerequisites, materials, steps, checkpoints, expected outputs, troubleshooting, Q&A | reproducible steps required |
+| `revision_response` | Reviewer X Comment Y, Comment, Response, Changes Made, Status | preserve every comment |
+
+Use [html_editable_contract.md](./html_editable_contract.md) for all HTML
+formats.

--- a/pantheon/factory/templates/skills/paper_writing/quality/SKILL.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/SKILL.md
@@ -1,0 +1,23 @@
+---
+id: paper_writing_quality
+name: Paper Writing Quality Gates
+description: Quality gate index for claim evidence, reviewer simulation, reporting guidelines, citation checks, editability, reproducibility, and response consistency.
+tags: [paper_writing, quality, review]
+---
+
+# Quality Gates
+
+Quality skills produce reports and risk flags. They should not silently rewrite
+the draft to hide problems.
+
+| Gate | File | Default trigger |
+|---|---|---|
+| Claim/evidence audit | [claim_evidence_check.md](./claim_evidence_check.md) | all high-stakes writing |
+| Reviewer simulation | [reviewer_rubric.md](./reviewer_rubric.md) | papers, grants, rebuttals |
+| Citation audit | [citation_check.md](./citation_check.md) | manuscripts with references |
+| Reproducibility audit | [reproducibility_check.md](./reproducibility_check.md) | methods, lab reports, workshops |
+| Format lint | [format_lint.md](./format_lint.md) | every final output |
+| Reporting guideline check | [reporting_guideline_check.md](./reporting_guideline_check.md) | clinical, observational, systematic review |
+| HTML editability check | [html_editability_check.md](./html_editability_check.md) | every HTML output |
+| Response consistency | [response_consistency_check.md](./response_consistency_check.md) | reviewer responses |
+| Skill structure audit | [skill_structure_check.md](./skill_structure_check.md) | modifying this skill family |

--- a/pantheon/factory/templates/skills/paper_writing/quality/citation_check.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/citation_check.md
@@ -1,0 +1,25 @@
+---
+id: paper_writing_citation_check
+name: Citation Check
+description: Audit references, citation metadata, and claim support before finalizing academic writing.
+tags: [paper_writing, citation, quality]
+---
+
+# Citation Check
+
+Use when a draft contains citations or references.
+
+## Output
+
+| Citation | Draft claim | Metadata status | Support status | Issue | Action |
+|---|---|---|---|---|---|
+
+Rules:
+
+- Do not invent or silently repair DOI, PMID, arXiv ID, year, volume, issue, or
+  pages.
+- Verify citation support using `evidence/citation_grounding.md`.
+- Flag duplicate references and inconsistent citation keys.
+- Treat uncited references and unsupported citation-backed claims as issues.
+
+Sources: nature-citation/SKILL.md, PaperQA prompts.py, K-Dense citation-management/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/quality/claim_evidence_check.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/claim_evidence_check.md
@@ -1,0 +1,29 @@
+---
+id: paper_writing_claim_evidence_check
+name: Claim Evidence Check
+description: Audit manuscript claims against claim_evidence_map.md and flag unsupported, overbroad, or missing evidence.
+tags: [paper_writing, evidence, quality]
+---
+
+# Claim Evidence Check
+
+Use before any final output.
+
+## Output
+
+Write `quality/claim_evidence_report.md`:
+
+| Claim ID | Draft location | Evidence | Status | Risk | Required action |
+|---|---|---|---|---|---|
+
+Statuses: `supported`, `partial`, `unsupported`, `missing`, `overbroad`,
+`conflicting`.
+
+Rules:
+
+- Unsupported claims must be removed, downgraded, or marked for user input.
+- Partial evidence requires narrower wording.
+- Claims about novelty, mechanism, generalization, or significance receive extra
+  scrutiny.
+
+Sources: paper-review.md, DeepScientist review/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/quality/format_lint.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/format_lint.md
@@ -1,0 +1,26 @@
+---
+id: paper_writing_format_lint
+name: Format Lint
+description: Validate scenario-specific structure, word/page limits, figure/table numbering, references, and output contract.
+tags: [paper_writing, format, lint]
+---
+
+# Format Lint
+
+Use before final delivery.
+
+## Output
+
+| Requirement | Status | Location | Fix |
+|---|---|---|---|
+
+Check:
+
+- required sections for `format_id`
+- page or word limits when known
+- figure/table numbering and captions
+- reference section presence and consistency
+- HTML contract if output is HTML
+- LaTeX path only when requested or required
+
+Sources: K-Dense venue-templates/SKILL.md, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/quality/html_editability_check.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/html_editability_check.md
@@ -1,0 +1,24 @@
+---
+id: paper_writing_html_editability_check
+name: HTML Editability Check
+description: Validate standalone editable HTML output, semantic blocks, print CSS, and data attributes.
+tags: [paper_writing, html, quality]
+---
+
+# HTML Editability Check
+
+Use after every HTML generation.
+
+## Pass Criteria
+
+- Single HTML file opens without the app runtime.
+- CSS is embedded.
+- Main text is semantic HTML, not an image.
+- Major blocks have `contenteditable="true"`.
+- Major blocks include `data-block-id`, `data-section`, `data-source`, and
+  `data-format-role`.
+- Print CSS includes `@page` or `@media print`.
+- Figures/tables use semantic `figure`, `figcaption`, `table`, `caption` where
+  applicable.
+
+Sources: Anthropic pdf/SKILL.md, Kami README/design/CHEATSHEET, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/quality/reporting_guideline_check.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/reporting_guideline_check.md
@@ -1,0 +1,30 @@
+---
+id: paper_writing_reporting_guideline_check
+name: Reporting Guideline Check
+description: Check applicable reporting guidelines such as CONSORT, STROBE, and PRISMA for clinical, observational, and systematic-review manuscripts.
+tags: [paper_writing, reporting_guidelines, consort, strobe, prisma]
+---
+
+# Reporting Guideline Check
+
+Use when study type or user request makes a reporting guideline relevant.
+
+| Study type | Guideline |
+|---|---|
+| randomized/clinical trial | CONSORT |
+| observational study | STROBE |
+| systematic review/meta-analysis | PRISMA |
+
+## Output
+
+| Guideline item | Present? | Draft location | Missing material | Action |
+|---|---|---|---|---|
+
+Rules:
+
+- Do not force an inapplicable guideline; explain non-applicability.
+- Missing items must point to a section, claim, table/figure, or user material.
+- This is a compliance check, not a generic writing checklist.
+
+Sources: K-Dense scientific-writing/SKILL.md, literature-review/SKILL.md,
+peer-review/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/quality/reproducibility_check.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/reproducibility_check.md
@@ -1,0 +1,25 @@
+---
+id: paper_writing_reproducibility_check
+name: Reproducibility Check
+description: Check methods, experiments, data processing, and workshop steps for reproducibility gaps.
+tags: [paper_writing, reproducibility, methods]
+---
+
+# Reproducibility Check
+
+Use for methods, lab reports, workshops, data analysis, and journal submissions.
+
+## Output
+
+| Item | Present? | Location | Missing detail | Action |
+|---|---|---|---|---|
+
+Check for:
+
+- samples, groups, batch IDs, inclusion/exclusion rules
+- instruments, software, versions, parameters
+- preprocessing and statistical tests
+- expected inputs/outputs for reproducible steps
+- data/code availability consistency
+
+Sources: K-Dense scientific-writing/SKILL.md, peer-review/SKILL.md, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/quality/response_consistency_check.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/response_consistency_check.md
@@ -1,0 +1,24 @@
+---
+id: paper_writing_response_consistency_check
+name: Response Consistency Check
+description: Verify every reviewer comment maps to response, manuscript change, and status.
+tags: [paper_writing, rebuttal, quality]
+---
+
+# Response Consistency Check
+
+Use before delivering rebuttal or revision packages.
+
+## Output
+
+| Comment ID | Has response | Change claimed | Draft location | Status | Issue |
+|---|---|---|---|---|---|
+
+Rules:
+
+- Every reviewer/editor comment must appear.
+- Every response must state whether text changed.
+- Claimed changes must be present in the revised draft.
+- Declined changes must include a defensible reason.
+
+Sources: nature-response/SKILL.md, DeepScientist rebuttal/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/quality/reviewer_rubric.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/reviewer_rubric.md
@@ -1,0 +1,32 @@
+---
+id: paper_writing_reviewer_rubric
+name: Reviewer Rubric
+description: Simulated reviewer audit for novelty, soundness, clarity, reproducibility, venue fit, and limitations.
+tags: [paper_writing, reviewer, quality]
+---
+
+# Reviewer Rubric
+
+Use for submissions, grants, major reports, and before rebuttal.
+
+## Output
+
+Write `quality/reviewer_report.md`:
+
+| Dimension | Strength | Concern | Severity | Evidence location | Action |
+|---|---|---|---|---|---|
+
+Dimensions:
+
+- novelty and positioning
+- technical soundness
+- evidence and statistics
+- clarity and organization
+- reproducibility
+- limitations and ethics
+- venue or agency fit
+
+Do not fabricate reviewer decisions. Report risks and concrete fixes.
+
+Sources: academic-paper-reviewer/SKILL.md, DeepScientist review/SKILL.md,
+K-Dense peer-review/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/quality/skill_structure_check.md
+++ b/pantheon/factory/templates/skills/paper_writing/quality/skill_structure_check.md
@@ -1,0 +1,24 @@
+---
+id: paper_writing_skill_structure_check
+name: Skill Structure Check
+description: Audit paper-writing skill files for trigger descriptions, routing pipeline, entry/exit criteria, one-hop references, and pressure scenarios.
+tags: [paper_writing, skill_design, quality]
+---
+
+# Skill Structure Check
+
+Use when changing this skill family.
+
+## Checklist
+
+- Root `description` includes real trigger terms.
+- Root skill uses Routing + Sequential Pipeline.
+- Workflow files specify entry criteria, actions, and exit criteria.
+- References are one hop from `SKILL.md`.
+- Each `SKILL.md` stays below 500 lines.
+- Long templates and examples live in adjacent files.
+- At least three pressure scenarios compare baseline behavior with skill-guided
+  behavior.
+
+Sources: Anthropic skill-creator/SKILL.md, Trail of Bits
+designing-workflow-skills/SKILL.md, obra writing-skills/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/report_academic.md
+++ b/pantheon/factory/templates/skills/paper_writing/report_academic.md
@@ -66,6 +66,9 @@ ${{CONTENT}}
 - CSS auto-numbers sections (h2, h3, h4), figures, and tables — writer should NOT manually number them
 - Theorem environments use fenced divs: `<div class="theorem">...</div>`
 - Figure captions get auto-prefixed with "Figure N:" — writer should NOT include the prefix
+- Major sections must follow [formats/html_editable_contract.md](./formats/html_editable_contract.md):
+  `class="editable-block"`, `contenteditable="true"`, `data-block-id`,
+  `data-section`, `data-source`, and `data-format-role`
 
 ## CSS
 
@@ -86,6 +89,12 @@ body {
 .paper-authors .author { margin-right: 12px; }
 .paper-affiliations { font-size: 10pt; color: #333; font-style: italic; }
 .paper-date { font-size: 10pt; color: #555; margin-top: 8px; }
+
+.editable-block:focus {
+    outline: 1.5pt solid #1B365D;
+    outline-offset: 4pt;
+    background: #faf9f5;
+}
 
 .abstract, section.abstract { margin: 24px 48px; font-size: 10pt; text-align: justify; }
 section.abstract > h2 { font-size: 11pt; font-weight: 700; text-align: center; border: none; padding: 0; margin: 0 0 6px 0; }

--- a/pantheon/factory/templates/skills/paper_writing/report_standard.md
+++ b/pantheon/factory/templates/skills/paper_writing/report_standard.md
@@ -77,9 +77,14 @@ ${{CONTENT}}
 
 When converting Markdown to HTML, apply these wrappers for proper styling:
 
-- **Abstract**: Wrap the first section ("摘要" or "Abstract") in `<section class="abstract">...</section>`
-- **References**: Wrap the last section ("参考文献" or "References") in `<section class="references">...</section>`
+- **Editable sections**: Wrap major sections as
+  `<section class="editable-block" data-block-id="..." data-section="..." data-source="draft/paper.md" data-format-role="..." contenteditable="true">...</section>`
+- **Abstract**: Add `abstract` to the first section ("摘要" or "Abstract")
+- **References**: Add `references` to the last section ("参考文献" or "References")
 - **Images**: Convert `![caption](path)` to `<figure><img src="path"><figcaption>caption</figcaption></figure>`
+
+Follow [formats/html_editable_contract.md](./formats/html_editable_contract.md)
+for all paper-writing HTML outputs.
 
 ## CSS
 
@@ -124,6 +129,13 @@ body {
 .report-authors .author { margin-right: 16px; }
 .report-affiliations { font-size: 13px; color: #777; margin-bottom: 8px; }
 .report-date { font-size: 14px; color: #999; }
+
+/* ===== Editable blocks ===== */
+.editable-block:focus {
+    outline: 2px solid #1B365D;
+    outline-offset: 4px;
+    background: #faf9f5;
+}
 
 /* ===== Abstract ===== */
 section.abstract, div.abstract { margin-bottom: 32px; }

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/SKILL.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/SKILL.md
@@ -1,0 +1,28 @@
+---
+id: paper_writing_scenarios
+name: Paper Writing Scenario Router
+description: |
+  Scenario router for paper-writing tasks. Use after root triage to select
+  paper submission, journal article, conference paper, grant proposal, lab
+  report, group report, talk/workshop, or revision-response behavior.
+tags: [paper_writing, scenarios, routing]
+---
+
+# Scenario Router
+
+Scenario files decide the task shape. They do not write prose directly; they
+select workflow, format, theme, and quality gates.
+
+| Scenario | File | Use when |
+|---|---|---|
+| `paper_submission` | [paper_submission.md](./paper_submission.md) | User asks for a manuscript or general paper submission |
+| `journal_article` | [journal_article.md](./journal_article.md) | User targets a journal or article type |
+| `conference_paper` | [conference_paper.md](./conference_paper.md) | User targets a conference/workshop paper |
+| `grant_proposal` | [grant_proposal.md](./grant_proposal.md) | User asks for grant/proposal/funding application |
+| `lab_report` | [lab_report.md](./lab_report.md) | User asks for experiment/lab report |
+| `group_report` | [group_report.md](./group_report.md) | User asks for group meeting, weekly report, progress report |
+| `conference_talk` | [conference_talk.md](./conference_talk.md) | User asks for talk, speech, slides narrative, speaker notes |
+| `workshop_share` | [workshop_share.md](./workshop_share.md) | User asks for workshop sharing, tutorial, reproducible notes |
+| `revision_response` | [revision_response.md](./revision_response.md) | User provides reviewer/editor comments or asks for rebuttal |
+
+For every scenario, write the chosen IDs into `triage.md` before drafting.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/conference_paper.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/conference_paper.md
@@ -1,0 +1,25 @@
+---
+id: conference_paper_scenario
+name: Conference Paper Scenario
+description: Conference or workshop paper route with page-limit and evaluation checks.
+tags: [paper_writing, conference, workshop, latex]
+---
+
+# Conference Paper Scenario
+
+Use for conference papers, workshop papers, double-column papers, or ML/CS venue
+submissions.
+
+| Field | Contract |
+|---|---|
+| Trigger | conference paper, workshop paper, NeurIPS, ICML, ICLR, ACL, double column |
+| Inputs | venue template, page limit, method, baselines, experiments, ablations |
+| Read next | `workflow/paper_outline.md`, `workflow/figure_storyline.md`, `quality/reviewer_rubric.md`, `formats/scenario_formats.md` |
+| Outputs | conference-style `draft/paper.md`, HTML preview, optional LaTeX path |
+| Gates | page limit, baseline completeness, evaluation validity, citation support |
+| Forbidden | hiding missing baselines, overclaiming SOTA, decorative method figures |
+
+Default emphasis: contribution clarity, experimental comparison, limitations,
+and reviewer-obvious failure modes.
+
+Sources: academic-paper/SKILL.md, paper-review.md, venue-templates/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/conference_talk.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/conference_talk.md
@@ -1,0 +1,25 @@
+---
+id: conference_talk_scenario
+name: Conference Talk Scenario
+description: Talk, speech, and speaker-note route for academic presentations.
+tags: [paper_writing, talk, speaker_notes]
+---
+
+# Conference Talk Scenario
+
+Use for talk scripts, conference speeches, invited talks, presentation
+narratives, or speaker notes.
+
+| Field | Contract |
+|---|---|
+| Trigger | talk, conference speech, presentation narrative, speaker notes, 会议发言 |
+| Inputs | audience, duration, figures, desired takeaway, venue context |
+| Read next | `workflow/figure_storyline.md`, `workflow/reader_testing.md`, `formats/scenario_formats.md` |
+| Outputs | talk outline, evidence sequence, spoken takeaways, Q&A notes |
+| Gates | every figure has one spoken takeaway and one audience bridge |
+| Forbidden | compressing the paper section-by-section into a talk |
+
+Default structure: opening hook, audience context, problem, key idea, evidence
+sequence, takeaway, Q&A.
+
+Sources: doc-coauthoring/SKILL.md, writing-shape/SKILL.md, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/grant_proposal.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/grant_proposal.md
@@ -1,0 +1,29 @@
+---
+id: grant_proposal_scenario
+name: Grant Proposal Scenario
+description: Funding proposal route for grants, proposals, and project applications.
+tags: [paper_writing, grant, proposal]
+---
+
+# Grant Proposal Scenario
+
+Use when the user asks for funding applications, project proposals, agency-style
+forms, or "国自然" style material.
+
+| Field | Contract |
+|---|---|
+| Trigger | grant, proposal, funding, 立项依据, 国自然, application |
+| Inputs | topic, research basis, team, preliminary data, aims, timeline, budget notes |
+| Read next | `workflow/research_question.md`, `workflow/knowledge_lineage.md`, `workflow/figure_storyline.md`, `formats/scenario_formats.md` |
+| Outputs | form-like editable HTML, aims, research content, route, feasibility, expected outcomes |
+| Gates | gap-aim-route consistency, feasibility, innovation boundary, word limits |
+| Forbidden | generic innovation claims, unsupported feasibility, invented budget/team facts |
+
+Proposal logic:
+
+```text
+field status -> gap -> scientific question -> aims -> work packages
+-> technical route -> feasibility -> risk and alternatives -> outputs
+```
+
+Sources: research-grants/SKILL.md, strategist/SKILL.md, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/group_report.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/group_report.md
@@ -1,0 +1,25 @@
+---
+id: group_report_scenario
+name: Group Report Scenario
+description: Group-meeting or weekly progress report route.
+tags: [paper_writing, group_meeting, weekly_report]
+---
+
+# Group Report Scenario
+
+Use for group meetings, weekly reports, progress updates, PI updates, or short
+internal research status documents.
+
+| Field | Contract |
+|---|---|
+| Trigger | group meeting, weekly report, 组会, 周报, progress report |
+| Inputs | progress, figures, evidence, blockers, questions, next plan |
+| Read next | `workflow/material_inventory.md`, `workflow/figure_storyline.md`, `evidence/evidence_summary.md` |
+| Outputs | scan-friendly report with progress, evidence, problems, discussion questions, next actions |
+| Gates | every discussion question is explicit; every claim links to evidence or missing |
+| Forbidden | turning a status report into a long manuscript summary |
+
+Prefer short sections, tables, bullets, and figure-first evidence over narrative
+prose.
+
+Sources: doc-coauthoring/SKILL.md, writing-shape/SKILL.md, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/journal_article.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/journal_article.md
@@ -1,0 +1,27 @@
+---
+id: journal_article_scenario
+name: Journal Article Scenario
+description: Journal article route for SCI, Nature-style, or target-journal manuscripts.
+tags: [paper_writing, journal, article]
+---
+
+# Journal Article Scenario
+
+Use when the user names a journal, article type, or asks for SCI/high-impact
+journal writing.
+
+| Field | Contract |
+|---|---|
+| Trigger | journal article, SCI, Nature, Cell, research article, short communication |
+| Inputs | target journal, article type, data/code availability, figures, SI needs |
+| Read next | `workflow/literature_review.md`, `workflow/figure_storyline.md`, `evidence/data_availability.md`, `formats/scenario_formats.md` |
+| Outputs | journal article draft, Data/Code Availability, figure/table captions, editable HTML |
+| Gates | data availability, citation check, reviewer rubric, reporting guideline if applicable |
+| Forbidden | inventing accession IDs, repository URLs, DOI, ethical approval, or SI files |
+
+Required sections unless the target journal says otherwise:
+Title, Abstract, Keywords, Introduction, Results, Discussion, Methods, Data
+Availability, Code Availability, Acknowledgements, References, Supplementary
+Information note.
+
+Sources: nature-data/SKILL.md, nature-figure/SKILL.md, scientific-writing/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/lab_report.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/lab_report.md
@@ -1,0 +1,25 @@
+---
+id: lab_report_scenario
+name: Lab Report Scenario
+description: Experiment or lab report route with reproducibility and raw observation separation.
+tags: [paper_writing, lab_report, reproducibility]
+---
+
+# Lab Report Scenario
+
+Use for lab reports, experiment records, data-processing reports, or practical
+course reports.
+
+| Field | Contract |
+|---|---|
+| Trigger | lab report, experiment report, 实验报告, 实验记录 |
+| Inputs | date, operator, samples, batch IDs, protocols, instruments, raw observations, data |
+| Read next | `workflow/material_inventory.md`, `workflow/data_analysis_summary.md`, `quality/reproducibility_check.md` |
+| Outputs | lab-report HTML/PDF with raw observation, processed result, abnormal events |
+| Gates | reproducibility, raw observation/result separation, anomaly logging |
+| Forbidden | deleting abnormal observations or merging interpretation into raw results |
+
+If no abnormal event is known, write "No abnormal event was reported" instead of
+silently omitting the field.
+
+Sources: local design PDF, scientific-writing/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/paper_submission.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/paper_submission.md
@@ -1,0 +1,31 @@
+---
+id: paper_submission_scenario
+name: Paper Submission Scenario
+description: General manuscript submission route for paper-writing tasks.
+tags: [paper_writing, manuscript, submission]
+---
+
+# Paper Submission Scenario
+
+Use when the user asks to write, revise, or package a paper but has not locked a
+journal/conference-specific structure.
+
+| Field | Contract |
+|---|---|
+| Trigger | "paper", "manuscript", "投稿", "论文写作", "write a paper" |
+| Inputs | research materials, draft, figures/tables, target venue if known |
+| Read next | `workflow/material_inventory.md`, `workflow/literature_review.md`, `workflow/paper_outline.md`, `writing/SKILL.md` |
+| Outputs | `triage.md`, `draft/paper.md`, `report/paper_preview.html`, quality reports |
+| Gates | `claim_evidence_check`, `reviewer_rubric`, `format_lint`, `html_editability_check` |
+| Forbidden | choosing a venue-agnostic structure when venue constraints are provided |
+
+Default path:
+
+```text
+triage -> material_inventory -> literature_review -> evidence_registry
+-> figure_storyline when figures are central -> paper_outline -> draft
+-> claim_evidence_check -> reviewer_rubric -> editable HTML
+```
+
+Sources: academic-paper/SKILL.md, research-paper-writing/SKILL.md,
+paper-outline/SKILL.md, paper-review.md.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/revision_response.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/revision_response.md
@@ -1,0 +1,32 @@
+---
+id: revision_response_scenario
+name: Revision Response Scenario
+description: Reviewer rebuttal and revision-response route.
+tags: [paper_writing, rebuttal, revision, reviewer_response]
+---
+
+# Revision Response Scenario
+
+Use when the user provides reviewer comments, editor letters, rebuttal requests,
+or asks for a point-by-point response.
+
+| Field | Contract |
+|---|---|
+| Trigger | reviewer comments, rebuttal, response letter, revision response, 返修 |
+| Inputs | editor letter, reviewer comments, current draft, changed text, new evidence |
+| Read next | `workflow/revision_loop.md`, `writing/response_letter.md`, `quality/response_consistency_check.md` |
+| Outputs | response letter, revision matrix, text deltas, revised draft, editable HTML |
+| Gates | every comment has response and change status; response matches manuscript |
+| Forbidden | omitting comments, changing reviewer meaning, claiming changes not made |
+
+Response unit:
+
+```text
+Reviewer X, Comment Y
+Comment:
+Response:
+Changes Made:
+Status: done | partial | declined-with-reason | needs-user-input
+```
+
+Sources: nature-response/SKILL.md, DeepScientist rebuttal/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/scenarios/workshop_share.md
+++ b/pantheon/factory/templates/skills/paper_writing/scenarios/workshop_share.md
@@ -1,0 +1,22 @@
+---
+id: workshop_share_scenario
+name: Workshop Share Scenario
+description: Workshop, tutorial, or reproducible sharing route.
+tags: [paper_writing, workshop, tutorial, reproducibility]
+---
+
+# Workshop Share Scenario
+
+Use for workshop sharing, tutorials, reproducible how-to notes, or internal
+method sharing.
+
+| Field | Contract |
+|---|---|
+| Trigger | workshop, tutorial, 分享, 复现步骤, hands-on |
+| Inputs | audience level, prerequisites, materials, commands/code, expected outputs |
+| Read next | `workflow/material_inventory.md`, `quality/reproducibility_check.md`, `formats/scenario_formats.md` |
+| Outputs | reproducible steps, checkpoints, expected outputs, Q&A notes |
+| Gates | prerequisites, inputs, commands, outputs, failure recovery are explicit |
+| Forbidden | writing only background introduction without runnable steps |
+
+Sources: doc-coauthoring/SKILL.md, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/themes/SKILL.md
+++ b/pantheon/factory/templates/skills/paper_writing/themes/SKILL.md
@@ -1,0 +1,16 @@
+---
+id: paper_writing_themes
+name: Paper Writing Themes
+description: Theme index for editable academic HTML outputs.
+tags: [paper_writing, theme, html]
+---
+
+# Theme Skills
+
+Use a theme only after the format contract is selected.
+
+| Theme | File | Default use |
+|---|---|---|
+| `kami_academic` | [kami_academic.md](./kami_academic.md) | warm academic reports and editable paper previews |
+
+Do not let theme choices alter scientific claims or evidence checks.

--- a/pantheon/factory/templates/skills/paper_writing/themes/kami_academic.md
+++ b/pantheon/factory/templates/skills/paper_writing/themes/kami_academic.md
@@ -1,0 +1,50 @@
+---
+id: paper_writing_kami_academic_theme
+name: Kami Academic Theme
+description: Warm parchment, ink-blue, serif-hierarchy theme constraints for editable academic HTML.
+tags: [paper_writing, kami, html_theme]
+---
+
+# Kami Academic Theme
+
+Use for editable academic HTML when the user wants a refined, print-friendly
+document.
+
+| Element | Rule |
+|---|---|
+| Canvas | parchment `#f5f4ed`; avoid pure white page background |
+| Accent | ink blue `#1B365D`; small surface area |
+| Neutrals | warm gray/stone, not cool blue-gray |
+| Typography | Chinese serif fallback first, English Georgia/Charter-style serif |
+| Headings | serif, moderate weight, compact hierarchy |
+| Tables | light borders, dense rows, readable print spacing |
+| Tags | solid hex colors, no translucent decorative blobs |
+| Print | include `@page`, `break-inside`, `print-color-adjust` |
+
+Minimal CSS hooks:
+
+```css
+:root {
+  --parchment: #f5f4ed;
+  --ivory: #faf9f5;
+  --brand: #1B365D;
+  --near-black: #141413;
+  --stone: #6b6a64;
+  --border: #e8e6dc;
+}
+
+body {
+  background: var(--parchment);
+  color: var(--near-black);
+  font-family: "Source Han Serif SC", "Noto Serif CJK SC", "Songti SC", Georgia, serif;
+  line-height: 1.55;
+}
+
+.editable-block:focus {
+  outline: 1.5pt solid var(--brand);
+  outline-offset: 4pt;
+  background: var(--ivory);
+}
+```
+
+Sources: tw93/Kami README.md, references/design.md, CHEATSHEET.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/SKILL.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/SKILL.md
@@ -1,0 +1,25 @@
+---
+id: paper_writing_workflow
+name: Paper Writing Workflow
+description: Workflow index for research writing phases, triage, outlining, evidence boundaries, revision loops, and finalize packets.
+tags: [paper_writing, workflow, triage, outline]
+---
+
+# Workflow Skills
+
+Workflow skills decide the order of work. They do not provide final prose style
+or visual themes.
+
+| Need | File |
+|---|---|
+| Start or reroute any task | [triage.md](./triage.md) |
+| Inventory user materials | [material_inventory.md](./material_inventory.md) |
+| Position literature and claims | [literature_review.md](./literature_review.md) |
+| Define question/aims | [research_question.md](./research_question.md) |
+| Split manuscript view from evidence view | [paper_outline.md](./paper_outline.md) |
+| Summarize experiments/data | [data_analysis_summary.md](./data_analysis_summary.md) |
+| Build figure logic | [figure_storyline.md](./figure_storyline.md) |
+| Check novelty lineage | [knowledge_lineage.md](./knowledge_lineage.md) |
+| Test reader understanding | [reader_testing.md](./reader_testing.md) |
+| Handle review/rebuttal | [revision_loop.md](./revision_loop.md) |
+| Close task safely | [finalize_packet.md](./finalize_packet.md) |

--- a/pantheon/factory/templates/skills/paper_writing/workflow/data_analysis_summary.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/data_analysis_summary.md
@@ -1,0 +1,23 @@
+---
+id: paper_writing_data_analysis_summary
+name: Data Analysis Summary
+description: Summarize experimental or statistical results while separating observation, analysis, and interpretation.
+tags: [paper_writing, data, results]
+---
+
+# Data Analysis Summary
+
+Use when the user provides result tables, plots, statistics, or experiment notes.
+
+## Output
+
+| Result ID | Question | Data/readout | Observation | Statistical result | Interpretation | Figure/table |
+|---|---|---|---|---|---|---|
+
+## Rules
+
+- Keep observation separate from interpretation.
+- Include sample size, grouping, statistical method, and uncertainty when known.
+- If a statistic is missing, mark it; do not invent p-values or effect sizes.
+
+Sources: paper-review.md, scientific-writing/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/figure_storyline.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/figure_storyline.md
@@ -1,0 +1,25 @@
+---
+id: paper_writing_figure_storyline
+name: Figure Storyline
+description: Define figure claims, panels, evidence logic, captions, and review risks before writing figure-based results.
+tags: [paper_writing, figures, storyline]
+---
+
+# Figure Storyline
+
+Use when figures/tables carry the core story. Do not force AI images or a fixed
+number of figures; create figure plans only when evidence requires them.
+
+## Output
+
+| Figure | Question | Main claim | Panels/metrics | Evidence source | Caption message | Review risk |
+|---|---|---|---|---|---|---|
+
+## Rules
+
+- One figure answers one scientific question.
+- One panel supports one sub-claim or visual comparison.
+- Captions state conclusion, evidence, and key condition, not only plot type.
+- Missing raw data or unclear statistics must be flagged before drafting.
+
+Sources: nature-figure/SKILL.md, K-Dense scientific-writing/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/finalize_packet.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/finalize_packet.md
@@ -1,0 +1,32 @@
+---
+id: paper_writing_finalize_packet
+name: Finalize Packet
+description: Final handoff protocol recording outputs, unresolved risks, limitations, and resume state.
+tags: [paper_writing, finalize, handoff]
+---
+
+# Finalize Packet
+
+Use before ending a full paper-writing task.
+
+## Output
+
+Create a concise final state block:
+
+| Item | Value |
+|---|---|
+| Main draft | `draft/paper.md` |
+| Editable HTML | `report/<slug>_preview.html` |
+| Quality reports | list |
+| Open evidence gaps | list or none |
+| Unsupported claims removed/downgraded | list |
+| User decisions still needed | list |
+| Suggested next action | concrete next step |
+
+## Rules
+
+- Do not hide unresolved risks.
+- Preserve enough state that another agent can resume without rereading the full
+  conversation.
+
+Sources: academic-pipeline/SKILL.md, DeepScientist review/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/knowledge_lineage.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/knowledge_lineage.md
@@ -1,0 +1,25 @@
+---
+id: paper_writing_knowledge_lineage
+name: Knowledge Lineage
+description: Trace idea lineage, prior failed attempts, and novelty boundaries before claiming originality.
+tags: [paper_writing, novelty, related_work]
+---
+
+# Knowledge Lineage
+
+Use before novelty, related work, grant innovation, or "nobody has done this"
+claims.
+
+## Output
+
+| Idea/claim | Prior lineage | Similar attempts | Failed attempts | Difference now | Novelty boundary |
+|---|---|---|---|---|---|
+
+## Rules
+
+- Treat "new" as a claim requiring evidence.
+- Search for older names, adjacent fields, negative results, and revived ideas.
+- If an idea repeats a known route with a new dataset/tool, say so precisely.
+- Use lineage results to narrow contributions, not to inflate them.
+
+Sources: obra tracing-knowledge-lineages/SKILL.md, OpenScholar posthoc attribution.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/literature_review.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/literature_review.md
@@ -1,0 +1,29 @@
+---
+id: paper_writing_literature_review
+name: Literature Review Workflow
+description: Build a themed literature matrix and claim-citation map instead of a paper-by-paper summary.
+tags: [paper_writing, literature, citation]
+---
+
+# Literature Review Workflow
+
+Use when claims need citation grounding, novelty needs positioning, or the user
+asks for related work.
+
+## Output
+
+Create a literature matrix:
+
+| Paper ID | Citation/URL | Theme | What it supports | Limitation/gap | Candidate claim IDs |
+|---|---|---|---|---|---|
+
+## Rules
+
+- Group by theme, method, finding, or debate; do not merely list papers by year.
+- Classify support as `strong`, `partial`, `background`, or `conflicting`.
+- If a paper only matches the topic but not the exact claim, label it
+  `background`, not `strong`.
+- For systematic reviews, trigger `quality/reporting_guideline_check.md` for
+  PRISMA.
+
+Sources: nature-citation/SKILL.md, PaperQA README, K-Dense literature-review/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/material_inventory.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/material_inventory.md
@@ -1,0 +1,28 @@
+---
+id: paper_writing_material_inventory
+name: Material Inventory
+description: Inventory protocol for mapping user files, notes, data, figures, drafts, and reviewer comments to paper sections and evidence gaps.
+tags: [paper_writing, materials, inventory]
+---
+
+# Material Inventory
+
+Use after triage when the user has supplied files, notes, datasets, figures, or
+reviewer comments.
+
+## Output
+
+Write `materials/inventory.md` with this table:
+
+| Material ID | Path/source | Type | Relevant sections | Claims supported | Gaps/risks |
+|---|---|---|---|---|---|
+| M001 | user file or note | draft/data/figure/PDF/comment | Methods, Results | C1, C4 | missing sample size |
+
+## Rules
+
+- Do not leave attachments only in chat context. Give each useful item an ID.
+- Mark unreadable or missing files explicitly.
+- Separate user-provided facts from model inference.
+- Map reviewer comments to `revision_response` IDs, not generic notes.
+
+Sources: Anthropic doc-coauthoring context gathering, local design PDF.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/paper_outline.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/paper_outline.md
@@ -1,0 +1,31 @@
+---
+id: paper_writing_outline
+name: Paper Outline
+description: Build separate paper_view and evidence_view outlines before drafting.
+tags: [paper_writing, outline, evidence]
+---
+
+# Paper Outline
+
+Use before drafting any full manuscript, grant, or report.
+
+## Output
+
+Produce two synchronized views:
+
+```text
+paper_view:
+  section -> purpose -> paragraph roles -> expected figures/tables
+evidence_view:
+  section -> claim IDs -> evidence IDs -> missing evidence -> risk
+```
+
+## Exit Criteria
+
+- Each section has a purpose.
+- Core claims are scoped and numbered.
+- Evidence gaps are visible before writing.
+- The outline does not include raw logs, implementation chatter, or unfiltered
+  analysis notes.
+
+Sources: DeepScientist paper-outline/SKILL.md, research-paper-writing/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/reader_testing.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/reader_testing.md
@@ -1,0 +1,34 @@
+---
+id: paper_writing_reader_testing
+name: Reader Testing
+description: Fresh-context reader test for abstracts, introductions, grants, talks, and final drafts.
+tags: [paper_writing, reader_testing, clarity]
+---
+
+# Reader Testing
+
+Use before finalizing high-stakes documents or after major rewrites.
+
+## Test Questions
+
+Ask from the target reader's perspective:
+
+1. What problem is this solving?
+2. What is the main contribution or ask?
+3. What evidence supports it?
+4. What remains uncertain?
+5. What should the reader do next?
+
+## Output
+
+| Reader test item | Pass/fail | Evidence in draft | Fix |
+|---|---|---|---|
+
+## Rules
+
+- Do not use author intention as proof of clarity. The draft must contain the
+  answer.
+- For talks, test spoken takeaway and figure sequence.
+- For grants, test whether the aim and feasibility are recoverable in one pass.
+
+Sources: Anthropic doc-coauthoring/SKILL.md, mattpocock writing-shape/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/research_question.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/research_question.md
@@ -1,0 +1,29 @@
+---
+id: paper_writing_research_question
+name: Research Question
+description: Convert topics into defensible research questions, hypotheses, aims, and contribution boundaries.
+tags: [paper_writing, research_question, grant]
+---
+
+# Research Question
+
+Use before outline writing for early papers, grants, and vague topics.
+
+## Output
+
+| Item | Requirement |
+|---|---|
+| Field context | What is already known |
+| Gap | What remains unknown or insufficient |
+| Question | Specific, testable question |
+| Hypothesis/aim | What the work claims or tests |
+| Boundary | What the work will not claim |
+| Evidence needed | Data, figure, citation, or user material needed |
+
+## Rules
+
+- Do not treat a broad topic as a research question.
+- For grants, produce aim-level statements and feasibility notes.
+- For papers, map each contribution to at least one evidence need.
+
+Sources: lishix520 strategist/SKILL.md, K-Dense research-grants/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/revision_loop.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/revision_loop.md
@@ -1,0 +1,27 @@
+---
+id: paper_writing_revision_loop
+name: Revision Loop
+description: Workflow for reviewer comments, rebuttal planning, text deltas, and response tracking.
+tags: [paper_writing, revision, rebuttal]
+---
+
+# Revision Loop
+
+Use after any review, especially formal reviewer comments.
+
+## Phases
+
+1. Preserve every comment verbatim and assign IDs.
+2. Classify route: `text`, `evidence`, `experiment`, `analysis`, `format`,
+   `claim_downgrade`, `decline_with_reason`, `needs_user_input`.
+3. Build revision roadmap.
+4. Revise draft with trackable text deltas.
+5. Write response letter.
+6. Run response consistency check.
+
+## Output
+
+| Comment ID | Reviewer text | Class | Required action | Manuscript change | Response status |
+|---|---|---|---|---|---|
+
+Sources: nature-response/SKILL.md, DeepScientist rebuttal/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/workflow/triage.md
+++ b/pantheon/factory/templates/skills/paper_writing/workflow/triage.md
@@ -1,0 +1,48 @@
+---
+id: paper_writing_triage
+name: Paper Writing Triage
+description: Triage protocol for selecting scenario, format, theme, language, audience, outputs, constraints, and quality gates.
+tags: [paper_writing, triage]
+---
+
+# Triage Protocol
+
+Use at the start of every paper-writing task and whenever user intent changes.
+
+## Output
+
+Create or update `triage.md`:
+
+```yaml
+scenario_id: paper_submission
+format_id: journal_article
+theme_id: editable_article
+language: zh
+audience: reviewers
+source_materials:
+  - materials/inventory.md
+output:
+  markdown_source: draft/paper.md
+  html_path: report/paper_preview.html
+  editable_html: true
+  pdf: true
+  docx: false
+  latex: false
+constraints:
+  venue_profile: null
+  page_size: A4
+  word_limits: null
+quality_gates:
+  - claim_evidence_check
+  - reviewer_rubric
+  - html_editability_check
+```
+
+## Checks
+
+- If a UI label and user text conflict, prefer the user's latest text and note
+  the conflict in `constraints`.
+- If target venue is unknown, keep `format_id` generic but do not ignore any
+  provided page/word/style limits.
+- If the user only asks for a small section edit, still record scenario and
+  gates, but output only the requested section plus relevant quality notes.

--- a/pantheon/factory/templates/skills/paper_writing/writing/SKILL.md
+++ b/pantheon/factory/templates/skills/paper_writing/writing/SKILL.md
@@ -1,0 +1,37 @@
+---
+id: paper_writing_writer
+name: Evidence-Bound Paper Writer
+description: Section-level writing skill for evidence-bound academic prose, IMRAD papers, grants, reports, talks, and response letters.
+tags: [paper_writing, writing, imrad]
+---
+
+# Evidence-Bound Paper Writer
+
+Use only after triage, outline, and evidence boundaries exist.
+
+## Drafting Rules
+
+- Write `draft/paper.md` as the content source of truth.
+- Keep each core claim within `claim_evidence_map.md`.
+- Use `missing` evidence to ask for material, downgrade, or remove claims.
+- Do not invent data, citations, mechanisms, reviewer changes, or availability
+  statements.
+- For major rewrites, shape from raw material to candidate openings to
+  paragraph-by-paragraph structure before polishing.
+
+## Section Roles
+
+| Section | Role | Quality gate |
+|---|---|---|
+| Title | searchable, precise, not inflated | no vague clever title |
+| Abstract | problem, gap, method, key result, meaning | no result-free impact claim |
+| Introduction | known -> gap -> insufficiency -> approach -> contribution | gap and contribution align |
+| Related work | themed positioning | not chronological paper dump |
+| Methods | reproducible protocol | data/software/parameters/statistics clear |
+| Results | question -> method -> observation -> quantitative result -> interpretation | each result points to figure/table/data |
+| Discussion | finding, relation to literature, mechanism, limits, future | no new data |
+| Limitations | honest boundary and risk | no hidden fatal flaw |
+| Conclusion | contribution and boundary | not abstract repetition |
+
+Sources: ResearAI writer.md, Research-Paper-Writing-Skills/SKILL.md,
+K-Dense scientific-writing/SKILL.md, mattpocock writing-shape/SKILL.md.

--- a/pantheon/factory/templates/skills/paper_writing/writing/response_letter.md
+++ b/pantheon/factory/templates/skills/paper_writing/writing/response_letter.md
@@ -1,0 +1,37 @@
+---
+id: paper_writing_response_letter
+name: Response Letter Writer
+description: Write point-by-point reviewer response letters with comment preservation, response, changes made, and status.
+tags: [paper_writing, rebuttal, response_letter]
+---
+
+# Response Letter Writer
+
+Use only with `workflow/revision_loop.md`.
+
+## Unit Format
+
+```text
+Reviewer 1, Comment 1
+
+Comment:
+<verbatim or faithful reviewer comment>
+
+Response:
+<polite scientific response, evidence-backed>
+
+Changes Made:
+<exact manuscript section, figure, table, or no-change rationale>
+
+Status:
+done | partial | declined-with-reason | needs-user-input
+```
+
+## Rules
+
+- Preserve reviewer meaning. Do not soften or rewrite away criticism.
+- If accepting, say what changed and where.
+- If declining, give scientific, scope, or data-availability reasons.
+- Response letter and revised manuscript must agree.
+
+Sources: nature-response/SKILL.md, DeepScientist rebuttal/SKILL.md.


### PR DESCRIPTION
## Summary

This PR bundles two documentation/template changes that were developed in the fork and are intended for upstream review:

1. Add a new root-level `architecture.md` as a readable Chinese codebase guide for PantheonOS.
2. Expand `pantheon/factory/templates/skills/paper_writing/` from a small template index into a routed skill family with scenario, workflow, evidence, quality, format, theme, and writing submodules.

## What Changed

### 1. Add `architecture.md` codebase guide

- Added a new root document: `architecture.md`.
- Updated `.gitignore` to explicitly keep `architecture.md` tracked while still ignoring other root-level markdown files by default.
- Structured the guide into:
  - project overview and recommended reading entry points;
  - reading conventions for the annotated tree;
  - an expanded core repository tree covering the root and `pantheon/` package;
  - summary-level coverage for supporting directories such as docs/examples/tests.
- The repository tree uses tree branches and aligned inline comments so readers can scan the structure visually instead of reading a flat file list.
- The guide is intentionally a code-navigation document and does not replace `docs/source/architecture.rst`.

### 2. Rework `paper_writing` into a routed skill family

#### 2.1 Update the top-level skill index

- Rewrote `pantheon/factory/templates/skills/paper_writing/SKILL.md` from a simple template list into a routing/index skill.
- Added a sequential pipeline covering:
  - triage;
  - materials/evidence collection;
  - outline and claim-boundary setup;
  - section drafting;
  - quality gates;
  - editable output generation.
- Added scenario-based routing guidance so the paper-writing entry point can choose the right downstream files based on user intent.
- Documented non-negotiable rules such as no invented citations, no unsupported claims, no Sci-Hub usage, and keeping HTML outputs semantic/editable.

#### 2.2 Add scenario-specific skill modules

Added a new `scenarios/` subtree with dedicated entry contracts for different writing tasks:

- `paper_submission.md`
- `journal_article.md`
- `conference_paper.md`
- `grant_proposal.md`
- `lab_report.md`
- `group_report.md`
- `conference_talk.md`
- `workshop_share.md`
- `revision_response.md`
- plus a scenario index `scenarios/SKILL.md`

These files define triggers, expected inputs, required next steps, output artifacts, gate requirements, and forbidden shortcuts for each writing context.

#### 2.3 Add workflow modules for paper-planning and handoff

Added a new `workflow/` subtree covering the major execution phases of a paper-writing task:

- `triage.md`
- `material_inventory.md`
- `literature_review.md`
- `research_question.md`
- `paper_outline.md`
- `data_analysis_summary.md`
- `figure_storyline.md`
- `knowledge_lineage.md`
- `reader_testing.md`
- `revision_loop.md`
- `finalize_packet.md`
- plus `workflow/SKILL.md`

These files formalize how an agent should move from vague user input to a claim-bounded draft and then to a resumable final packet.

#### 2.4 Add evidence-layer modules

Added a new `evidence/` subtree to separate literature retrieval and claim support from prose drafting:

- `paper_search.md`
- `paper_fetch.md`
- `evidence_summary.md`
- `evidence_registry.md`
- `citation_grounding.md`
- `rerank_and_attribution.md`
- `context_answering.md`
- `data_availability.md`
- plus `evidence/SKILL.md`

This makes the evidence path explicit and enforces a distinction between search candidates, validated evidence, and final claims.

#### 2.5 Add quality gates

Added a new `quality/` subtree with explicit audit/check files:

- `claim_evidence_check.md`
- `reviewer_rubric.md`
- `citation_check.md`
- `reproducibility_check.md`
- `format_lint.md`
- `reporting_guideline_check.md`
- `html_editability_check.md`
- `response_consistency_check.md`
- `skill_structure_check.md`
- plus `quality/SKILL.md`

These files define review outputs instead of silently rewriting drafts, making quality checks inspectable and resumable.

#### 2.6 Add output-format and theme contracts

Added new format/theme protocol files:

- `formats/html_editable_contract.md`
- `formats/scenario_formats.md`
- `themes/SKILL.md`
- `themes/kami_academic.md`

These additions define:

- editable standalone HTML requirements;
- scenario-specific output structure contracts;
- a dedicated warm academic visual theme for HTML deliverables.

#### 2.7 Add dedicated writing skill files

Added:

- `writing/SKILL.md`
- `writing/response_letter.md`

These files clarify the drafting role, section-by-section writing expectations, and the exact response-letter unit format for reviewer rebuttal work.

#### 2.8 Update existing HTML templates for editability support

Updated:

- `report_standard.md`
- `report_academic.md`

Changes include:

- requiring major sections to be wrapped as editable semantic blocks;
- adding references to `formats/html_editable_contract.md`;
- adding focus styling for `.editable-block` sections so the resulting HTML is easier to edit interactively.

## Validation

I validated the change set locally with the following checks:

- confirmed the staged diff is limited to `.gitignore`, `architecture.md`, and `pantheon/factory/templates/skills/paper_writing/**`;
- ran `git diff --cached --check` to confirm there are no whitespace or patch-format issues;
- reviewed the generated tree/document and the new skill-family structure before commit.

## Impact

- No Python runtime code paths or public APIs are changed.
- This PR is documentation/template focused.
- Primary impact areas are:
  - developer onboarding and repository navigation;
  - paper-writing template routing and quality-control guidance;
  - HTML output contract expectations for paper-writing flows.

## Testing Notes

- No automated test suite was run for this PR because the changes are documentation/template content only.
- Local validation was limited to staging checks and content review.
