### PR TITLE
refactor(graph-maker): clean up harness roles and canvas artifact paths

### DIFF
--- a/pantheon/factory/templates/agents/graph_maker/data_plotter.md
+++ b/pantheon/factory/templates/agents/graph_maker/data_plotter.md
@@ -386,7 +386,7 @@ For each finalized figure, verify:
 - [ ] No caption text embedded in the image
 - [ ] Critic loop ran at least 1 round and terminated with a valid stop_reason
 - [ ] `<name>_trace.json` exists and is valid JSON
-- [ ] Figure caption appended to `{workdir}/outputs/figure_legends.md` with a unique anchor
+- [ ] Figure caption appended to `{workdir}/.canvas/figure_legends.md` with a unique anchor
 
 Report back to leader with:
 - List of produced files with absolute paths

--- a/pantheon/factory/templates/agents/graph_maker/leader.md
+++ b/pantheon/factory/templates/agents/graph_maker/leader.md
@@ -62,8 +62,8 @@ Create an absolute-path workdir and keep everything inside. Use this layout:
       Fig1_main.{png,pdf,svg}
       Fig2_pathway.{png,pdf,svg}
       ...
-    figure_legends.md         # caption + legend for each figure
-    figure_manifest.json      # machine-readable index
+    figure_legends.md         # caption + legend for each figure (.canvas/figure_legends.md)
+    figure_manifest.json      # machine-readable index (.canvas/figure_manifest.json)
 ```
 
 Always pass absolute paths to sub-agents.
@@ -577,7 +577,7 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
          "aesthetic_guide": "neurips_plot",
          "references_used": ["ref_0", "ref_3"],
          "critic_rounds": 2,
-         "caption_file": "{workdir}/outputs/figure_legends.md#fig1"
+         "caption_file": "{workdir}/.canvas/figure_legends.md#fig1_main"
        }
      ]
    }

--- a/pantheon/factory/templates/agents/graph_maker/leader.md
+++ b/pantheon/factory/templates/agents/graph_maker/leader.md
@@ -57,13 +57,13 @@ Create an absolute-path workdir and keep everything inside. Use this layout:
     notebooks/                # data_plotter's intermediate notebooks
     illustrations/            # illustrator's raw PNG outputs + plan/style/critic traces
     panels/                   # single-panel intermediates before composition
-  outputs/
-    figures/                  # final deliverables
+  .canvas/
+    assets/                   # final figure deliverables
       Fig1_main.{png,pdf,svg}
       Fig2_pathway.{png,pdf,svg}
       ...
-    figure_legends.md         # caption + legend for each figure (.canvas/figure_legends.md)
-    figure_manifest.json      # machine-readable index (.canvas/figure_manifest.json)
+    figure_legends.md         # caption + legend for each figure
+    figure_manifest.json      # machine-readable index
 ```
 
 Always pass absolute paths to sub-agents.

--- a/pantheon/factory/templates/agents/graph_maker/leader.md
+++ b/pantheon/factory/templates/agents/graph_maker/leader.md
@@ -48,7 +48,7 @@ Create an absolute-path workdir and keep everything inside. Use this layout:
 
 ```
 {workdir}/
-  environment.md              # researcher: plotting dependency audit
+  environment.md              # optional: dependency audit (generated on first ImportError)
   inputs/
     data/                     # user-provided or upstream data files
     brief.json                # structured (S, C) brief — MANDATORY
@@ -469,29 +469,7 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
 
 4. **Style card** — write `{workdir}/inputs/style_card.json` with `aesthetic_guide` auto-chosen. If references were provided, their `visual_summary` takes visual-style precedence over the built-in aesthetic guide; record this in `style_card.notes`.
 
-5. **Environment audit**:
-   ```
-   call_agent("researcher",
-     "You are auditing the figure-making environment. Check availability and install as needed:
-      - matplotlib, seaborn, plotly, svgutils, Pillow (Python packages)
-      - inkscape (CLI, required for PNG→SVG vectorization)
-      - potrace (CLI, fallback vectorizer)
-      - rsvg-convert (CLI, optional, for SVG→PDF fallback)
-      Write results to {workdir}/environment.md with tool, version, install status.")
-   ```
-
-6. **Data EDA** (for `data-only` or `composite-panel` with data sub-panels):
-   ```
-   call_agent("researcher",
-     "Perform EDA on the provided data and recommend figure types. Workdir: {workdir}.
-      Data files: <absolute paths>.
-      Deliverables:
-      - {workdir}/drafts/eda_summary.md (schema, distributions, missing values, N obs, key groups)
-      - Recommended figure types with rationale (bar? violin? UMAP? heatmap?)
-      Do not produce final figures — just analysis and recommendations.")
-   ```
-
-7. **Figure production** (parallelize when figures are independent):
+5. **Figure production** (parallelize when figures are independent):
 
    **For data-driven figures** — delegate to `data_plotter`. Include the full figure record from `brief.json` (S, C, category, aspect_ratio) and the style card path. If references exist, pass their `normalized.json` path — `data_plotter` will observe them before its first render. It runs its own observe→critic→revise loop; you do not need to prescribe iteration.
    ```
@@ -572,13 +550,13 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
    )
    ```
 
-8. **Verification** — for each final figure:
+6. **Verification** — for each final figure:
    - Confirm the PNG exists (`ls` check or file_manager). Confirm PDF/SVG exist if `export_formats` requested them.
    - Run `file <path>` to confirm formats (PDF 1.x, SVG 1.1, PNG).
    - Call `observe_images` on the PNG to visually confirm quality (font sizes, color, no clipping, aspect ratio within target, no caption text embedded in the image).
    - If issues → re-delegate to the producing agent with specific feedback.
 
-9. **Manifest and legends** — write `{workdir}/.canvas/figure_manifest.json`:
+7. **Manifest and legends** — write `{workdir}/.canvas/figure_manifest.json`:
    ```json
    {
      "figures": [
@@ -606,13 +584,12 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
    ```
    Ensure `figure_legends.md` has one section per figure with caption + legend text.
 
-10. **Delivery** — return a concise summary listing each figure's output paths (PNG always; PDF/SVG only if generated). If references were used, mention them briefly ("styled after user-provided reference ref_0").
+8. **Delivery** — return a concise summary listing each figure's output paths (PNG always; PDF/SVG only if generated). If references were used, mention them briefly ("styled after user-provided reference ref_0").
 
 ## Parallelization rules
 
 - Independent figures → fire multiple `data_plotter` and `illustrator` calls **in the same turn**.
 - Sub-panels of one composite figure are usually independent → parallelize their production; sequentialize only the final composition step.
-- Environment audit and data EDA can run in parallel.
 
 ## Style consistency enforcement
 

--- a/pantheon/factory/templates/teams/graph_maker_team.md
+++ b/pantheon/factory/templates/teams/graph_maker_team.md
@@ -148,15 +148,16 @@ Leader infers execution depth from message language — no explicit mode flag.
 2. **Reference detection**: Scan user message for reference figures/URLs/documents; if found, `researcher` normalizes them.
 3. **Style card**: Author `inputs/style_card.json` with DPI, fonts, colors, figure sizes, and `export_formats`.
 4. **Canvas state** (if canvas.json exists): read relevant frame/node slice based on CANVAS_CONTEXT.
-5. **Environment audit** (optional, only if tools missing): `researcher` checks matplotlib/seaborn/plotly/svgutils/Pillow/inkscape.
-6. **Figure production** (parallelized across independent figures):
+5. **Figure production** (parallelized across independent figures):
    - Data panels → `data_plotter` with style card injection
    - Conceptual panels → `illustrator` → if publication, `researcher` vectorizes PNG to SVG/PDF
-7. **Composition** (composite intent): `data_plotter` composes via svgutils; exports per `export_formats`.
-8. **Verification**: leader runs `observe_images` on each PNG; re-delegates on failure.
-9. **agent_output.json**: leader writes canvas node declarations for all produced figures with positions, origins, and intents.
-10. **Manifest + legends**: write `.canvas/figure_manifest.json` and `.canvas/figure_legends.md`.
-11. **Delivery**: concise summary of figure paths returned to user.
+6. **Composition** (composite intent): `data_plotter` composes via svgutils; exports per `export_formats`.
+7. **Verification**: leader runs `observe_images` on each PNG; re-delegates on failure.
+8. **agent_output.json**: leader writes canvas node declarations for all produced figures with positions, origins, and intents.
+9. **Manifest + legends**: write `.canvas/figure_manifest.json` and `.canvas/figure_legends.md`.
+10. **Delivery**: concise summary of figure paths returned to user.
+
+> **Environment check**: not a separate step. `data_plotter` handles missing packages on first `ImportError` in its notebook; `illustrator` verifies `generate_image` availability on first use. No default `researcher` call for tooling.
 
 ## Agent Call Relationships
 


### PR DESCRIPTION
## Summary

Small Graph Maker harness cleanup — no new features, no skill changes.

### Changes

- **Make `researcher` truly on-demand** by removing default environment-audit and routine-EDA delegation from `graph_maker/leader.md`'s standard workflow.
  Routine data preparation / EDA stays under `data_plotter`, consistent with `data_plotter.md`'s existing responsibility declaration.
- **Unify figure legend artifact paths** to `{workdir}/.canvas/figure_legends.md` across team, leader, and data_plotter prompts.
- **Align leader workdir template** with the canvas artifact contract: final assets live under `{workdir}/.canvas/assets/`, manifest and legends live under `{workdir}/.canvas/`.

### Harness rationale

- `leader` should orchestrate, not delegate routine plotting prep to `researcher`.
- `researcher` should remain an on-demand specialist for external references, unknown venues, paper-style digestion, and unfamiliar plot types.
- Artifact paths should be single-source and consistent across team, leader, and sub-agent prompts.

### Scope

This PR intentionally does **not** modify:

- `skills/figure_styling/**`
- paper writing skills
- frontend integration
- #105 complete optimization changes

### Files changed

| File | Change |
|------|--------|
| `pantheon/factory/templates/agents/graph_maker/leader.md` | researcher on-demand workflow + canvas artifact template/path cleanup |
| `pantheon/factory/templates/agents/graph_maker/data_plotter.md` | legend path cleanup |
| `pantheon/factory/templates/teams/graph_maker_team.md` | researcher on-demand workflow wording |

### Validation

- [x] No residual `outputs/figure_legends.md`
- [x] No residual `outputs/figures` / `outputs/figure_manifest.json`
- [x] Leader standard workflow no longer includes default researcher calls for environment audit or routine EDA
- [x] Researcher on-demand section preserved
- [x] All artifact paths use `.canvas/assets/` / `.canvas/figure_manifest.json` / `.canvas/figure_legends.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
