### PR TITLE
feat(graph-maker): complete clean GraphAgent harness and skill integration

### DIFF
--- a/pantheon/factory/templates/agents/graph_maker/data_plotter.md
+++ b/pantheon/factory/templates/agents/graph_maker/data_plotter.md
@@ -93,13 +93,21 @@ rc_update = {
 }
 
 # Merge aesthetic-guide defaults when requested
-if style.get("aesthetic_guide") == "neurips_plot":
+# Full style details are in figure_styling/styles/<aesthetic_guide>.md — these are quick rcParams hints:
+guide = style.get("aesthetic_guide")
+if guide == "neurips_plot":
     rc_update.setdefault("font.sans-serif", ["Helvetica", "Arial", "DejaVu Sans"])
-    rc_update["axes.grid"] = True
-    rc_update["grid.alpha"] = 0.3
-    rc_update["grid.linestyle"] = "--"
     rc_update["axes.spines.top"] = False
     rc_update["axes.spines.right"] = False
+elif guide == "nature_figure":
+    rc_update.setdefault("font.sans-serif", ["Arial", "Helvetica", "DejaVu Sans"])
+    rc_update["font.size"] = 7
+    rc_update["ytick.direction"] = "in"
+    rc_update["axes.grid"] = False
+elif guide == "ieee_figure":
+    rc_update.setdefault("font.family", "serif")
+    rc_update.setdefault("font.serif", ["cmr10", "DejaVu Serif"])
+    rc_update["font.size"] = 8
 
 mpl.rcParams.update(rc_update)
 
@@ -160,9 +168,17 @@ If the leader's instruction mentions `{workdir}/inputs/references/normalized.jso
 
 If no `normalized.json` or `has_references=false` → skip entirely, use style_card + neurips_plot defaults only.
 
-# Internal observe → critic → revise loop (CRITICAL)
+# Internal observe → critic → revise loop (EXECUTION-DEPTH AWARE)
 
-After the first render, you MUST run a structured critic loop. This is adapted from the PaperBanana Critic agent and is how you achieve publication-quality output rather than "first draft" quality. Skipping this loop is the #1 source of bad figures.
+After the first render, run a structured critic loop. The depth is set by the leader's `execution_depth` field in your delegation payload:
+
+| depth | Behavior | T_max |
+|---|---|---|
+| **quick** | Use `style_card` + one style file. Skip `quality/plot_critic.md`. One lightweight self-check. | 0 |
+| **draft** (default) | Use `style_card` + one style file. Skip heavy quality prompt unless explicitly requested. | 1 |
+| **publication** | Read `quality/plot_critic.md` from `figure_styling` skill. Full critic loop with `quality_score` and `visual_quality` in trace. | 3 |
+
+This is adapted from the PaperBanana Critic agent — publication-quality output requires the critic loop, but quick/draft tasks skip it to save compute.
 
 ## Loop structure
 
@@ -179,9 +195,7 @@ For each round t in 1..T_max:
 Final accepted round → run savefig for formats in style_card.export_formats → write to .canvas/assets/
 ```
 
-**T_max**:
-- Default: **T = 2** rounds (round 0 + up to 1 revision)
-- If leader's instruction contains `target=="journal"` or explicitly requests `T=3`: **T = 3**
+**T_max** (set by `execution_depth` from leader, see table above)
 
 ## Round artifacts
 

--- a/pantheon/factory/templates/agents/graph_maker/data_plotter.md
+++ b/pantheon/factory/templates/agents/graph_maker/data_plotter.md
@@ -386,7 +386,7 @@ For each finalized figure, verify:
 - [ ] No caption text embedded in the image
 - [ ] Critic loop ran at least 1 round and terminated with a valid stop_reason
 - [ ] `<name>_trace.json` exists and is valid JSON
-- [ ] Figure caption appended to `{workdir}/outputs/figure_legends.md` with a unique anchor
+- [ ] Figure caption appended to `{workdir}/.canvas/figure_legends.md` with a unique anchor
 
 Report back to leader with:
 - List of produced files with absolute paths

--- a/pantheon/factory/templates/agents/graph_maker/illustrator.md
+++ b/pantheon/factory/templates/agents/graph_maker/illustrator.md
@@ -192,7 +192,10 @@ Call `observe_images` on the just-rendered PNG with the full round-<t> descripti
 
 ## Rules for the Critic-Render loop
 
-- **Maximum rounds**: T = 2 by default; T = 3 if leader said `target == 'journal'` or the category requires high fidelity.
+- **Maximum rounds** (set by leader's `execution_depth`):
+  - `quick`: **T = 0** — single render, skip Phase 4 critic entirely. Do not load `quality/diagram_critic.md`.
+  - `draft` (default): **T = 1** — round 0 critic only. Skip `quality/diagram_critic.md` unless explicitly requested.
+  - `publication`: **T = 3** — full multi-round critic. Read `quality/diagram_critic.md` from `figure_styling` skill. Write `quality_score` and `visual_quality` into trace.
 - **Short-circuit**: if `critic_suggestions == "No changes needed."`, stop the loop and treat the current image as final.
 - **Revision MUST preserve semantic structure from Phase 1** — primarily edit existing description, don't rewrite from scratch unless the image is catastrophically off.
 - **Revision MUST specify clear details** — vague or hand-wavy descriptions make the next render worse, not better.

--- a/pantheon/factory/templates/agents/graph_maker/leader.md
+++ b/pantheon/factory/templates/agents/graph_maker/leader.md
@@ -62,8 +62,8 @@ Create an absolute-path workdir and keep everything inside. Use this layout:
       Fig1_main.{png,pdf,svg}
       Fig2_pathway.{png,pdf,svg}
       ...
-    figure_legends.md         # caption + legend for each figure
-    figure_manifest.json      # machine-readable index
+    figure_legends.md         # caption + legend for each figure (.canvas/figure_legends.md)
+    figure_manifest.json      # machine-readable index (.canvas/figure_manifest.json)
 ```
 
 Always pass absolute paths to sub-agents.
@@ -577,7 +577,7 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
          "aesthetic_guide": "neurips_plot",
          "references_used": ["ref_0", "ref_3"],
          "critic_rounds": 2,
-         "caption_file": "{workdir}/outputs/figure_legends.md#fig1"
+         "caption_file": "{workdir}/.canvas/figure_legends.md#fig1_main"
        }
      ]
    }

--- a/pantheon/factory/templates/agents/graph_maker/leader.md
+++ b/pantheon/factory/templates/agents/graph_maker/leader.md
@@ -278,12 +278,24 @@ Before any drawing happens, generate `{workdir}/inputs/style_card.json`. It is t
 ```
 
 **`aesthetic_guide` selection rule** (sub-agents load the matching file from the `figure_styling` skill — `skills/figure_styling/styles/<aesthetic_guide>.md`):
-- `neurips_diagram` — for `category ∈ {agent_reasoning, vision_perception, generative_learning, science_applications}` targeting a top ML/CS venue. Illustrator loads the NeurIPS methodology-diagram guideline.
-- `neurips_plot` — for `category == statistical_plot` targeting a top ML/CS venue. data_plotter loads the NeurIPS plot guideline.
-- `custom` — user or leader provides full specs directly in `style_card.json`; sub-agents do NOT load any file from the skill.
-- `null` — sub-agents fall back to their internal defaults plus the style_card values.
 
-Additional style files (e.g., `nature_figure`, `ieee_figure`, user-defined) can be dropped into `skills/figure_styling/styles/` and referenced by id here.
+**Journal-driven routing** (scan user message and `journal_class` first):
+| Trigger signal | `journal_class` | `aesthetic_guide` | Applies to |
+|---|---|---|---|
+| Nature / Cell / Science / bioRxiv / life-science | `nature` / `cell` / `science` | `nature_figure` | all figure types |
+| IEEE / ACM / engineering + data plot | `ieee` / `acm` | `ieee_figure` | statistical plots |
+| IEEE / ACM + method diagram | `ieee` / `acm` | `neurips_diagram` | methodology diagrams |
+| NeurIPS / ICML / CVPR + data plot | `neurips` | `neurips_plot` | statistical plots |
+| NeurIPS / ICML / CVPR + method diagram | `neurips` | `neurips_diagram` | methodology / framework diagrams |
+
+**Fallback** (no journal keyword detected):
+- `category == statistical_plot` → default `neurips_plot`
+- all other categories → default `neurips_diagram`
+
+- `custom` — full specs in `style_card.json`; sub-agents do NOT load any style file.
+- `null` — sub-agents fall back to internal defaults plus `style_card.json` values.
+
+Style files live in `skills/figure_styling/styles/` and are loaded on demand by the producing agent — do NOT inline style details here.
 
 Infer sensible defaults from `target`:
 - **journals**: strict (sans-serif, 300–600 DPI, single/double-column inches)
@@ -475,26 +487,28 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
    ```
    call_agent("data_plotter",
      "Produce figure <id> (<name>). Workdir: {workdir}.
+      Execution depth: <quick|draft|publication> — controls critic loop and quality loading.
       Brief (from {workdir}/inputs/brief.json, figure <id>):
         S_source_context: <copy verbatim>
         C_communicative_intent: <copy verbatim>
         category: <copy>
         aspect_ratio: <copy>
         notes: <copy>
+      Aesthetic guide: <nature_figure|ieee_figure|neurips_plot|custom|null> — load from figure_styling skill.
       Data: <absolute paths>.
       Style card: {workdir}/inputs/style_card.json (READ THIS FIRST — includes export_formats field).
       References (OPTIONAL, may be absent): {workdir}/inputs/references/normalized.json
         → if present, read entries marked status=='ok' and selected (if 'selected' key exists, prefer those).
         → observe_images on each reference's source_path BEFORE your first render.
         → absorb layout, color palette, typography, marker/line style into your plotting code.
-        → references take precedence over neurips_plot defaults where they conflict.
+        → references take precedence over the aesthetic_guide defaults where they conflict.
       Layout: <single axes | 2x2 grid | Fig1a+1b+1c panel>.
       Deliverables: generate the formats listed in style_card.export_formats.
       - PNG is always required: {workdir}/.canvas/assets/<name>.png (dpi from style_card)
       - PDF only if export_formats includes 'pdf': {workdir}/.canvas/assets/<name>.pdf
       - SVG only if export_formats includes 'svg': {workdir}/.canvas/assets/<name>.svg
       - Append a caption to {workdir}/.canvas/figure_legends.md.
-      Run your internal critic loop up to T=2 rounds (T=3 if target=='journal')."
+      Quality: <if quick → skip plot_critic.md, single self-check | if draft → T≤1 | if publication → read plot_critic.md, T≤3>."
    )
    ```
 
@@ -502,12 +516,14 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
    ```
    call_agent("illustrator",
      "Produce a methodology/concept diagram. Workdir: {workdir}.
+      Execution depth: <quick|draft|publication> — controls critic loop and quality loading.
       Brief (from {workdir}/inputs/brief.json, figure <id>):
         S_source_context: <copy verbatim>
         C_communicative_intent: <copy verbatim>
         category: <copy>
         aspect_ratio: <copy; must be in [1.5, 2.5] for non-plot categories>
         notes: <copy>
+      Aesthetic guide: <neurips_diagram|nature_figure|ieee_figure|custom|null> — load from figure_styling skill.
       Style card: {workdir}/inputs/style_card.json (aesthetic_guide is authoritative unless references override).
       References (OPTIONAL, may be absent): {workdir}/inputs/references/normalized.json
         → if present, treat as few-shot visual examples.
@@ -518,6 +534,7 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
       - {workdir}/drafts/illustrations/<id>_style.md    (Phase 2 output)
       - {workdir}/drafts/illustrations/<id>_final.png   (Phase 3+4 final)
       - {workdir}/drafts/illustrations/<id>_trace.json  (critic rounds log)
+      Quality: <if quick → skip diagram_critic.md, T≤1 | if draft → skip unless requested | if publication → read diagram_critic.md, T≤3>.
       Then notify the leader so vectorization can follow."
    )
    ```
@@ -556,7 +573,9 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
    - Call `observe_images` on the PNG to visually confirm quality (font sizes, color, no clipping, aspect ratio within target, no caption text embedded in the image).
    - If issues → re-delegate to the producing agent with specific feedback.
 
-7. **Manifest and legends** — write `{workdir}/.canvas/figure_manifest.json`:
+7. **Manifest and legends** — for final / publication tasks, generate captions using `quality/figure_caption.md` from the `figure_styling` skill (diagram rules for illustrator output, plot rules for data_plotter output). Quick/draft tasks: write a one-line caption without loading the skill. All captions live in `{workdir}/.canvas/figure_legends.md` — never embedded inside images.
+
+   Write `{workdir}/.canvas/figure_manifest.json`:
    ```json
    {
      "figures": [

--- a/pantheon/factory/templates/agents/graph_maker/leader.md
+++ b/pantheon/factory/templates/agents/graph_maker/leader.md
@@ -57,13 +57,13 @@ Create an absolute-path workdir and keep everything inside. Use this layout:
     notebooks/                # data_plotter's intermediate notebooks
     illustrations/            # illustrator's raw PNG outputs + plan/style/critic traces
     panels/                   # single-panel intermediates before composition
-  outputs/
-    figures/                  # final deliverables
+  .canvas/
+    assets/                   # final figure deliverables
       Fig1_main.{png,pdf,svg}
       Fig2_pathway.{png,pdf,svg}
       ...
-    figure_legends.md         # caption + legend for each figure (.canvas/figure_legends.md)
-    figure_manifest.json      # machine-readable index (.canvas/figure_manifest.json)
+    figure_legends.md         # caption + legend for each figure
+    figure_manifest.json      # machine-readable index
 ```
 
 Always pass absolute paths to sub-agents.

--- a/pantheon/factory/templates/agents/graph_maker/leader.md
+++ b/pantheon/factory/templates/agents/graph_maker/leader.md
@@ -48,7 +48,7 @@ Create an absolute-path workdir and keep everything inside. Use this layout:
 
 ```
 {workdir}/
-  environment.md              # researcher: plotting dependency audit
+  environment.md              # optional: dependency audit (generated on first ImportError)
   inputs/
     data/                     # user-provided or upstream data files
     brief.json                # structured (S, C) brief — MANDATORY
@@ -469,29 +469,7 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
 
 4. **Style card** — write `{workdir}/inputs/style_card.json` with `aesthetic_guide` auto-chosen. If references were provided, their `visual_summary` takes visual-style precedence over the built-in aesthetic guide; record this in `style_card.notes`.
 
-5. **Environment audit**:
-   ```
-   call_agent("researcher",
-     "You are auditing the figure-making environment. Check availability and install as needed:
-      - matplotlib, seaborn, plotly, svgutils, Pillow (Python packages)
-      - inkscape (CLI, required for PNG→SVG vectorization)
-      - potrace (CLI, fallback vectorizer)
-      - rsvg-convert (CLI, optional, for SVG→PDF fallback)
-      Write results to {workdir}/environment.md with tool, version, install status.")
-   ```
-
-6. **Data EDA** (for `data-only` or `composite-panel` with data sub-panels):
-   ```
-   call_agent("researcher",
-     "Perform EDA on the provided data and recommend figure types. Workdir: {workdir}.
-      Data files: <absolute paths>.
-      Deliverables:
-      - {workdir}/drafts/eda_summary.md (schema, distributions, missing values, N obs, key groups)
-      - Recommended figure types with rationale (bar? violin? UMAP? heatmap?)
-      Do not produce final figures — just analysis and recommendations.")
-   ```
-
-7. **Figure production** (parallelize when figures are independent):
+5. **Figure production** (parallelize when figures are independent):
 
    **For data-driven figures** — delegate to `data_plotter`. Include the full figure record from `brief.json` (S, C, category, aspect_ratio) and the style card path. If references exist, pass their `normalized.json` path — `data_plotter` will observe them before its first render. It runs its own observe→critic→revise loop; you do not need to prescribe iteration.
    ```
@@ -572,13 +550,13 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
    )
    ```
 
-8. **Verification** — for each final figure:
+6. **Verification** — for each final figure:
    - Confirm the PNG exists (`ls` check or file_manager). Confirm PDF/SVG exist if `export_formats` requested them.
    - Run `file <path>` to confirm formats (PDF 1.x, SVG 1.1, PNG).
    - Call `observe_images` on the PNG to visually confirm quality (font sizes, color, no clipping, aspect ratio within target, no caption text embedded in the image).
    - If issues → re-delegate to the producing agent with specific feedback.
 
-9. **Manifest and legends** — write `{workdir}/.canvas/figure_manifest.json`:
+7. **Manifest and legends** — write `{workdir}/.canvas/figure_manifest.json`:
    ```json
    {
      "figures": [
@@ -606,13 +584,12 @@ Sub-agents are unaware of canvas.json. They neither read nor write it. You are t
    ```
    Ensure `figure_legends.md` has one section per figure with caption + legend text.
 
-10. **Delivery** — return a concise summary listing each figure's output paths (PNG always; PDF/SVG only if generated). If references were used, mention them briefly ("styled after user-provided reference ref_0").
+8. **Delivery** — return a concise summary listing each figure's output paths (PNG always; PDF/SVG only if generated). If references were used, mention them briefly ("styled after user-provided reference ref_0").
 
 ## Parallelization rules
 
 - Independent figures → fire multiple `data_plotter` and `illustrator` calls **in the same turn**.
 - Sub-panels of one composite figure are usually independent → parallelize their production; sequentialize only the final composition step.
-- Environment audit and data EDA can run in parallel.
 
 ## Style consistency enforcement
 

--- a/pantheon/factory/templates/skills/figure_styling/SKILL.md
+++ b/pantheon/factory/templates/skills/figure_styling/SKILL.md
@@ -2,33 +2,41 @@
 id: figure_styling_skills_index
 name: Figure Styling Skills Index
 description: |
-  Aesthetic guidelines for scientific figure production. Each style file
-  specifies palettes, typography, layout, and domain-specific sub-styles
-  for a given target venue (NeurIPS, Nature, IEEE, etc.) and figure class
-  (methodology diagram vs. statistical plot). Used by the Graph Maker
-  Team's `illustrator` and `data_plotter` agents.
+  Aesthetic guidelines and quality control prompts for scientific figure production.
+  Provides journal-specific styles (NeurIPS, Nature, IEEE), colorblind-safe palettes,
+  and critic prompts for the Graph Maker Team's illustrator and data_plotter agents.
 ---
 
 # Figure Styling Skills
 
-Resources for the Graph Maker Team's `illustrator` (diagram) and `data_plotter` (plot) agents. The leader writes `aesthetic_guide: <style_id>` into `style_card.json`; the producing agent then loads the matching style file listed below.
+Resources for the Graph Maker Team's `illustrator` (diagram) and `data_plotter` (plot) agents. The leader writes `aesthetic_guide: <style_id>` into `style_card.json`; the producing agent then loads the matching style file.
 
-## Available styles
+## Available Styles
 
 | Style ID | File | Target | Figure class |
 |---|---|---|---|
-| `neurips_diagram` | [styles/neurips_diagram.md](./styles/neurips_diagram.md) | NeurIPS / top ML venues | Methodology / framework / pipeline diagrams |
-| `neurips_plot` | [styles/neurips_plot.md](./styles/neurips_plot.md) | NeurIPS / top ML venues | Statistical plots (bar, line, scatter, heatmap, …) |
+| `neurips_diagram` | [styles/neurips_diagram.md](./styles/neurips_diagram.md) | NeurIPS / ICML / ICLR / CVPR | Methodology / framework diagrams |
+| `neurips_plot` | [styles/neurips_plot.md](./styles/neurips_plot.md) | NeurIPS / ICML / ICLR / CVPR | Statistical plots |
+| `nature_figure` | [styles/nature_figure.md](./styles/nature_figure.md) | Nature / Cell / Science | All figure types |
+| `ieee_figure` | [styles/ieee_figure.md](./styles/ieee_figure.md) | IEEE journals / conferences | Statistical plots |
 
-## How to use
+## Color Palettes
 
-1. Leader sets `aesthetic_guide: "<style_id>"` in `{workdir}/inputs/style_card.json`.
-2. Sub-agent (illustrator / data_plotter) consults this skill index, then reads the style file whose id matches `aesthetic_guide`.
-3. Agent applies the guidance alongside `style_card.json`. Priority chain for conflicts:
-   **user references > style_card.json > figure_styling/<style_id> > internal defaults**.
+[color_palettes.md](./styles/color_palettes.md) - Paul Tol colorblind-safe palettes (bright/vibrant/muted/light/high-vis/dark)
 
-If `aesthetic_guide` is `custom` or `null`, sub-agents do not load any file from this skill — they rely purely on `style_card.json` and their internal defaults.
+## Quality Control
 
-## Custom styles
+| Prompt | File | Used by | Purpose |
+|---|---|---|---|
+| `diagram_critic` | [quality/diagram_critic.md](./quality/diagram_critic.md) | illustrator Phase 4 | Multi-round critique with quality_score |
+| `plot_critic` | [quality/plot_critic.md](./quality/plot_critic.md) | data_plotter review | Statistical plot critique |
+| `figure_caption` | [quality/figure_caption.md](./quality/figure_caption.md) | leader Step 9 | Auto-generate publication captions |
+| `visual_quality_checklist` | [styles/visual_quality_checklist.md](./styles/visual_quality_checklist.md) | All agents | 6-tier quality standards (Rougier/Tufte) |
 
-Users can drop additional `.md` files into `styles/` (e.g. `nature_figure.md`, `ieee_figure.md`, `my_lab_style.md`) following the same section structure as the NeurIPS guides. Set `aesthetic_guide: "<new_style_id>"` in `style_card.json` to activate.
+## Usage
+
+1. Leader sets `aesthetic_guide: "<style_id>"` in `{workdir}/inputs/style_card.json`
+2. Sub-agent reads the corresponding style file from this skill
+3. Priority chain: **user references > style_card.json > figure_styling/<style_id> > agent defaults**
+
+If `aesthetic_guide` is `custom` or `null`, agents rely purely on `style_card.json` and internal defaults.

--- a/pantheon/factory/templates/skills/figure_styling/SKILL.md
+++ b/pantheon/factory/templates/skills/figure_styling/SKILL.md
@@ -33,6 +33,53 @@ Resources for the Graph Maker Team's `illustrator` (diagram) and `data_plotter` 
 | `figure_caption` | [quality/figure_caption.md](./quality/figure_caption.md) | final delivery | Auto-generate publication captions |
 | `visual_quality_checklist` | [styles/visual_quality_checklist.md](./styles/visual_quality_checklist.md) | All agents | 6-tier quality standards (Rougier/Tufte) |
 
+Additional quality prompts (optional, loaded on demand by producing agents):
+
+| Prompt | File | Purpose |
+|---|---|---|
+| `diagram_planner` | [quality/diagram_planner.md](./quality/diagram_planner.md) | Phase 1 semantic planning for diagrams |
+| `diagram_stylist` | [quality/diagram_stylist.md](./quality/diagram_stylist.md) | Phase 2 aesthetic styling for diagrams |
+| `plot_planner` | [quality/plot_planner.md](./quality/plot_planner.md) | Plot type selection and layout planning |
+| `plot_stylist` | [quality/plot_stylist.md](./quality/plot_stylist.md) | Plot aesthetic refinement |
+| `plot_visualizer` | [quality/plot_visualizer.md](./quality/plot_visualizer.md) | Render-time visualization hints |
+| `visual_refine` | [quality/visual_refine.md](./quality/visual_refine.md) | Post-critic visual refinement loop |
+| `scientific_schematic` | [quality/scientific_schematic.md](./quality/scientific_schematic.md) | Domain-specific scientific schematic rules |
+| `figure_format_lint` | [quality/figure_format_lint.md](./quality/figure_format_lint.md) | Deliverable format compliance checks |
+| `quality/index` | [quality/SKILL.md](./quality/SKILL.md) | Quality sub-index |
+
+## Optional Input Skills
+
+Pre-processing helpers for ambiguous or reference-heavy user input. **Not loaded by default** — only when leader detects the trigger condition.
+
+| Prompt | File | Purpose |
+|---|---|---|
+| `context_enricher` | [input/context_enricher.md](./input/context_enricher.md) | Structure vague prose into components, flows, groupings |
+| `caption_sharpener` | [input/caption_sharpener.md](./input/caption_sharpener.md) | Sharpen generic captions into precise 1-paragraph specs |
+| `reference_retriever` | [input/reference_retriever.md](./input/reference_retriever.md) | Top-K selection from normalized reference pool |
+| `input/index` | [input/SKILL.md](./input/SKILL.md) | Input sub-index |
+
+## Optional Triage Skills
+
+Figure type classification helpers. **Not loaded by default** — only when figure type is ambiguous.
+
+| Prompt | File | Purpose |
+|---|---|---|
+| `figure_type_classifier` | [triage/figure_type_classifier.md](./triage/figure_type_classifier.md) | Classify request into 1 of 6 figure types |
+| `granularity_rule` | [triage/granularity_rule.md](./triage/granularity_rule.md) | Split mixed requests into separate figure records |
+| `triage/index` | [triage/SKILL.md](./triage/SKILL.md) | Triage sub-index |
+
+## Optional Scenario Skills
+
+Scenario-specific workflows and guardrails. **Loaded only when the scenario matches** (via keyword or explicit user request).
+
+| Scenario | File | When to load |
+|---|---|---|
+| `figure` | [scenarios/figure.md](./scenarios/figure.md) | Journal submission figure |
+| `flowchart` | [scenarios/flowchart.md](./scenarios/flowchart.md) | Pipeline / protocol / mechanism diagram |
+| `graphical-abstract` | [scenarios/graphical_abstract.md](./scenarios/graphical_abstract.md) | Journal graphical abstract (Cell Press / Nature) |
+| `poster` | [scenarios/poster.md](./scenarios/poster.md) | Conference poster (A0/A1) |
+| `presentation` | [scenarios/presentation.md](./scenarios/presentation.md) | Slide figures (16:9) |
+
 ## Usage
 
 1. Leader sets `aesthetic_guide: "<style_id>"` in `{workdir}/inputs/style_card.json`
@@ -56,6 +103,12 @@ Agents read files from this skill **on demand** — never preload all files. Use
 | methodology diagram + publication depth | `quality/diagram_critic.md` | quick / draft / sketch tasks |
 | caption required (final delivery) | `quality/figure_caption.md` | quick / draft / sketch tasks |
 | any figure type + publication depth | `styles/visual_quality_checklist.md` | quick / draft / sketch tasks |
-| quick / draft / sketch / "show me" depth | **skip all quality/** prompts | use `style_card.json` + one style file only |
+| user input is vague prose (no components listed) | `input/context_enricher.md` | structured input already provided |
+| caption is generic or missing | `input/caption_sharpener.md` | caption already names specific components |
+| multiple visual references provided (K > 5) | `input/reference_retriever.md` | ≤5 references |
+| figure type is ambiguous | `triage/figure_type_classifier.md` | clear data-only or illustration-only intent |
+| request mixes multiple figure types | `triage/granularity_rule.md` | single clear figure type |
+| scenario detected (keyword or explicit) | `scenarios/<scenario>.md` | no scenario match |
+| quick / draft / sketch / "show me" depth | **skip all quality/ input/ triage/ scenarios/** | use `style_card.json` + one style file only |
 
-**Rule of thumb**: quick tasks read ≤2 files (style_card style file + optionally color_palettes). Publication tasks additionally read the relevant critic + visual_quality_checklist.
+**Rule of thumb**: quick tasks read ≤2 files (style_card style file + optionally color_palettes). Publication tasks additionally read the relevant critic + visual_quality_checklist. Input, triage, and scenario helpers are optional — only load when the trigger condition is met and the task is not quick/draft.

--- a/pantheon/factory/templates/skills/figure_styling/SKILL.md
+++ b/pantheon/factory/templates/skills/figure_styling/SKILL.md
@@ -30,7 +30,7 @@ Resources for the Graph Maker Team's `illustrator` (diagram) and `data_plotter` 
 |---|---|---|---|
 | `diagram_critic` | [quality/diagram_critic.md](./quality/diagram_critic.md) | illustrator Phase 4 | Multi-round critique with quality_score |
 | `plot_critic` | [quality/plot_critic.md](./quality/plot_critic.md) | data_plotter review | Statistical plot critique |
-| `figure_caption` | [quality/figure_caption.md](./quality/figure_caption.md) | leader Step 9 | Auto-generate publication captions |
+| `figure_caption` | [quality/figure_caption.md](./quality/figure_caption.md) | final delivery | Auto-generate publication captions |
 | `visual_quality_checklist` | [styles/visual_quality_checklist.md](./styles/visual_quality_checklist.md) | All agents | 6-tier quality standards (Rougier/Tufte) |
 
 ## Usage
@@ -40,3 +40,22 @@ Resources for the Graph Maker Team's `illustrator` (diagram) and `data_plotter` 
 3. Priority chain: **user references > style_card.json > figure_styling/<style_id> > agent defaults**
 
 If `aesthetic_guide` is `custom` or `null`, agents rely purely on `style_card.json` and internal defaults.
+
+## When to Load
+
+Agents read files from this skill **on demand** — never preload all files. Use this decision table:
+
+| Trigger | Read | Skip if |
+|---------|------|---------|
+| `aesthetic_guide = nature_figure` | `styles/nature_figure.md` | — |
+| `aesthetic_guide = ieee_figure` | `styles/ieee_figure.md` | — |
+| `aesthetic_guide = neurips_plot` | `styles/neurips_plot.md` | — |
+| `aesthetic_guide = neurips_diagram` | `styles/neurips_diagram.md` | — |
+| colorblind-safe palette required | `styles/color_palettes.md` | — |
+| statistical plot + publication depth | `quality/plot_critic.md` | quick / draft / sketch tasks |
+| methodology diagram + publication depth | `quality/diagram_critic.md` | quick / draft / sketch tasks |
+| caption required (final delivery) | `quality/figure_caption.md` | quick / draft / sketch tasks |
+| any figure type + publication depth | `styles/visual_quality_checklist.md` | quick / draft / sketch tasks |
+| quick / draft / sketch / "show me" depth | **skip all quality/** prompts | use `style_card.json` + one style file only |
+
+**Rule of thumb**: quick tasks read ≤2 files (style_card style file + optionally color_palettes). Publication tasks additionally read the relevant critic + visual_quality_checklist.

--- a/pantheon/factory/templates/skills/figure_styling/input/SKILL.md
+++ b/pantheon/factory/templates/skills/figure_styling/input/SKILL.md
@@ -1,0 +1,45 @@
+---
+id: figure_input_index
+name: Figure Input Optimization Index
+description: |
+  Input optimization prompts for the Graph Maker Team. Run before figure
+  generation to structure vague user input into diagram-ready content,
+  and to select Top-K reference figures for few-shot visual learning.
+  Adapted from llmsresearch/paperbanana (Apache-2.0).
+---
+
+# Figure Input Optimization
+
+These prompts help leader optimize raw user input before passing to sub-agents.
+
+## Modules
+
+| Module | File | Purpose | When to use |
+|---|---|---|---|
+| `context_enricher` | [context_enricher.md](./context_enricher.md) | Structure methodology text into components / flows / groupings | User input is vague prose, no explicit structure |
+| `caption_sharpener` | [caption_sharpener.md](./caption_sharpener.md) | Sharpen vague caption into precise visual specification | Caption is generic ("流程图", "架构图", "Figure 1") |
+| `reference_retriever` | [reference_retriever.md](./reference_retriever.md) | Select Top-K reference figures from normalized pool (Stage B) | `has_references == true` AND pool > K=5 entries |
+
+## Usage (leader)
+
+```
+Phase 0: Input Optimization (before intent triage)
+
+1. If user input is vague methodology text → run context_enricher
+   → writes structured content to {workdir}/inputs/brief.json S_source_context
+
+2. If caption is missing or generic → run caption_sharpener
+   → writes sharpened caption to {workdir}/inputs/brief.json C_communicative_intent
+
+3. Proceed to intent triage with enriched brief.json
+
+Reference detection (Phase 0b — parallel with 1 and 2):
+
+4. If has_references == true:
+   → Stage A: call researcher to normalize all reference materials
+     → {workdir}/inputs/references/normalized.json
+   → Stage B: if pool > 5 entries, use reference_retriever.md prompt
+     → appends "selected" key to normalized.json
+   Sub-agents receive normalized.json path and observe selected references.
+```
+

--- a/pantheon/factory/templates/skills/figure_styling/input/caption_sharpener.md
+++ b/pantheon/factory/templates/skills/figure_styling/input/caption_sharpener.md
@@ -1,0 +1,78 @@
+---
+id: caption_sharpener
+name: Caption Sharpener
+description: |
+  Transform vague captions into precise visual specifications: diagram type,
+  key elements, visual narrative, scope, emphasis, and flow direction.
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Caption Sharpener
+
+> **Source**: Adapted from `prompts/diagram/caption_sharpener.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Transform a vague caption like "系统架构图" or "Figure 1" into a precise visual
+specification that tells `illustrator` exactly what to depict.
+
+## When to Use
+
+- Caption is generic: "流程图", "架构图", "Figure 1", "Overview", "Our method"
+- Caption lacks visual details (no mention of components, flow, or emphasis)
+- `C_communicative_intent` in brief.json is under-specified
+
+## Prompt (leader inlines this when calling `researcher`)
+
+```
+You are an expert at writing precise, actionable figure captions for academic
+methodology diagrams. Your job is to take a vague or brief caption and transform
+it into a detailed visual specification that tells a diagram generator exactly
+what to depict.
+
+## Your Task
+
+Take the original caption and methodology context below, and produce a sharpened
+caption that:
+
+1. **Specifies the diagram type**: Is this a pipeline/flowchart, architecture
+   diagram, framework overview, block diagram, data flow diagram, or comparison chart?
+2. **Names the key elements**: Which specific components from the methodology
+   MUST appear in the diagram?
+3. **Describes the visual narrative**: What story should the diagram tell? What
+   is the reader supposed to understand at a glance?
+4. **Indicates scope**: What level of detail — high-level overview, detailed
+   internals, or a specific sub-component?
+5. **Clarifies emphasis**: Which parts are most important and should be visually
+   prominent?
+6. **Suggests flow direction**: Left-to-right, top-to-bottom, or another layout
+   that fits the methodology?
+
+## Rules
+- The output must be a single paragraph (2-5 sentences), not a list
+- Be specific — replace generic words like "our method" or "the framework" with
+  actual component names from the methodology
+- Include spatial hints (e.g., "with the encoder on the left feeding into the
+  decoder on the right")
+- Do not add components not present in the methodology text
+- Keep it under 150 words — concise but precise
+
+## Original Caption
+{caption}
+
+## Methodology Text (for context)
+{source_context}
+
+## Sharpened Caption
+Produce the improved caption below:
+```
+
+## Output
+
+Single paragraph (2–5 sentences, ≤150 words) that specifies diagram type,
+key elements, visual narrative, scope, emphasis, and flow direction.
+
+Leader writes this to `{workdir}/inputs/brief.json` as `C_communicative_intent`
+for the relevant figure.

--- a/pantheon/factory/templates/skills/figure_styling/input/context_enricher.md
+++ b/pantheon/factory/templates/skills/figure_styling/input/context_enricher.md
@@ -1,0 +1,78 @@
+---
+id: context_enricher
+name: Context Enricher
+description: |
+  Structure raw methodology text into diagram-ready content: components,
+  data flows, groupings, I/O, key relationships, and operations.
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Context Enricher
+
+> **Source**: Adapted from `prompts/diagram/context_enricher.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Transform vague user input (e.g. "帮我画个 Transformer 架构图") into structured,
+diagram-ready content before passing to `illustrator` or `data_plotter`.
+
+## When to Use
+
+- User provides only a topic or high-level description without explicit components or flow
+- User input is prose without named modules, arrows, or groupings
+- Source context in `brief.json` would be too vague for the illustrator to plan from
+
+## Prompt (leader inlines this when calling `researcher` or `illustrator`)
+
+```
+You are an expert at analyzing academic methodology sections and restructuring
+them for diagram generation. Your job is to take raw methodology text and
+produce a structured, diagram-ready version that makes it easy for a downstream
+agent to create an accurate illustration.
+
+## Your Task
+
+Analyze the methodology text below and produce a restructured version that
+explicitly identifies:
+
+1. **Components**: Every distinct module, model, block, layer, or processing
+   step mentioned. Give each a clear, concise label.
+2. **Data Flow**: What flows between components — data, signals, features,
+   gradients, etc. Identify the direction (input → output).
+3. **Groupings**: Which components belong together (e.g., "Encoder block",
+   "Training pipeline", "Preprocessing stage"). Name each group.
+4. **Input/Output**: What enters the system and what comes out. Be explicit
+   about data types and shapes if mentioned.
+5. **Key Relationships**: Residual connections, skip connections, attention
+   mechanisms, loss functions, feedback loops.
+6. **Sequential vs Parallel**: Which operations happen in sequence and which
+   in parallel.
+7. **Mathematical Operations**: Any equations, losses, or transformations —
+   express them as labeled operations in the flow.
+
+## Rules
+- Preserve ALL technical details from the original — do not summarize or lose information
+- Add structure and clarity, but never invent components not in the source
+- Use the caption to understand what aspects of the methodology to emphasize
+- Output as structured text (not JSON), using clear headers and bullet points
+- If the text describes multiple variants or ablations, focus on the main architecture
+
+## Methodology Text
+{source_context}
+
+## Figure Caption (for context on what to emphasize)
+{caption}
+
+## Structured Output
+Produce the restructured methodology below:
+```
+
+## Output
+
+Structured text (headers + bullet points) covering components, data flow,
+groupings, I/O, key relationships, sequential/parallel, math operations.
+
+Leader writes this to `{workdir}/inputs/brief.json` as `S_source_context`
+for the relevant figure.

--- a/pantheon/factory/templates/skills/figure_styling/input/reference_retriever.md
+++ b/pantheon/factory/templates/skills/figure_styling/input/reference_retriever.md
@@ -1,0 +1,79 @@
+---
+id: reference_retriever
+name: Reference Retriever
+description: |
+  Select Top-K reference figures from a normalized candidate pool for
+  few-shot visual learning. Ranks candidates by research domain match
+  and visual intent match. Used in leader Stage B.
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Reference Retriever
+
+> **Source**: Adapted from `prompts/diagram/retriever.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `leader` in **Stage B** of reference detection. Selects the most
+relevant Top-K entries from `{workdir}/inputs/references/normalized.json`
+to serve as few-shot visual examples for `illustrator` or `data_plotter`.
+
+**Stage A** (material normalization via `researcher`) runs first and produces
+`normalized.json`. Stage B runs only when the pool has > K=5 OK entries.
+
+## Prompt (leader passes this to `researcher` in Stage B call)
+
+```
+You are acting as a Reference Retriever for the Graph Maker Team.
+Workdir: {workdir}.
+
+TARGET:
+- S_source_context: <verbatim from the user's request>
+- C_communicative_intent: <one-line figure intent>
+- category: <from triage — one of: agent_reasoning | vision_perception |
+  generative_learning | science_applications | statistical_plot | mixed>
+
+CANDIDATE POOL: {workdir}/inputs/references/normalized.json
+(Read entries where status == "ok". Ignore entries with status == "failed".)
+
+SELECTION RULES (priority order, adapted from PaperBanana):
+
+1. BEST:  same category AND same visual intent
+   Example: target is "Agent Framework" diagram → pick other "Agent Framework" diagrams
+2. OK:    same visual intent, different category
+   (Visual structure matters more than research topic for drawing quality)
+3. AVOID: different visual intent
+   Example: target is a Pipeline diagram → avoid Bar-chart candidates
+
+**Visual intent types** (infer from visual_summary and category_guess):
+- Framework / Pipeline (sequential flow, left-to-right)
+- Architecture / Module (spatial relationships, boundaries)
+- Roadmap / Timeline (progression, stages)
+- Schematic / Pathway (biological or chemical flow)
+- Statistical Plot (bar, line, scatter, heatmap)
+- Conceptual / Abstract (theory, relationships)
+
+K = 5.
+
+OUTPUT (strict JSON) → append to {workdir}/inputs/references/normalized.json
+under the key "selected":
+{
+  "selected_ids": ["ref_1", "ref_42", ...],
+  "rationale_per_pick": {
+    "ref_1": "Same category (agent_reasoning) + same visual intent (Framework pipeline)",
+    "ref_42": "Different category but same left-to-right pipeline structure"
+  }
+}
+
+Do NOT modify existing entries. Only append the "selected" key.
+```
+
+## Integration with leader Stage B
+
+Leader's `call_agent("researcher", ...)` for Stage B uses this prompt verbatim,
+substituting `{workdir}`, `S_source_context`, `C_communicative_intent`, and
+`category` from the current task context.
+
+If Stage B is skipped (pool ≤ K entries), set `selected_ids` to all `ok` entry IDs.

--- a/pantheon/factory/templates/skills/figure_styling/quality/SKILL.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/SKILL.md
@@ -1,0 +1,63 @@
+---
+id: figure_quality_index
+name: Figure Quality Evaluation Index
+description: |
+  Quality evaluation prompts for the Graph Maker Team. Covers planning,
+  styling, critic, and visual refinement prompts used across all phases.
+  Adapted from llmsresearch/paperbanana (Apache-2.0), thunlp/MatPlotAgent
+  (MIT), and rileydog53/imageGenV0 (MIT).
+---
+
+# Figure Quality Evaluation
+
+## Quality Thresholds (by scenario)
+
+| Scenario | Threshold | Max iterations T |
+|---|---|---|
+| `figure` / `graphical-abstract` | 8.5 / 10 | 3 |
+| `flowchart` | 8.0 / 10 | 2 |
+| `poster` | 7.0 / 10 | 2 |
+| `presentation` | 6.5 / 10 | 1 |
+| default (no scenario) | 8.0 / 10 | 2 |
+
+**Early stop**: when `quality_score >= threshold` OR `revised_description == null` / `revised_code_hints == "No changes needed."`, the loop terminates regardless of remaining iterations.
+
+## Four-Dimensional Evaluation Standard
+
+| Dimension | Weight | What it checks |
+|---|---|---|
+| **Faithfulness** | 30% | All components present; no hallucinations; matches S and C |
+| **Conciseness** | 20% | Labels ≤5 words; no clutter; no redundant text legend |
+| **Readability** | 30% | Labels/flow clear; font size meets scenario minimum; no overlap |
+| **Aesthetics** | 20% | Matches style_card + aesthetic_guide; publication finish |
+
+`quality_score = 0.3×F + 0.2×C + 0.3×R + 0.2×A`
+
+## Planning Prompts (Phase 1)
+
+| Prompt | File | Used by | Source |
+|---|---|---|---|
+| `diagram_planner` | [diagram_planner.md](./diagram_planner.md) | `illustrator` Phase 1 | PaperBanana |
+| `plot_planner` | [plot_planner.md](./plot_planner.md) | `data_plotter` pre-code | PaperBanana |
+
+## Styling Prompts (Phase 2)
+
+| Prompt | File | Used by | Source |
+|---|---|---|---|
+| `diagram_stylist` | [diagram_stylist.md](./diagram_stylist.md) | `illustrator` Phase 2 | PaperBanana |
+| `plot_stylist` | [plot_stylist.md](./plot_stylist.md) | `data_plotter` pre-code (optional) | PaperBanana |
+
+## Critic Prompts (Phase 4 / review loop)
+
+| Prompt | File | Used by | Source |
+|---|---|---|---|
+| `diagram_critic` | [diagram_critic.md](./diagram_critic.md) | `illustrator` Phase 4 | PaperBanana |
+| `plot_critic` | [plot_critic.md](./plot_critic.md) | `data_plotter` review loop | PaperBanana |
+| `plot_visualizer` | [plot_visualizer.md](./plot_visualizer.md) | `data_plotter` code generation | PaperBanana |
+| `visual_refine` | [visual_refine.md](./visual_refine.md) | `data_plotter` vision-based refinement | MatPlotAgent |
+
+## Specialist Skills
+
+| Skill | File | Used by | Source |
+|---|---|---|---|
+| `scientific_schematic` | [scientific_schematic.md](./scientific_schematic.md) | `illustrator` (bio/chem archetypes) | imageGenV0 |

--- a/pantheon/factory/templates/skills/figure_styling/quality/diagram_critic.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/diagram_critic.md
@@ -81,7 +81,7 @@ If the image is publication-ready with no issues:
 }
 ```
 
-`quality_score` = `0.3 × faithfulness + 0.2 × conciseness + 0.3 × readability + 0.2 × aesthetics` (0–10 scale).
+`quality_score` = `0.35 × faithfulness + 0.35 × readability + 0.30 × aesthetics` (0–10 scale). All three dimensions correspond to the output fields above; fewer issues → higher score.
 
 `visual_quality.blockers` lists any Tier 1 failures from `figure_styling/styles/visual_quality_checklist.md` — these prevent delivery.
 

--- a/pantheon/factory/templates/skills/figure_styling/quality/diagram_critic.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/diagram_critic.md
@@ -1,0 +1,147 @@
+---
+id: diagram_critic
+name: Diagram Critic
+description: |
+  Critic prompt for methodology / framework / pipeline diagrams. Evaluates
+  fidelity, text quality, clarity, and legend management. Returns JSON with
+  critic_suggestions and revised_description (null = no changes needed).
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Diagram Critic
+
+> **Source**: Adapted from `prompts/diagram/critic.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `illustrator` in Phase 4 (critic loop). Evaluates the generated diagram
+against the source context and caption. Returns specific suggestions and a
+revised description if changes are needed.
+
+## Prompt
+
+```
+## ROLE
+
+You are a Lead Visual Designer for top-tier AI conferences (e.g., NeurIPS 2025).
+
+## TASK
+Your task is to conduct a sanity check and provide a critique of the target
+diagram based on its content and presentation. You must ensure its alignment
+with the provided 'Methodology Section' and 'Figure Caption'.
+
+You are also provided with the 'Detailed Description' corresponding to the
+current diagram. If you identify areas for improvement in the diagram, you must
+list your specific critique and provide a revised version of the 'Detailed
+Description' that incorporates these corrections.
+
+## CRITIQUE & REVISION RULES
+
+1. Content
+    - **Fidelity & Alignment:** Ensure the diagram accurately reflects the method
+      described in the "Methodology Section" and aligns with the "Figure Caption."
+      Reasonable simplifications are allowed, but no critical components should be
+      omitted or misrepresented. Also, the diagram should not contain any
+      hallucinated content. Consistent with the provided methodology section &
+      figure caption is always the most important thing.
+    - **Text QA:** Check for typographical errors, nonsensical text, or unclear
+      labels within the diagram. Flag any garbled, misspelled, or non-English text.
+      Flag any hex codes, pixel dimensions, or CSS values rendered as text.
+      Suggest specific corrections.
+    - **Validation of Examples:** Verify the accuracy of illustrative examples.
+      If the diagram includes specific examples to aid understanding (e.g.,
+      molecular formulas, attention maps, mathematical expressions), ensure they
+      are factually correct and logically consistent. If an example is incorrect,
+      provide the correct version.
+    - **Caption Exclusion:** Ensure the figure caption text (e.g.,
+      "Figure 1: Overview...") is **not** included within the image visual itself.
+      The caption should remain separate.
+
+2. Presentation
+    - **Clarity & Readability:** Evaluate the overall visual clarity. If the flow
+      is confusing or the layout is cluttered, suggest structural improvements.
+    - **Legend Management:** Be aware that the description & diagram may include a
+      text-based legend explaining color coding. Since this is typically redundant,
+      please excise such descriptions if found.
+
+** IMPORTANT: **
+Your Description should primarily be modifications based on the original
+description, rather than rewriting from scratch. If the original description has
+obvious problems in certain parts that require re-description, your description
+should be as detailed as possible. Semantically, clearly describe each element
+and their connections. Formally, include various details such as background,
+colors, line thickness, icon styles, etc. Remember: vague or unclear
+specifications will only make the generated figure worse, not better.
+
+## INPUT DATA
+
+- **Methodology Section**: {source_context}
+- **Figure Caption**: {caption}
+- **Detailed Description**: {description}
+- **Target Diagram**: [The generated figure is provided as an image]
+
+## OUTPUT
+Provide your response strictly in the following JSON format:
+{
+    "round": 0,
+    "quality_score": 8.2,
+    "faithfulness_issues": ["list of issues w.r.t. S and C, or empty"],
+    "readability_issues": ["list of layout / text clarity issues, or empty"],
+    "aesthetics_issues": ["list of visual polish issues, or empty"],
+    "critic_suggestions": ["specific actionable suggestion 1", "specific actionable suggestion 2"],
+    "revised_description": "The complete revised description incorporating all suggested fixes. If no revision is needed, set to null.",
+    "visual_quality": {
+        "tier1_data_integrity": "pass",
+        "blockers": [],
+        "warnings": ["optional: non-blocking style notes"]
+    }
+}
+
+If the image is publication-ready with no issues, return:
+{
+    "round": 0,
+    "quality_score": 9.1,
+    "faithfulness_issues": [],
+    "readability_issues": [],
+    "aesthetics_issues": [],
+    "critic_suggestions": [],
+    "revised_description": null,
+    "visual_quality": {
+        "tier1_data_integrity": "pass",
+        "blockers": [],
+        "warnings": []
+    }
+}
+```
+
+`quality_score` = `0.3 × faithfulness + 0.2 × conciseness + 0.3 × readability + 0.2 × aesthetics` (0–10 scale).
+`visual_quality.blockers` lists any Tier 1 failures from `figure_styling/styles/visual_quality_checklist.md` — these prevent delivery.
+
+## Early Stop Rule
+
+`revised_description == null` → critic loop terminates. Leader marks figure
+as accepted and proceeds to vectorization / delivery.
+
+## Final Quality Gate
+
+After the critic loop exits (regardless of stop reason), run the
+**Tier 1 checks** from `figure_styling/styles/visual_quality_checklist.md`:
+
+- Axis zero baseline (if applicable)
+- Color not sole encoding dimension
+- No caption text inside image (universal guardrail)
+
+Append a `visual_quality` block to the final round's JSON:
+```json
+{
+  "visual_quality": {
+    "tier1_data_integrity": "pass",
+    "blockers": [],
+    "warnings": ["legend could be replaced by direct labels for CNS style"]
+  }
+}
+```
+
+Tier 1 blockers prevent delivery — re-delegate with specific fix instruction.

--- a/pantheon/factory/templates/skills/figure_styling/quality/diagram_critic.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/diagram_critic.md
@@ -2,7 +2,7 @@
 id: diagram_critic
 name: Diagram Critic
 description: |
-  Critic prompt for methodology / framework / pipeline diagrams. Evaluates
+  Critic instructions for methodology / framework / pipeline diagrams. Evaluates
   fidelity, text quality, clarity, and legend management. Returns JSON with
   critic_suggestions and revised_description (null = no changes needed).
 source: https://github.com/llmsresearch/paperbanana
@@ -14,76 +14,38 @@ license: Apache-2.0
 > **Source**: Adapted from `prompts/diagram/critic.txt` in
 > [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
 
-## Purpose
+You are a Lead Visual Designer for top-tier AI conferences (e.g., NeurIPS 2025). Your task is to conduct a sanity check and critique of the target diagram based on its content and presentation. Ensure its alignment with the provided Methodology Section and Figure Caption.
 
-Used by `illustrator` in Phase 4 (critic loop). Evaluates the generated diagram
-against the source context and caption. Returns specific suggestions and a
-revised description if changes are needed.
+You are also provided with the Detailed Description corresponding to the current diagram. If you identify areas for improvement, list your specific critique and provide a revised version of the Detailed Description that incorporates these corrections.
 
-## Prompt
+## Critique & Revision Rules
 
-```
-## ROLE
+### 1. Content
 
-You are a Lead Visual Designer for top-tier AI conferences (e.g., NeurIPS 2025).
+- **Fidelity & Alignment**: Ensure the diagram accurately reflects the method described in the Methodology Section and aligns with the Figure Caption. Reasonable simplifications are allowed, but no critical components should be omitted or misrepresented. No hallucinated content. Consistency with the provided methodology section and figure caption is always the most important thing.
+- **Text QA**: Check for typographical errors, nonsensical text, or unclear labels within the diagram. Flag any garbled, misspelled, or non-English text. Flag any hex codes, pixel dimensions, or CSS values rendered as text. Suggest specific corrections.
+- **Validation of Examples**: Verify the accuracy of illustrative examples (e.g., molecular formulas, attention maps, mathematical expressions). If an example is incorrect, provide the correct version.
+- **Caption Exclusion**: Ensure the figure caption text (e.g., "Figure 1: Overview...") is **not** included within the image visual itself. The caption must remain separate.
 
-## TASK
-Your task is to conduct a sanity check and provide a critique of the target
-diagram based on its content and presentation. You must ensure its alignment
-with the provided 'Methodology Section' and 'Figure Caption'.
+### 2. Presentation
 
-You are also provided with the 'Detailed Description' corresponding to the
-current diagram. If you identify areas for improvement in the diagram, you must
-list your specific critique and provide a revised version of the 'Detailed
-Description' that incorporates these corrections.
+- **Clarity & Readability**: Evaluate the overall visual clarity. If the flow is confusing or the layout is cluttered, suggest structural improvements.
+- **Legend Management**: If the description or diagram includes a text-based legend explaining color coding, this is typically redundant — excise such descriptions.
 
-## CRITIQUE & REVISION RULES
+**Important**: Your revised description should be modifications based on the original description, not a rewrite from scratch. If a specific part has obvious problems, re-describe that part in detail. Be as detailed as possible: semantically describe each element and their connections; formally include details such as background, colors, line thickness, icon styles. Vague or unclear specifications will only make the generated figure worse.
 
-1. Content
-    - **Fidelity & Alignment:** Ensure the diagram accurately reflects the method
-      described in the "Methodology Section" and aligns with the "Figure Caption."
-      Reasonable simplifications are allowed, but no critical components should be
-      omitted or misrepresented. Also, the diagram should not contain any
-      hallucinated content. Consistent with the provided methodology section &
-      figure caption is always the most important thing.
-    - **Text QA:** Check for typographical errors, nonsensical text, or unclear
-      labels within the diagram. Flag any garbled, misspelled, or non-English text.
-      Flag any hex codes, pixel dimensions, or CSS values rendered as text.
-      Suggest specific corrections.
-    - **Validation of Examples:** Verify the accuracy of illustrative examples.
-      If the diagram includes specific examples to aid understanding (e.g.,
-      molecular formulas, attention maps, mathematical expressions), ensure they
-      are factually correct and logically consistent. If an example is incorrect,
-      provide the correct version.
-    - **Caption Exclusion:** Ensure the figure caption text (e.g.,
-      "Figure 1: Overview...") is **not** included within the image visual itself.
-      The caption should remain separate.
-
-2. Presentation
-    - **Clarity & Readability:** Evaluate the overall visual clarity. If the flow
-      is confusing or the layout is cluttered, suggest structural improvements.
-    - **Legend Management:** Be aware that the description & diagram may include a
-      text-based legend explaining color coding. Since this is typically redundant,
-      please excise such descriptions if found.
-
-** IMPORTANT: **
-Your Description should primarily be modifications based on the original
-description, rather than rewriting from scratch. If the original description has
-obvious problems in certain parts that require re-description, your description
-should be as detailed as possible. Semantically, clearly describe each element
-and their connections. Formally, include various details such as background,
-colors, line thickness, icon styles, etc. Remember: vague or unclear
-specifications will only make the generated figure worse, not better.
-
-## INPUT DATA
+## Input
 
 - **Methodology Section**: {source_context}
 - **Figure Caption**: {caption}
 - **Detailed Description**: {description}
-- **Target Diagram**: [The generated figure is provided as an image]
+- **Target Diagram**: [provided as an image]
 
-## OUTPUT
-Provide your response strictly in the following JSON format:
+## Output Format
+
+Return strictly in this JSON format:
+
+```json
 {
     "round": 0,
     "quality_score": 8.2,
@@ -98,8 +60,11 @@ Provide your response strictly in the following JSON format:
         "warnings": ["optional: non-blocking style notes"]
     }
 }
+```
 
-If the image is publication-ready with no issues, return:
+If the image is publication-ready with no issues:
+
+```json
 {
     "round": 0,
     "quality_score": 9.1,
@@ -117,31 +82,19 @@ If the image is publication-ready with no issues, return:
 ```
 
 `quality_score` = `0.3 × faithfulness + 0.2 × conciseness + 0.3 × readability + 0.2 × aesthetics` (0–10 scale).
+
 `visual_quality.blockers` lists any Tier 1 failures from `figure_styling/styles/visual_quality_checklist.md` — these prevent delivery.
 
 ## Early Stop Rule
 
-`revised_description == null` → critic loop terminates. Leader marks figure
-as accepted and proceeds to vectorization / delivery.
+`revised_description == null` → critic loop terminates. Leader marks figure as accepted and proceeds to vectorization / delivery.
 
 ## Final Quality Gate
 
-After the critic loop exits (regardless of stop reason), run the
-**Tier 1 checks** from `figure_styling/styles/visual_quality_checklist.md`:
+After the critic loop exits (regardless of stop reason), run the **Tier 1 checks** from `figure_styling/styles/visual_quality_checklist.md`:
 
 - Axis zero baseline (if applicable)
 - Color not sole encoding dimension
 - No caption text inside image (universal guardrail)
 
-Append a `visual_quality` block to the final round's JSON:
-```json
-{
-  "visual_quality": {
-    "tier1_data_integrity": "pass",
-    "blockers": [],
-    "warnings": ["legend could be replaced by direct labels for CNS style"]
-  }
-}
-```
-
-Tier 1 blockers prevent delivery — re-delegate with specific fix instruction.
+Append a `visual_quality` block to the final round's JSON. Tier 1 blockers prevent delivery — re-delegate with specific fix instruction.

--- a/pantheon/factory/templates/skills/figure_styling/quality/diagram_planner.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/diagram_planner.md
@@ -1,0 +1,101 @@
+---
+id: diagram_planner
+name: Diagram Planner
+description: |
+  Phase 1 planning prompt for methodology/framework/pipeline diagrams.
+  Takes S_source_context + C_communicative_intent + reference examples,
+  outputs a detailed semantic description with aspect ratio recommendation.
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Diagram Planner
+
+> **Source**: `prompts/diagram/planner.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `illustrator` in **Phase 1 (Plan)**. Takes raw methodology text and
+a figure caption, outputs the most detailed possible semantic description of
+the diagram — without any aesthetic specification.
+
+## When to Use
+
+- Phase 1 of every illustrator task
+- Especially valuable when references are provided (they are passed as `{examples}`)
+
+## Prompt
+
+```
+I am working on a task: given the 'Methodology' section of a paper, and the
+caption of the desired figure, automatically generate a corresponding
+illustrative diagram. I will input the text of the 'Methodology' section,
+the figure caption, and your output should be a detailed description of an
+illustrative figure that effectively represents the methods described in the
+text.
+
+To help you understand the task better, and grasp the principles for
+generating such figures, I will also provide you with several examples.
+You should learn from these examples to provide your figure description.
+
+** IMPORTANT: **
+Your description should be as detailed as possible. Semantically, clearly
+describe each element and their connections. Formally, include various details
+such as background style (typically pure white or very light pastel), colors,
+line thickness, icon styles, etc. Remember: vague or unclear specifications
+will only make the generated figure worse, not better.
+
+Your description should cover:
+1. **Overall layout**: General flow direction (left-to-right or top-to-bottom),
+   major sections/phases
+2. **Components**: Each box, module, or element with its exact label
+3. **Connections**: Arrows, data flows, and their directions
+4. **Groupings**: How components are grouped or sectioned (colored regions,
+   dashed borders)
+5. **Labels and annotations**: Text labels, mathematical notations
+6. **Input/Output**: What enters and exits the system
+7. **Styling**: Background fills, color palettes (in natural language, e.g.,
+   "soft sky blue", "warm peach" — never hex codes), line weights, icon styles
+
+## Methodology Section
+{source_context}
+
+## Figure Caption
+{caption}
+
+## Reference Examples
+{examples}
+
+Based on the methodology section, figure caption, and learning from the style
+and structure of the reference examples above, generate a comprehensive and
+detailed textual description of the methodology diagram.
+
+Note: Do not include figure titles (e.g., "Figure 1: ...") in the diagram
+description. The caption should remain separate from the diagram content.
+
+## Aspect Ratio Recommendation
+
+After your detailed description, on a **new line**, output exactly one line
+in this format:
+RECOMMENDED_RATIO: <ratio>
+where <ratio> is one of: {supported_ratios}.
+
+Choose the best aspect ratio based on:
+- The **content structure**: pipelines and sequential flows → wide (16:9,
+  21:9); deep hierarchies or vertical stacks → tall (2:3, 9:16); balanced
+  architectures → square-ish (1:1, 4:3, 3:4)
+- The **reference examples' aspect ratios** listed above (if available)
+- The **number of components** and their spatial arrangement
+
+For example, a left-to-right encoder-decoder pipeline would be 16:9, while
+a top-to-bottom tree structure would be 2:3.
+```
+
+## Notes for `illustrator`
+
+- `{source_context}` = `S_source_context` from brief.json (enriched by context_enricher if run)
+- `{caption}` = `C_communicative_intent` from brief.json (sharpened by caption_sharpener if run)
+- `{examples}` = reference figure observations from `<id>_references.md` (Phase 0), or empty if no references
+- `{supported_ratios}` = the set of aspect ratios your image-gen model supports
+- Save output to `{workdir}/drafts/illustrations/<id>_plan.md`

--- a/pantheon/factory/templates/skills/figure_styling/quality/diagram_stylist.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/diagram_stylist.md
@@ -1,0 +1,102 @@
+---
+id: diagram_stylist
+name: Diagram Stylist
+description: |
+  Phase 2 styling prompt for methodology/framework/pipeline diagrams.
+  Takes the Phase 1 semantic description + aesthetic guidelines,
+  outputs a polished visual specification ready for image generation.
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Diagram Stylist
+
+> **Source**: `prompts/diagram/stylist.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `illustrator` in **Phase 2 (Style)**. Takes the Phase 1 description
+and aesthetic guidelines from `style_card.json` + the matching style file,
+outputs a publication-ready visual specification. This is the step that
+dramatically improves aesthetics without touching semantic content.
+
+## Prompt
+
+```
+You are a Lead Visual Designer for top-tier AI conferences (NeurIPS, ICML,
+ICLR, CVPR). You specialize in transforming rough diagram descriptions into
+polished, publication-ready visual specifications.
+
+You are given a Detailed Description of an academic methodology diagram, along
+with Aesthetic Guidelines, the original Source Context from the paper, and
+the Figure Caption.
+
+Your task is to refine the Detailed Description so it produces a visually
+stunning, clear, and professional academic illustration.
+
+## 6 Crucial Instructions
+
+1. **Preserve Aesthetics**: Maintain and enhance the visual quality. Use soft,
+   muted pastel colors described in natural language (e.g., "soft sky blue",
+   "warm peach", "light sage green"). NEVER output hex color codes, pixel
+   dimensions, point sizes, or CSS-like specifications — these will be
+   rendered as garbled text in the final image.
+
+2. **Intervene Only When Necessary**: If the description already describes a
+   high-quality, professional visual design, PRESERVE IT. Do not rewrite for
+   the sake of rewriting. Focus your edits on areas that genuinely need
+   improvement.
+
+3. **Respect Diversity**: Different diagram styles (flowcharts, architecture
+   diagrams, pipeline visualizations) have different conventions. Adapt your
+   refinements to the specific diagram type rather than forcing a single
+   template. For example, agent/LLM papers often use illustrative icons (cute
+   2D robot avatars, chat bubbles), while theoretical papers use minimalist
+   graph nodes — respect these domain conventions.
+
+4. **Enrich Details**: Where the description is vague about visual properties,
+   add specific but natural-language guidance. For example, instead of leaving
+   "a box labeled X", specify "a rounded rectangle with soft blue fill and a
+   slightly darker blue border, labeled X in bold sans-serif text".
+
+5. **Preserve Content**: Do NOT add, remove, or modify any components,
+   connections, or labels from the original description. Your role is purely
+   visual refinement — the content and structure must remain exactly as
+   specified.
+
+6. **Handle Icons with Care**: Be cautious when modifying icons — they may
+   carry specific semantic meanings in the research context. Some icons have
+   conventional technical meanings (e.g., snowflake ❄️ = frozen/non-trainable
+   parameters, flame 🔥 = trainable/fine-tuned parameters, padlock 🔒 =
+   locked/static). When encountering such icons, reference the Source Context
+   to verify their intent before making changes.
+
+## Aesthetic Guidelines
+{guidelines}
+
+## Source Context
+{source_context}
+
+## Figure Caption
+{caption}
+
+## Current Description
+Note: Your primary focus should be on the Current Description and Aesthetic
+Guidelines. The Source Context and Figure Caption are provided for reference
+only — do not regenerate a description from scratch based solely on them while
+ignoring the existing description.
+{description}
+
+Output ONLY the final polished Detailed Description. Do not include any
+conversational text, explanations, or preamble.
+```
+
+## Notes for `illustrator`
+
+- `{guidelines}` = content of `figure_styling/styles/<aesthetic_guide>.md` (e.g. `neurips_diagram.md`) — load this file and paste its content here. If references override the guide, prepend the reference-based guidance.
+- `{source_context}` = `S_source_context` from brief.json
+- `{caption}` = `C_communicative_intent` from brief.json
+- `{description}` = content of `{workdir}/drafts/illustrations/<id>_plan.md` (Phase 1 output)
+- Save output to `{workdir}/drafts/illustrations/<id>_style.md`
+- **Color rule**: never output hex codes in the image-gen prompt — they render as garbled text. Use natural-language color names only in the stylist output.

--- a/pantheon/factory/templates/skills/figure_styling/quality/figure_caption.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/figure_caption.md
@@ -1,0 +1,138 @@
+---
+id: figure_caption
+name: Figure Caption Writer
+description: |
+  Generate a publication-ready figure caption after the figure is produced.
+  Starts with "Overview of..." or a direct summary, 1-3 sentences, standalone.
+  Adapted from llmsresearch/paperbanana prompts/diagram/caption.txt and
+  prompts/plot/caption.txt (Apache-2.0).
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Figure Caption Writer
+
+> **Source**: Adapted from `prompts/diagram/caption.txt` and
+> `prompts/plot/caption.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `leader` in **Step 9** (Manifest and legends). After sub-agents deliver
+their final figures, leader generates a publication-ready caption for each figure
+and appends it to `{workdir}/.canvas/figure_legends.md`.
+
+## When to Use
+
+Always — for every figure produced, regardless of scenario. Caption quality
+directly determines whether the figure is usable in a paper submission.
+
+## Prompt (diagram figures — illustrator output)
+
+```
+## ROLE
+You are an expert academic writer specializing in figure captions for top-tier
+AI/ML conference papers (NeurIPS, ICML, ICLR, CVPR, ACL) and biology/medicine
+journals (Nature, Cell, Science).
+
+## TASK
+Given the methodology section, the communicative intent, the detailed visual
+description, and the final generated diagram, write a publication-ready figure
+caption.
+
+## CAPTION RULES
+1. **Length**: 1–3 sentences. No more.
+2. **Structure**: Start with a brief label like "Overview of [method/framework]."
+   or "Illustration of [concept]." Follow with 1–2 sentences describing what the
+   diagram shows and how it connects to the paper's contribution.
+3. **Standalone**: The caption must be fully understandable without reading the
+   paper body. Introduce necessary acronyms on first use.
+4. **Precise**: Use exact method names, module names, and terminology from the
+   source context. Do not invent names not present in the source.
+5. **No figure number**: Do not include "Figure 1:" or any numbering — the
+   template handles that.
+6. **Active voice**: Prefer active, concise constructions over passive.
+7. **No meta-language**: Do not say "This figure shows..." — describe directly.
+
+## INPUT DATA
+- **Source Context (S)**: {source_context}
+- **Communicative Intent (C)**: {communicative_intent}
+- **Visual Description**: {description}
+- **Final Diagram**: [The generated figure is provided as an image — describe
+  what is visible if image not available]
+
+## OUTPUT
+Return only the caption text. No JSON, no markdown, no extra commentary.
+Plain text only.
+```
+
+## Prompt (statistical plots — data_plotter output)
+
+```
+## ROLE
+You are an expert academic writer specializing in figure captions for top-tier
+AI/ML conference papers and scientific journals.
+
+## TASK
+Given the data context, the communicative intent, the visual description, and
+the final generated statistical plot, write a publication-ready figure caption.
+
+## CAPTION RULES
+1. **Length**: 1–3 sentences. No more.
+2. **Structure**: Start with a brief summary of what the plot shows. Follow with
+   1–2 sentences highlighting the key takeaway or trend.
+3. **Standalone**: Fully understandable without reading the paper body.
+4. **Precise**: Reference exact metrics, baselines, datasets, or model names
+   present in the data. Do not invent terms not present in the source.
+5. **No figure number**: Do not include "Figure 1:" or any numbering.
+6. **Active voice**: Prefer active, concise constructions.
+7. **No meta-language**: Do not say "This figure shows..." — describe directly.
+8. **Highlight insight**: Briefly note the most important result or trend.
+
+## INPUT DATA
+- **Data Context (S)**: {source_context}
+- **Communicative Intent (C)**: {communicative_intent}
+- **Visual Description**: {description}
+- **Final Plot**: [The generated plot is provided as an image]
+
+## OUTPUT
+Return only the caption text. No JSON, no markdown, no extra commentary.
+Plain text only.
+```
+
+## Usage in `leader` Step 9
+
+For each figure after production and verification:
+
+```
+# Determine which prompt to use
+if figure.source_agent == "data_plotter":
+    prompt = plot_caption_prompt
+else:
+    prompt = diagram_caption_prompt
+
+# Call researcher (or inline reasoning) with the caption prompt
+caption_text = call_agent("researcher",
+  "<use the appropriate prompt above, substituting:
+   - {source_context} = S_source_context from brief.json for this figure
+   - {communicative_intent} = C_communicative_intent from brief.json
+   - {description} = the final accepted description (from _style.md or last round JSON)
+   - Attach the final PNG for visual grounding if possible>")
+
+# Append to figure_legends.md
+append to {workdir}/.canvas/figure_legends.md:
+  ## {figure.name}
+  {caption_text}
+  (Source: {figure.source_agent}, aesthetic_guide: {style_card.aesthetic_guide},
+   critic_rounds: {trace.rounds_executed})
+```
+
+## Caption Length by Scenario
+
+| Scenario | Target length | Notes |
+|---|---|---|
+| `figure` (journal) | 2–3 sentences | Include key result or method insight |
+| `graphical-abstract` | 1–2 sentences | Single clear message only |
+| `poster` | 1 sentence per panel | Short, direct — poster has limited space |
+| `presentation` | 1 sentence | Slide caption is spoken, not read |
+| `flowchart` | 2 sentences | Describe what process and what output |

--- a/pantheon/factory/templates/skills/figure_styling/quality/figure_caption.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/figure_caption.md
@@ -12,120 +12,61 @@ license: Apache-2.0
 
 # Figure Caption Writer
 
-> **Source**: Adapted from `prompts/diagram/caption.txt` and
-> `prompts/plot/caption.txt` in
+> **Source**: Adapted from `prompts/diagram/caption.txt` and `prompts/plot/caption.txt` in
 > [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
 
-## Purpose
+You are an expert academic writer specializing in figure captions for top-tier AI/ML conference papers (NeurIPS, ICML, ICLR, CVPR, ACL) and biology/medicine journals (Nature, Cell, Science).
 
-Used by `leader` in **Step 9** (Manifest and legends). After sub-agents deliver
-their final figures, leader generates a publication-ready caption for each figure
-and appends it to `{workdir}/.canvas/figure_legends.md`.
+Select the appropriate section below based on figure type:
+- **Diagram figures** (illustrator output) → use [Diagram Caption Rules](#diagram-caption-rules)
+- **Statistical plots** (data_plotter output) → use [Plot Caption Rules](#plot-caption-rules)
 
-## When to Use
+## Diagram Caption Rules
 
-Always — for every figure produced, regardless of scenario. Caption quality
-directly determines whether the figure is usable in a paper submission.
+Given the methodology section, the communicative intent, the detailed visual description, and the final generated diagram, write a publication-ready figure caption.
 
-## Prompt (diagram figures — illustrator output)
-
-```
-## ROLE
-You are an expert academic writer specializing in figure captions for top-tier
-AI/ML conference papers (NeurIPS, ICML, ICLR, CVPR, ACL) and biology/medicine
-journals (Nature, Cell, Science).
-
-## TASK
-Given the methodology section, the communicative intent, the detailed visual
-description, and the final generated diagram, write a publication-ready figure
-caption.
-
-## CAPTION RULES
+**Rules**:
 1. **Length**: 1–3 sentences. No more.
-2. **Structure**: Start with a brief label like "Overview of [method/framework]."
-   or "Illustration of [concept]." Follow with 1–2 sentences describing what the
-   diagram shows and how it connects to the paper's contribution.
-3. **Standalone**: The caption must be fully understandable without reading the
-   paper body. Introduce necessary acronyms on first use.
-4. **Precise**: Use exact method names, module names, and terminology from the
-   source context. Do not invent names not present in the source.
-5. **No figure number**: Do not include "Figure 1:" or any numbering — the
-   template handles that.
+2. **Structure**: Start with a brief label like "Overview of [method/framework]." or "Illustration of [concept]." Follow with 1–2 sentences describing what the diagram shows and how it connects to the paper's contribution.
+3. **Standalone**: The caption must be fully understandable without reading the paper body. Introduce necessary acronyms on first use.
+4. **Precise**: Use exact method names, module names, and terminology from the source context. Do not invent names not present in the source.
+5. **No figure number**: Do not include "Figure 1:" or any numbering — the template handles that.
 6. **Active voice**: Prefer active, concise constructions over passive.
 7. **No meta-language**: Do not say "This figure shows..." — describe directly.
 
-## INPUT DATA
+**Input**:
 - **Source Context (S)**: {source_context}
 - **Communicative Intent (C)**: {communicative_intent}
 - **Visual Description**: {description}
-- **Final Diagram**: [The generated figure is provided as an image — describe
-  what is visible if image not available]
+- **Final Diagram**: [provided as an image — describe what is visible if image not available]
 
-## OUTPUT
-Return only the caption text. No JSON, no markdown, no extra commentary.
-Plain text only.
-```
+**Output**: Return only the caption text. No JSON, no markdown, no extra commentary. Plain text only.
 
-## Prompt (statistical plots — data_plotter output)
+---
 
-```
-## ROLE
-You are an expert academic writer specializing in figure captions for top-tier
-AI/ML conference papers and scientific journals.
+## Plot Caption Rules
 
-## TASK
-Given the data context, the communicative intent, the visual description, and
-the final generated statistical plot, write a publication-ready figure caption.
+Given the data context, the communicative intent, the visual description, and the final generated statistical plot, write a publication-ready figure caption.
 
-## CAPTION RULES
+**Rules**:
 1. **Length**: 1–3 sentences. No more.
-2. **Structure**: Start with a brief summary of what the plot shows. Follow with
-   1–2 sentences highlighting the key takeaway or trend.
+2. **Structure**: Start with a brief summary of what the plot shows. Follow with 1–2 sentences highlighting the key takeaway or trend.
 3. **Standalone**: Fully understandable without reading the paper body.
-4. **Precise**: Reference exact metrics, baselines, datasets, or model names
-   present in the data. Do not invent terms not present in the source.
+4. **Precise**: Reference exact metrics, baselines, datasets, or model names present in the data. Do not invent terms not present in the source.
 5. **No figure number**: Do not include "Figure 1:" or any numbering.
 6. **Active voice**: Prefer active, concise constructions.
 7. **No meta-language**: Do not say "This figure shows..." — describe directly.
 8. **Highlight insight**: Briefly note the most important result or trend.
 
-## INPUT DATA
+**Input**:
 - **Data Context (S)**: {source_context}
 - **Communicative Intent (C)**: {communicative_intent}
 - **Visual Description**: {description}
-- **Final Plot**: [The generated plot is provided as an image]
+- **Final Plot**: [provided as an image]
 
-## OUTPUT
-Return only the caption text. No JSON, no markdown, no extra commentary.
-Plain text only.
-```
+**Output**: Return only the caption text. No JSON, no markdown, no extra commentary. Plain text only.
 
-## Usage in `leader` Step 9
-
-For each figure after production and verification:
-
-```
-# Determine which prompt to use
-if figure.source_agent == "data_plotter":
-    prompt = plot_caption_prompt
-else:
-    prompt = diagram_caption_prompt
-
-# Call researcher (or inline reasoning) with the caption prompt
-caption_text = call_agent("researcher",
-  "<use the appropriate prompt above, substituting:
-   - {source_context} = S_source_context from brief.json for this figure
-   - {communicative_intent} = C_communicative_intent from brief.json
-   - {description} = the final accepted description (from _style.md or last round JSON)
-   - Attach the final PNG for visual grounding if possible>")
-
-# Append to figure_legends.md
-append to {workdir}/.canvas/figure_legends.md:
-  ## {figure.name}
-  {caption_text}
-  (Source: {figure.source_agent}, aesthetic_guide: {style_card.aesthetic_guide},
-   critic_rounds: {trace.rounds_executed})
-```
+---
 
 ## Caption Length by Scenario
 
@@ -136,3 +77,20 @@ append to {workdir}/.canvas/figure_legends.md:
 | `poster` | 1 sentence per panel | Short, direct — poster has limited space |
 | `presentation` | 1 sentence | Slide caption is spoken, not read |
 | `flowchart` | 2 sentences | Describe what process and what output |
+
+## Leader Step 9 Usage
+
+For each figure after production and verification, determine figure type from `source_agent` field in the brief:
+
+- `source_agent == "data_plotter"` → use Plot Caption Rules
+- `source_agent == "illustrator"` → use Diagram Caption Rules
+
+Substitute `{source_context}`, `{communicative_intent}`, `{description}` from the figure's `brief.json`. Attach the final PNG for visual grounding.
+
+Append to `{workdir}/.canvas/figure_legends.md`:
+
+```
+## {figure.name}
+{caption_text}
+(Source: {source_agent}, aesthetic_guide: {style_card.aesthetic_guide}, critic_rounds: {trace.rounds_executed})
+```

--- a/pantheon/factory/templates/skills/figure_styling/quality/figure_caption.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/figure_caption.md
@@ -78,7 +78,7 @@ Given the data context, the communicative intent, the visual description, and th
 | `presentation` | 1 sentence | Slide caption is spoken, not read |
 | `flowchart` | 2 sentences | Describe what process and what output |
 
-## Leader Step 9 Usage
+## Usage
 
 For each figure after production and verification, determine figure type from `source_agent` field in the brief:
 

--- a/pantheon/factory/templates/skills/figure_styling/quality/figure_format_lint.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/figure_format_lint.md
@@ -1,0 +1,103 @@
+---
+id: figure_format_lint
+name: Figure Format Lint
+description: |
+  Check figure deliverables for format compliance: file naming, DPI,
+  file format integrity, style_card consistency, caption presence,
+  figure numbering continuity, and export completeness.
+---
+
+# Figure Format Lint
+
+## When to Use
+
+- Verification phase — before writing the manifest
+- After critic loop exits — confirm deliverables are actually correct on disk
+- Before any submission-mode export
+
+## Checklist
+
+### 1. File Naming (semantic, no raw paths)
+
+- [ ] All filenames in `.canvas/assets/` are **semantic**: `Fig1_umap_celltypes.png`, not `output.png`, `test.png`, `tmp_fig.png`
+- [ ] Filename contains figure ID: `Fig1_`, `Fig2_`, etc.
+- [ ] No workdir path segments visible in filename (no `workspace_abc123_fig.png`)
+- [ ] Multi-panel composite figures named with `_composite` suffix: `Fig1_composite.png`
+
+### 2. File Format Integrity
+
+- [ ] **PNG**: `file <path>` returns `PNG image data` — non-zero size
+- [ ] **PDF** (if in `export_formats`): first 4 bytes are `%PDF` — non-zero size, version ≥ 1.4
+- [ ] **SVG** (if in `export_formats`): file contains `<svg` root element — non-zero size
+- [ ] No file is 0 bytes or a broken placeholder
+
+### 3. DPI Compliance
+
+- [ ] PNG DPI matches `style_card.dpi_final` (check with `identify -verbose <file> | grep Resolution` or PIL)
+- [ ] `figure` / `graphical-abstract` scenario: DPI ≥ 600
+- [ ] `poster` scenario: DPI ≥ 300
+- [ ] `presentation` scenario: DPI ≥ 150
+
+```python
+from PIL import Image
+img = Image.open(png_path)
+dpi = img.info.get("dpi", (72, 72))
+assert dpi[0] >= required_dpi, f"DPI {dpi[0]} < required {required_dpi}"
+```
+
+### 4. Style Card Compliance
+
+- [ ] `font_size.axis_label` matches `aesthetic_guide` spec:
+  - `nature_figure` → 7 pt; `neurips_*` → 9–10 pt; `ieee_figure` → 8 pt
+- [ ] `categorical_palette` is Paul Tol bright or a named override (not `Dark2`)
+- [ ] `export_formats` matches scenario defaults:
+  - `figure` → `["png", "pdf", "svg"]`; `poster` → `["png", "pdf"]`; `presentation` → `["png"]`
+- [ ] `dpi_final` is consistent with scenario (not accidentally left at 72 or 96)
+
+### 5. Caption Completeness
+
+- [ ] `figure_legends.md` exists at `{workdir}/.canvas/figure_legends.md`
+- [ ] Every figure in `figure_manifest.json` has a corresponding `##` section in `figure_legends.md`
+- [ ] No caption section is empty (check for `##` followed immediately by another `##`)
+- [ ] Caption does not contain figure number prefix (`Figure 1:`, `Fig. 1.`) — numbering is handled by document template
+
+### 6. Figure Numbering Continuity
+
+- [ ] Figure IDs in `figure_manifest.json` are sequential: Fig1, Fig2, Fig3 … (no gaps, no duplicates)
+- [ ] Panel letters within a composite figure are sequential: a, b, c … (no gaps)
+- [ ] If supplementary figures exist: labeled `FigS1`, `FigS2`, not `Fig7`, `Fig8`
+
+### 7. Export Completeness
+
+For each figure in the manifest:
+- [ ] PNG always present
+- [ ] PDF present iff `"pdf" in style_card.export_formats`
+- [ ] SVG present iff `"svg" in style_card.export_formats`
+- [ ] No orphaned files in `.canvas/assets/` that are not in the manifest
+
+### 8. No Caption Text Inside Images
+
+- [ ] `observe_images` did not flag caption-looking text in any PNG
+- [ ] Critic loop confirmed `caption_exclusion: pass` for all rounds
+
+## Output (append to leader verification notes)
+
+```json
+{
+  "format_lint": {
+    "file_naming": "pass | fail",
+    "file_integrity": "pass | fail",
+    "dpi_compliance": "pass | fail",
+    "style_card_compliance": "pass | fail",
+    "caption_completeness": "pass | fail",
+    "numbering_continuity": "pass | fail",
+    "export_completeness": "pass | fail",
+    "caption_not_in_image": "pass | fail",
+    "blockers": ["list of failures that prevent delivery"],
+    "warnings": ["list of non-blocking issues"]
+  }
+}
+```
+
+Any `"fail"` in `blockers` → do not deliver, fix first.
+`"warnings"` are noted in the delivery summary but do not block.

--- a/pantheon/factory/templates/skills/figure_styling/quality/plot_critic.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/plot_critic.md
@@ -1,0 +1,130 @@
+---
+id: plot_critic
+name: Plot Critic
+description: |
+  Critic prompt for statistical plots. Evaluates data fidelity, text quality,
+  overlap/layout, and handles generation failures. Returns JSON with
+  critic_suggestions and revised_description (null = no changes needed).
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Plot Critic
+
+> **Source**: Adapted from `prompts/plot/critic.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `data_plotter` in its review loop. Evaluates the rendered plot against
+the raw data and visual intent. Handles generation failures (missing/broken plots).
+
+## Prompt
+
+```
+## ROLE
+
+You are a Lead Visual Designer for top-tier AI conferences (e.g., NeurIPS 2025).
+
+## TASK
+Your task is to conduct a sanity check and provide a critique of the target plot
+based on its content and presentation. You must ensure its alignment with the
+provided 'Raw Data' and 'Visual Intent'.
+
+You are also provided with the 'Detailed Description' corresponding to the
+current plot. If you identify areas for improvement in the plot, you must list
+your specific critique and provide a revised version of the 'Detailed
+Description' that incorporates these corrections.
+
+## CRITIQUE & REVISION RULES
+
+1. Content
+    - **Data Fidelity & Alignment:** Ensure the plot accurately represents all
+      data points from the "Raw Data" and aligns with the "Visual Intent." All
+      quantitative values must be correct. No data should be hallucinated,
+      omitted, or misrepresented.
+    - **Text QA:** Check for typographical errors, nonsensical text, or unclear
+      labels within the plot (axis labels, legend entries, annotations). Suggest
+      specific corrections.
+    - **Validation of Values:** Verify the accuracy of all numerical values,
+      axis scales, and data points. If any values are incorrect or inconsistent
+      with the raw data, provide the correct values.
+    - **Caption Exclusion:** Ensure the figure caption text (e.g.,
+      "Figure 1: Performance comparison...") is **not** included within the
+      image visual itself. The caption should remain separate.
+
+2. Presentation
+    - **Clarity & Readability:** Evaluate the overall visual clarity. If the
+      plot is confusing, cluttered, or hard to interpret, suggest structural
+      improvements (e.g., better axis labeling, clearer legend, appropriate
+      plot type).
+    - **Overlap & Layout:** Check for any overlapping elements that reduce
+      readability, such as text labels being obscured by heavy hatching, grid
+      lines, or other chart elements (e.g., pie chart labels inside dark slices).
+      If overlaps exist, suggest adjusting element positions (e.g., moving labels
+      outside the chart, using leader lines, or adjusting transparency).
+    - **Legend Management:** Be aware that the description & plot may include a
+      text-based legend explaining symbols or colors. Since this is typically
+      redundant in well-designed plots, please excise such descriptions if found.
+
+3. Handling Generation Failures
+    - **Invalid Plot:** If the target plot is missing or replaced by a system
+      notice (e.g., "[SYSTEM NOTICE]"), it means the previous description
+      generated invalid code.
+    - **Action:** You must carefully analyze the "Detailed Description" for
+      potential logical errors, complex syntax, or missing data references.
+    - **Revision:** Provide a simplified and robust version of the description
+      to ensure it can be correctly rendered. Do not just repeat the same
+      description.
+
+## INPUT DATA
+
+- **Raw Data**: {source_context}
+- **Visual Intent**: {caption}
+- **Detailed Description**: {description}
+- **Target Plot**: [The generated plot is provided as an image]
+
+## OUTPUT
+Provide your response strictly in the following JSON format:
+{
+    "critic_suggestions": ["specific actionable suggestion 1", "specific actionable suggestion 2"],
+    "revised_description": "The complete revised description incorporating all suggested fixes. If no revision is needed, set to null."
+}
+
+If the plot is publication-ready with no issues, return:
+{
+    "critic_suggestions": [],
+    "revised_description": null
+}
+```
+
+## Early Stop Rule
+
+`revised_description == null` → review loop terminates. `data_plotter` proceeds
+to export (PNG + PDF/SVG per `style_card.export_formats`).
+
+## Final Quality Gate
+
+After the critic loop exits, run **Tier 1–4 checks** from
+`figure_styling/styles/visual_quality_checklist.md`:
+
+- **Tier 1**: axis zero baseline, error bar definition, no dual-axis distortion
+- **Tier 2**: no chartjunk, no redundant legend, minimal spines
+- **Tier 3**: axis labels have units, font hierarchy consistent
+- **Tier 4**: colorblind-safe palette, no Jet/Rainbow
+
+Append a `visual_quality` block to the final round's JSON:
+```json
+{
+  "visual_quality": {
+    "tier1_data_integrity": "pass",
+    "tier2_data_ink": "warning",
+    "tier3_typography": "pass",
+    "tier4_color": "pass",
+    "blockers": [],
+    "warnings": ["floating legend could be replaced by direct annotation"]
+  }
+}
+```
+
+Tier 1 blockers prevent delivery.

--- a/pantheon/factory/templates/skills/figure_styling/quality/plot_critic.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/plot_critic.md
@@ -48,12 +48,27 @@ You are also provided with the Detailed Description corresponding to the current
 
 ## Output Format
 
-Return strictly in this JSON format:
+Return strictly in this JSON format (aligned with `diagram_critic.md` so leader can read both sub-agents' quality results uniformly):
 
 ```json
 {
+    "round": 1,
+    "quality_score": 8.2,
+    "faithfulness_issues": ["list of data fidelity issues, or empty"],
+    "readability_issues": ["list of layout / text clarity issues, or empty"],
+    "aesthetics_issues": ["list of visual polish issues, or empty"],
     "critic_suggestions": ["specific actionable suggestion 1", "specific actionable suggestion 2"],
-    "revised_description": "The complete revised description incorporating all suggested fixes. If no revision is needed, set to null."
+    "visual_quality": {
+        "tier1_data_integrity": "pass",
+        "tier2_data_ink": "pass",
+        "tier3_typography": "pass",
+        "tier4_color": "pass",
+        "tier1_blockers": [],
+        "warnings": [],
+        "passed": true
+    },
+    "revised_description": "The complete revised description incorporating all suggested fixes. If no revision is needed, set to null.",
+    "early_stop": false
 }
 ```
 
@@ -61,14 +76,31 @@ If the plot is publication-ready with no issues:
 
 ```json
 {
+    "round": 0,
+    "quality_score": 9.1,
+    "faithfulness_issues": [],
+    "readability_issues": [],
+    "aesthetics_issues": [],
     "critic_suggestions": [],
-    "revised_description": null
+    "visual_quality": {
+        "tier1_data_integrity": "pass",
+        "tier2_data_ink": "pass",
+        "tier3_typography": "pass",
+        "tier4_color": "pass",
+        "tier1_blockers": [],
+        "warnings": [],
+        "passed": true
+    },
+    "revised_description": null,
+    "early_stop": true
 }
 ```
 
+`quality_score` = `0.35 × faithfulness + 0.35 × readability + 0.30 × aesthetics` (0–10 scale). Derived from the critic issues: fewer issues → higher score.
+
 ## Early Stop Rule
 
-`revised_description == null` → review loop terminates. `data_plotter` proceeds to export (PNG + PDF/SVG per `style_card.export_formats`).
+`revised_description == null` OR `quality_score >= 8.5` → review loop terminates. `data_plotter` proceeds to export (PNG + PDF/SVG per `style_card.export_formats`).
 
 ## Final Quality Gate
 
@@ -79,7 +111,7 @@ After the critic loop exits, run **Tier 1–4 checks** from `figure_styling/styl
 - **Tier 3**: axis labels have units, font hierarchy consistent
 - **Tier 4**: colorblind-safe palette, no Jet/Rainbow
 
-Append a `visual_quality` block to the final round's JSON:
+Populate the `visual_quality` block in the output JSON using the results of these checks:
 
 ```json
 {

--- a/pantheon/factory/templates/skills/figure_styling/quality/plot_critic.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/plot_critic.md
@@ -2,7 +2,7 @@
 id: plot_critic
 name: Plot Critic
 description: |
-  Critic prompt for statistical plots. Evaluates data fidelity, text quality,
+  Critic instructions for statistical plots. Evaluates data fidelity, text quality,
   overlap/layout, and handles generation failures. Returns JSON with
   critic_suggestions and revised_description (null = no changes needed).
 source: https://github.com/llmsresearch/paperbanana
@@ -14,84 +14,52 @@ license: Apache-2.0
 > **Source**: Adapted from `prompts/plot/critic.txt` in
 > [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
 
-## Purpose
+You are a Lead Visual Designer for top-tier AI conferences (e.g., NeurIPS 2025). Your task is to conduct a sanity check and critique of the target plot based on its content and presentation. Ensure its alignment with the provided Raw Data and Visual Intent.
 
-Used by `data_plotter` in its review loop. Evaluates the rendered plot against
-the raw data and visual intent. Handles generation failures (missing/broken plots).
+You are also provided with the Detailed Description corresponding to the current plot. If you identify areas for improvement, list your specific critique and provide a revised version of the Detailed Description that incorporates these corrections.
 
-## Prompt
+## Critique & Revision Rules
 
-```
-## ROLE
+### 1. Content
 
-You are a Lead Visual Designer for top-tier AI conferences (e.g., NeurIPS 2025).
+- **Data Fidelity & Alignment**: Ensure the plot accurately represents all data points from the Raw Data and aligns with the Visual Intent. All quantitative values must be correct. No data should be hallucinated, omitted, or misrepresented.
+- **Text QA**: Check for typographical errors, nonsensical text, or unclear labels within the plot (axis labels, legend entries, annotations). Suggest specific corrections.
+- **Validation of Values**: Verify the accuracy of all numerical values, axis scales, and data points. If any values are incorrect or inconsistent with the raw data, provide the correct values.
+- **Caption Exclusion**: Ensure the figure caption text (e.g., "Figure 1: Performance comparison...") is **not** included within the image visual itself. The caption must remain separate.
 
-## TASK
-Your task is to conduct a sanity check and provide a critique of the target plot
-based on its content and presentation. You must ensure its alignment with the
-provided 'Raw Data' and 'Visual Intent'.
+### 2. Presentation
 
-You are also provided with the 'Detailed Description' corresponding to the
-current plot. If you identify areas for improvement in the plot, you must list
-your specific critique and provide a revised version of the 'Detailed
-Description' that incorporates these corrections.
+- **Clarity & Readability**: Evaluate the overall visual clarity. If the plot is confusing, cluttered, or hard to interpret, suggest structural improvements (e.g., better axis labeling, clearer legend, appropriate plot type).
+- **Overlap & Layout**: Check for overlapping elements that reduce readability — text labels obscured by heavy hatching, grid lines, or other chart elements (e.g., pie chart labels inside dark slices). If overlaps exist, suggest adjusting element positions (e.g., moving labels outside the chart, using leader lines, or adjusting transparency).
+- **Legend Management**: If the description or plot includes a text-based legend explaining symbols or colors and it is redundant, excise it.
 
-## CRITIQUE & REVISION RULES
+### 3. Handling Generation Failures
 
-1. Content
-    - **Data Fidelity & Alignment:** Ensure the plot accurately represents all
-      data points from the "Raw Data" and aligns with the "Visual Intent." All
-      quantitative values must be correct. No data should be hallucinated,
-      omitted, or misrepresented.
-    - **Text QA:** Check for typographical errors, nonsensical text, or unclear
-      labels within the plot (axis labels, legend entries, annotations). Suggest
-      specific corrections.
-    - **Validation of Values:** Verify the accuracy of all numerical values,
-      axis scales, and data points. If any values are incorrect or inconsistent
-      with the raw data, provide the correct values.
-    - **Caption Exclusion:** Ensure the figure caption text (e.g.,
-      "Figure 1: Performance comparison...") is **not** included within the
-      image visual itself. The caption should remain separate.
+- **Invalid Plot**: If the target plot is missing or replaced by a system notice (e.g., "[SYSTEM NOTICE]"), the previous description generated invalid code.
+- **Action**: Carefully analyze the Detailed Description for potential logical errors, complex syntax, or missing data references.
+- **Revision**: Provide a simplified and robust version of the description to ensure correct rendering. Do not repeat the same description.
 
-2. Presentation
-    - **Clarity & Readability:** Evaluate the overall visual clarity. If the
-      plot is confusing, cluttered, or hard to interpret, suggest structural
-      improvements (e.g., better axis labeling, clearer legend, appropriate
-      plot type).
-    - **Overlap & Layout:** Check for any overlapping elements that reduce
-      readability, such as text labels being obscured by heavy hatching, grid
-      lines, or other chart elements (e.g., pie chart labels inside dark slices).
-      If overlaps exist, suggest adjusting element positions (e.g., moving labels
-      outside the chart, using leader lines, or adjusting transparency).
-    - **Legend Management:** Be aware that the description & plot may include a
-      text-based legend explaining symbols or colors. Since this is typically
-      redundant in well-designed plots, please excise such descriptions if found.
-
-3. Handling Generation Failures
-    - **Invalid Plot:** If the target plot is missing or replaced by a system
-      notice (e.g., "[SYSTEM NOTICE]"), it means the previous description
-      generated invalid code.
-    - **Action:** You must carefully analyze the "Detailed Description" for
-      potential logical errors, complex syntax, or missing data references.
-    - **Revision:** Provide a simplified and robust version of the description
-      to ensure it can be correctly rendered. Do not just repeat the same
-      description.
-
-## INPUT DATA
+## Input
 
 - **Raw Data**: {source_context}
 - **Visual Intent**: {caption}
 - **Detailed Description**: {description}
-- **Target Plot**: [The generated plot is provided as an image]
+- **Target Plot**: [provided as an image]
 
-## OUTPUT
-Provide your response strictly in the following JSON format:
+## Output Format
+
+Return strictly in this JSON format:
+
+```json
 {
     "critic_suggestions": ["specific actionable suggestion 1", "specific actionable suggestion 2"],
     "revised_description": "The complete revised description incorporating all suggested fixes. If no revision is needed, set to null."
 }
+```
 
-If the plot is publication-ready with no issues, return:
+If the plot is publication-ready with no issues:
+
+```json
 {
     "critic_suggestions": [],
     "revised_description": null
@@ -100,13 +68,11 @@ If the plot is publication-ready with no issues, return:
 
 ## Early Stop Rule
 
-`revised_description == null` → review loop terminates. `data_plotter` proceeds
-to export (PNG + PDF/SVG per `style_card.export_formats`).
+`revised_description == null` → review loop terminates. `data_plotter` proceeds to export (PNG + PDF/SVG per `style_card.export_formats`).
 
 ## Final Quality Gate
 
-After the critic loop exits, run **Tier 1–4 checks** from
-`figure_styling/styles/visual_quality_checklist.md`:
+After the critic loop exits, run **Tier 1–4 checks** from `figure_styling/styles/visual_quality_checklist.md`:
 
 - **Tier 1**: axis zero baseline, error bar definition, no dual-axis distortion
 - **Tier 2**: no chartjunk, no redundant legend, minimal spines
@@ -114,6 +80,7 @@ After the critic loop exits, run **Tier 1–4 checks** from
 - **Tier 4**: colorblind-safe palette, no Jet/Rainbow
 
 Append a `visual_quality` block to the final round's JSON:
+
 ```json
 {
   "visual_quality": {

--- a/pantheon/factory/templates/skills/figure_styling/quality/plot_planner.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/plot_planner.md
@@ -1,0 +1,73 @@
+---
+id: plot_planner
+name: Plot Planner
+description: |
+  Planning prompt for statistical plots. Takes raw data + visual intent,
+  outputs a detailed description with exact data point coordinates and
+  aesthetic parameters ready for code generation.
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Plot Planner
+
+> **Source**: `prompts/plot/planner.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `data_plotter` before code generation. Takes raw data and a visual
+intent, outputs a comprehensive description that maps every data point to
+visual channels with full aesthetic specification.
+
+## When to Use
+
+- When user provides raw data (CSV, JSON, table) and a vague plot intent
+- When `context_enricher` has run but the plot description still lacks
+  exact variable-to-channel mapping and style parameters
+
+## Prompt
+
+```
+I am working on a task: given the raw data (typically in tabular or json
+format) and a visual intent of the desired plot, automatically generate a
+corresponding statistical plot that is both accurate and aesthetically
+pleasing. I will input the raw data and the plot visual intent, and your
+output should be a detailed description of an illustrative plot that
+effectively represents the data. Note that your description should include
+all the raw data points to be plotted.
+
+To help you understand the task better, and grasp the principles for
+generating such plots, I will also provide you with several examples.
+You should learn from these examples to provide your plot description.
+
+** IMPORTANT: **
+Your description should be as detailed as possible. For content, explain the
+precise mapping of variables to visual channels (x, y, hue) and explicitly
+enumerate every raw data point's coordinate to be drawn to ensure accuracy.
+For presentation, specify the exact aesthetic parameters, including specific
+HEX color codes, font sizes for all labels, line widths, marker dimensions,
+legend placement, and grid styles. You should learn from the examples' content
+presentation and aesthetic design (e.g., color schemes).
+
+## Raw Data
+{source_context}
+
+## Visual Intent (Figure Caption)
+{caption}
+
+## Reference Examples
+{examples}
+
+Based on the raw data, visual intent, and learning from the style and
+structure of the reference examples above, generate a comprehensive and
+detailed textual description of the statistical plot.
+```
+
+## Notes for `data_plotter`
+
+- `{source_context}` = raw data (CSV snippet, JSON, or data file description + key columns)
+- `{caption}` = `C_communicative_intent` from brief.json
+- `{examples}` = observations from reference plots in `<id>_references.md` (if Phase 0 ran), or empty
+- Unlike diagram stylist: hex codes ARE acceptable in plot descriptions (they feed into matplotlib code, not an image-gen model)
+- Output feeds directly into the `plot_visualizer.md` code generation step

--- a/pantheon/factory/templates/skills/figure_styling/quality/plot_stylist.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/plot_stylist.md
@@ -1,0 +1,80 @@
+---
+id: plot_stylist
+name: Plot Stylist
+description: |
+  Phase 2 styling prompt for statistical plots. Takes the plot planner
+  description + NeurIPS style guidelines, outputs an aesthetically enriched
+  description with exact color codes and font specs for code generation.
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Plot Stylist
+
+> **Source**: `prompts/plot/stylist.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `data_plotter` as an optional pre-code step when a description needs
+aesthetic polish before generating matplotlib code. Unlike `diagram_stylist`,
+plot styling CAN include hex color codes (they feed into Python code, not an
+image-gen model).
+
+## When to Use
+
+- After `plot_planner` when the resulting description lacks specific color
+  and font specs
+- When user requests a specific aesthetic ("NeurIPS style", "Nature style")
+- When references provide a palette that should be applied
+
+## Prompt
+
+```
+## ROLE
+
+You are a Lead Visual Designer for top-tier AI conferences (e.g., NeurIPS 2025).
+
+## TASK
+You are provided with a preliminary description of a statistical plot to be
+generated. However, this description may lack specific aesthetic details, such
+as color palettes, background styling, and font choices.
+
+Your task is to refine and enrich this description based on the provided
+[NeurIPS 2025 Style Guidelines] to ensure the final generated image is a
+high-quality, publication-ready plot that strictly adheres to the NeurIPS 2025
+aesthetic standards.
+
+**Crucial Instructions:**
+
+1. **Enrich Details:** Focus on specifying visual attributes (colors, fonts,
+   line styles, layout adjustments) defined in the guidelines.
+2. **Preserve Content:** Do NOT alter the semantic content, logic, or
+   quantitative results of the plot. Your job is purely aesthetic refinement,
+   not content editing.
+3. **Context Awareness:** Use the provided "Raw Data" and "Figure Caption" to
+   understand the emphasis of the plot, ensuring the style supports the content
+   effectively.
+
+## INPUT DATA
+
+- **Detailed Description**: {description}
+- **Style Guidelines**: {guidelines}
+- **Raw Data**: {source_context}
+- **Figure Caption**: {caption}
+
+## OUTPUT
+Output ONLY the final polished Detailed Description. Do not include any
+conversational text or explanations.
+```
+
+## Notes for `data_plotter`
+
+- `{guidelines}` = content of `figure_styling/styles/<aesthetic_guide>.md`
+  (e.g. `neurips_plot.md`) — load this file and paste its content here
+- `{description}` = output of `plot_planner.md` or an initial description
+- `{source_context}` = raw data snippet
+- `{caption}` = `C_communicative_intent` from brief.json
+- Unlike `diagram_stylist`: hex color codes ARE acceptable in the output
+  (they will be embedded in Python code, not passed to an image-gen model)
+- Output is used as input to `plot_visualizer.md` for code generation

--- a/pantheon/factory/templates/skills/figure_styling/quality/plot_visualizer.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/plot_visualizer.md
@@ -1,0 +1,52 @@
+---
+id: plot_visualizer
+name: Plot Visualizer
+description: |
+  Code generation prompt for statistical plots. Instructs data_plotter to
+  produce complete, executable matplotlib/seaborn Python code at 300 DPI.
+source: https://github.com/llmsresearch/paperbanana
+license: Apache-2.0
+---
+
+# Plot Visualizer
+
+> **Source**: Adapted from `prompts/plot/visualizer.txt` in
+> [llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana) (Apache-2.0).
+
+## Purpose
+
+Used by `data_plotter` to generate initial plot code from a description.
+Ensures the output is complete, executable, and publication-quality.
+
+## Prompt
+
+```
+You are an expert statistical plot illustrator. Write code to generate
+high-quality statistical plots based on user requests.
+
+Generate complete, executable Python code using matplotlib and/or seaborn
+to create the following statistical plot. The code should save the figure
+to the path specified by the OUTPUT_PATH variable.
+
+## Plot Description
+{description}
+
+## Requirements
+- Set OUTPUT_PATH variable at the top of the code
+- Use plt.savefig(OUTPUT_PATH, dpi=300, bbox_inches='tight')
+- Do NOT include plt.show() calls
+- Publication-quality figure suitable for NeurIPS/ICML/ICLR
+- Clean, minimal design (maximize data-ink ratio)
+- Professional, colorblind-friendly color palette
+- Clear axis labels with appropriate font sizes
+- Legend that does not obstruct data
+- High resolution (300 DPI minimum)
+- Only output the Python code, nothing else
+```
+
+## Notes for `data_plotter`
+
+- Override `dpi=300` with `style_card.dpi_final` (typically 600 for journal figures)
+- Apply `style_card.font_family` and `style_card.font_size` via `mpl.rcParams`
+- Apply `style_card.colors.primary` as the first categorical color
+- Load `aesthetic_guide` file (from `figure_styling` skill) before generating code

--- a/pantheon/factory/templates/skills/figure_styling/quality/scientific_schematic.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/scientific_schematic.md
@@ -1,0 +1,141 @@
+---
+id: scientific_schematic
+name: Scientific Schematic Generator
+description: |
+  Skill for generating publication-style biological/chemical schematics:
+  pathway diagrams, reaction schemes, experimental workflows, cellular
+  schematics, and mechanism cartoons. Vector-first (SVG/PNG/PDF).
+  NOT for data plots or photorealistic images.
+source: https://github.com/rileydog53/imageGenV0
+license: MIT
+---
+
+# Scientific Schematic Generator
+
+> **Source**: `SKILL.md` in
+> [rileydog53/imageGenV0](https://github.com/rileydog53/imageGenV0) (MIT).
+
+## Purpose
+
+Generates publication-style schematic figures for biology/chemistry/medicine
+scenarios. Routes to `illustrator` with a structured intermediate representation
+(IR) that enforces semantic correctness before image generation.
+
+## When to Use (Trigger conditions)
+
+- Signalling / metabolic pathway diagram
+- Chemical reaction scheme
+- Experimental workflow / protocol
+- Cellular schematic (organelles, membranes, compartments)
+- Mechanism cartoon (drug inhibition, protein interaction)
+- Multi-panel graphical abstract for biology papers
+
+## When NOT to Use
+
+- Photorealistic images → use image generation directly
+- Real data plots (bar, line, scatter) → use `data_plotter`
+- 3D molecular structures (PDB rendering) → specialist tool
+- General ML/AI architecture diagrams → use `diagram_planner`
+
+## 5 Archetypes
+
+| Archetype | Description | Key requirements |
+|---|---|---|
+| `pathway` | Signalling/metabolic cascade with entities, compartments, relations | Inhibition T-bars; activation arrows; compartment boundaries |
+| `reaction_scheme` | Chemical reactions with reactants, products, conditions | SMILES validation; arrow conventions; reagent labels |
+| `workflow` | Experimental protocol steps | Step boxes; decision diamonds; fallback logic |
+| `cellular_schematic` | Cell with organelles and molecular actors | Membrane boundaries; compartment labels; scale consistency |
+| `mechanism_cartoon` | Drug/protein mechanism of action | Before/after states; interaction highlights |
+
+## 3 Style Presets
+
+| Preset | Description | Use case |
+|---|---|---|
+| `cell_press` | Rounded nodes, warm pastels, friendly | Cell, Nature Cell Biology, iScience |
+| `nature` | Bold lines, colorblind-safe palette | Nature, Nature Methods, Nature Communications |
+| `acs` | Monochrome, formal, minimal decoration | JACS, ACS Nano, chemical journals |
+
+## Structured IR (Intermediate Representation)
+
+Before generating, extract a validated IR from the user's description:
+
+```json
+{
+  "archetype": "pathway",
+  "style_preset": "cell_press",
+  "title": "JAK-STAT Signaling in Activated T Cells",
+  "entities": [
+    {
+      "id": "e1",
+      "label": "IL-6",
+      "type": "ligand",
+      "compartment": "extracellular",
+      "shape": "hexagon"
+    },
+    {
+      "id": "e2",
+      "label": "JAK1",
+      "type": "kinase",
+      "compartment": "membrane",
+      "shape": "rounded_rect"
+    }
+  ],
+  "compartments": [
+    {"id": "c1", "label": "Extracellular", "color": "pale_blue"},
+    {"id": "c2", "label": "Cytoplasm", "color": "pale_green"}
+  ],
+  "relations": [
+    {
+      "from": "e1",
+      "to": "e2",
+      "type": "activation",
+      "arrow": "filled_arrow",
+      "label": "binds"
+    },
+    {
+      "from": "e3",
+      "to": "e4",
+      "type": "inhibition",
+      "arrow": "T_bar",
+      "label": "blocks"
+    }
+  ],
+  "panels": [],
+  "annotations": []
+}
+```
+
+**Relation types → arrow conventions**:
+- `activation` → filled arrowhead →
+- `inhibition` → T-bar ⊣
+- `binding` → double-headed arrow ↔
+- `translocation` → dashed arrow - ->
+- `phosphorylation` → circled P label on arrow
+
+## Mandatory Workflow for `illustrator` (when archetype detected)
+
+```
+1. Classify → identify archetype from user description
+2. Extract IR → build the JSON above from user's text
+3. Validate IR → check: all relation endpoints exist; compartments assigned;
+   no missing labels; arrow types are valid
+4. Pass IR to Phase 1 (Plan) → use IR as the structured source context
+   instead of raw text; guarantees semantic correctness
+5. Phase 2 (Style) → apply style_preset + neurips_diagram aesthetic guide
+6. Phase 3 (Render) → generate_image with biological accuracy emphasis
+7. Phase 4 (Critic) → apply diagram_critic.md + verify:
+   - Inhibition T-bars are T-shaped, NOT arrows
+   - Activation arrows have filled arrowheads
+   - Compartment boundaries are visible and labeled
+   - All entities from IR are present in the image
+```
+
+## Quality Gate
+
+Before accepting as final, `illustrator` must verify:
+- [ ] All entities from IR are visible and labeled
+- [ ] All inhibition relations use T-bar notation
+- [ ] Compartment boundaries clearly delineated
+- [ ] No text labels inside dark-colored shapes (use white text or label outside)
+- [ ] Style preset palette applied consistently
+- [ ] No caption text embedded in image

--- a/pantheon/factory/templates/skills/figure_styling/quality/visual_refine.md
+++ b/pantheon/factory/templates/skills/figure_styling/quality/visual_refine.md
@@ -1,0 +1,109 @@
+---
+id: visual_refine
+name: Visual Refine Agent Prompt
+description: |
+  Visual refinement prompt for data_plotter iterative loop. Given the
+  rendered PNG + original code + user query, produces step-by-step
+  improvement instructions. Adapted from thunlp/MatPlotAgent (MIT).
+source: https://github.com/thunlp/MatPlotAgent
+license: MIT
+---
+
+# Visual Refine
+
+> **Source**: Adapted from `agents/visual_refine_agent/prompt.py` in
+> [thunlp/MatPlotAgent](https://github.com/thunlp/MatPlotAgent) (MIT).
+
+## Purpose
+
+Used by `data_plotter` as an alternative to the PaperBanana critic when the
+agent has the rendered PNG available for vision-based review. Produces concrete
+code-level instructions rather than a revised description.
+
+## System Prompt
+
+```
+Given a piece of code, a user query, and an image of the current plot, please
+determine whether the plot has faithfully followed the user query. Your task
+is to provide instruction to make sure the plot has strictly completed the
+requirements of the query. Please output a detailed step by step instruction
+on how to use python code to enhance the plot.
+```
+
+## User Prompt
+
+```
+Here is the code: [Code]:
+"""
+{code}
+"""
+
+Here is the user query: [Query]:
+"""
+{query}
+"""
+
+Carefully read and analyze the user query to understand what kind of plot the
+user wants to create. Identify the key requirements and features mentioned in
+the user query, such as: the type of plot (e.g., line chart, bar chart,
+scatter plot), the data to be plotted, the labels, titles, and annotations
+required, any specific colors, styles, or formatting instructions, and any
+other special requirements.
+
+Analyze the provided image of the current plot. Compare these elements with
+the requirements specified in the user query. Note any differences, missing
+elements, or areas for improvement.
+
+Based on your analysis, provide step-by-step instructions on how to modify the
+Python code to make the plot better align with the user query. Remember to save
+the plot to a png file. The file name should be """{file_name}"""
+```
+
+## Error Correction Prompt
+
+```
+There are some errors in the code you gave:
+{error_message}
+please correct the errors.
+Then give the complete code and don't omit anything.
+```
+
+## Query Expansion System Prompt
+
+```
+According to the user query, expand and solidify the query into a step by step
+detailed instruction (or comment) on how to write python code to fulfill the
+user query's requirements. Import the appropriate libraries. Pinpoint the
+correct library functions to call and set each parameter in every function call
+accordingly.
+```
+
+## Query Expansion User Prompt
+
+```
+Here is the user query: [User Query]:
+"""
+{query}
+"""
+You should understand what the query's requirements are, and output step by
+step, detailed instructions on how to use python code to fulfill these
+requirements. Include what libraries to import, what library functions to call,
+how to set the parameters in each function correctly, how to prepare the data,
+how to manipulate the data, and how to set the figure properties.
+```
+
+## Usage in `data_plotter`
+
+MatPlotAgent uses a three-agent loop that `data_plotter` can replicate:
+
+```
+1. QueryExpansionAgent → expand raw user query into step-by-step code instructions
+2. PlotAgent (initial) → generate Python code from expanded instructions
+3. Execute code → render PNG
+4. VisualRefineAgent → compare rendered PNG vs query → produce improvement instructions
+5. PlotAgent (refine) → apply improvement instructions → new code
+6. Repeat steps 3-5 up to 4 attempts or until plot_critic returns null
+```
+
+Retry loop: up to 4 attempts; extract Python from ```python...``` blocks;
+run code; if error → feed ERROR_PROMPT back to PlotAgent.

--- a/pantheon/factory/templates/skills/figure_styling/scenarios/figure.md
+++ b/pantheon/factory/templates/skills/figure_styling/scenarios/figure.md
@@ -1,0 +1,121 @@
+---
+id: figure_scenario
+name: "Figure Scenario"
+description: |
+  Workflow for producing publication-ready scientific figures (data plots,
+  methodology diagrams, or composite panels) targeting journals and
+  top-tier ML/bio venues (Nature, Cell, NeurIPS, ICML, etc.).
+---
+
+# Figure Scenario
+
+## When to Use
+
+- Frontend `scenarioId`: `"figure"` (or `outputType: "figure"`)
+- User says: "论文图", "科学图表", "发表图", "publication figure", "Figure 1", "journal figure"
+- Goal: Produce print-quality figure suitable for journal / conference paper submission
+- Output: PNG (always) + PDF + SVG (for journal submissions)
+
+---
+
+## Scenario Constraints
+
+| Parameter | Value |
+|-----------|-------|
+| `target` | `journal` |
+| `dpi_preview` | 300 |
+| `dpi_final` | 600 |
+| `export_formats` | `["png", "pdf", "svg"]` |
+| `font_family` | Arial / Helvetica (sans-serif) |
+| `font_size.axis_label` | 9 pt |
+| `font_size.tick` | 8 pt |
+| `font_size.title` | 10 pt |
+
+**Figure size defaults (inches)**:
+- Single column: `[3.3, 2.5]` (Nature/IEEE standard)
+- Double column: `[7.0, 5.0]`
+- Square (heatmap, radar): `[3.3, 3.3]`
+
+**Aspect ratio rule**: For methodology/framework diagrams, enforce 1.5 : 1 to 2.5 : 1 landscape. For statistical plots, use journal column width.
+
+---
+
+## Style Card Defaults
+
+```json
+{
+  "target": "journal",
+  "aesthetic_guide": "neurips_plot",
+  "dpi_preview": 300,
+  "dpi_final": 600,
+  "figure_size_inches": { "single_column": [3.3, 2.5], "double_column": [7.0, 5.0] },
+  "font_family": "Arial",
+  "font_size": { "axis_label": 9, "tick": 8, "legend": 8, "title": 10, "panel_letter": 11 },
+  "export_formats": ["png", "pdf", "svg"]
+}
+```
+
+Override `aesthetic_guide`:
+- For data plots → `neurips_plot` (default) or `nature_figure` / `ieee_figure`
+- For methodology diagrams → `neurips_diagram`
+- Guided by `style` field from `<graph_settings>`:
+  - `nature-science` → use `nature_figure` style
+  - `minimalist` → `null` (style_card notes: "Open spines, no grid, muted palette")
+  - `modern` → `null` (style_card notes: "Flat design, bold accent, clean white background")
+
+---
+
+## Workflow
+
+```
+<graph_settings> parse → intent triage → reference detection
+  → brief.json → style_card.json (this scenario's defaults)
+  → figure production (data_plotter / illustrator)
+  → critic loop (T ≤ 3) → vectorization (PDF + SVG)
+  → observe_images quality check → delivery
+```
+
+### Step 1: Intent triage (from leader standard triage)
+
+Classify based on user input and `<graph_settings>`:
+- Has data file → `data-only` → `data_plotter`
+- No data, conceptual description → `illustration-only` → `illustrator`
+- Both → `composite-panel` → both agents in parallel
+
+### Step 2: Style card initialization
+
+Apply this scenario's defaults first. Then layer overrides:
+1. `<graph_settings>.colorScheme.colors[0]` → `colors.primary`
+2. `<graph_settings>.colorScheme.colors[1]` → `colors.secondary`
+3. `<graph_settings>.style` → map to `aesthetic_guide` per table above
+4. `<graph_settings>.audience == "expert"` → keep 8–10pt fonts; `== "graduate"` → bump 1pt
+
+### Step 3: Figure production
+
+`data_plotter` critic loop: T ≤ **3** rounds (journal quality requires more iteration).
+
+`illustrator` critic loop: T ≤ **3** rounds.
+
+### Step 4: Mandatory guardrails (journal-specific)
+
+In addition to universal guardrails:
+- All text in figures must be **editable** in the exported SVG/PDF (`pdf.fonttype: 42`, `svg.fonttype: "none"`)
+- No embedded raster in SVG when vector alternatives exist
+- Panel letters (a, b, c …) must be **bold, top-left corner** of each panel. Size is determined by `aesthetic_guide`: `nature_figure` → 8 pt; `neurips_*` → 11 pt; `ieee_figure` → 9 pt; default → `style_card.font_size.panel_letter`
+- Color-blind safe palette required unless user explicitly overrides: prefer Paul Tol's bright/vibrant sets
+
+### Step 5: Export
+
+Always produce: PNG (600 DPI), PDF (vector), SVG (editable).
+
+---
+
+## Quality Checklist (leader verify before delivery)
+
+- [ ] All fonts are sans-serif on axis labels
+- [ ] DPI ≥ 600 on final PNG
+- [ ] PDF and SVG contain vector text (not rasterized)
+- [ ] No caption text embedded inside figure image
+- [ ] Aspect ratio matches brief.json spec
+- [ ] Color palette is colorblind-accessible
+- [ ] Panel letters present and correctly formatted

--- a/pantheon/factory/templates/skills/figure_styling/scenarios/flowchart.md
+++ b/pantheon/factory/templates/skills/figure_styling/scenarios/flowchart.md
@@ -1,0 +1,147 @@
+---
+id: flowchart_scenario
+name: "Flowchart Scenario"
+description: |
+  Workflow for producing methodology flowcharts, pipeline schematics,
+  experimental protocols, and mechanism diagrams. Pure illustration —
+  no data required. Routes exclusively to illustrator.
+---
+
+# Flowchart Scenario
+
+## When to Use
+
+- Frontend `scenarioId`: `"flowchart"` (or `outputType: "flowchart"`)
+- User says: "流程图", "机制图", "实验流程", "pipeline", "架构图", "flowchart", "protocol diagram"
+- Goal: Clear step-by-step process or mechanism diagram
+- Output: PNG + SVG (for editable modification)
+
+---
+
+## Scenario Constraints
+
+| Parameter | Value |
+|-----------|-------|
+| `target` | `journal` or `internal` (infer from context) |
+| `dpi_preview` | 300 |
+| `dpi_final` | 600 |
+| `export_formats` | `["png", "svg"]` |
+| `font_family` | Arial / Helvetica |
+
+**Aspect ratio rule**: Flowcharts use the most flexible aspect ratios:
+- Horizontal flow (left → right): 2.0 : 1 to 3.0 : 1
+- Vertical flow (top → bottom): 0.7 : 1 to 1.0 : 1
+- Circular / cyclic: 1.0 : 1 (square)
+
+Infer from `<graph_settings>.layout`:
+- `horizontal` → aspect ratio 2.2 : 1
+- `vertical` → aspect ratio 0.8 : 1
+- `circular` → aspect ratio 1.0 : 1
+
+---
+
+## Style Card Defaults
+
+```json
+{
+  "target": "journal",
+  "aesthetic_guide": "neurips_diagram",
+  "dpi_preview": 300,
+  "dpi_final": 600,
+  "figure_size_inches": { "single_column": [7.0, 3.2] },
+  "font_family": "Arial",
+  "font_size": { "label": 9, "annotation": 8, "step_number": 10 },
+  "export_formats": ["png", "svg"]
+}
+```
+
+**`aesthetic_guide` based on `<graph_settings>.style`**:
+- `nature-science` → `neurips_diagram` (clean, professional)
+- `minimalist` → `null` + notes: "Flat arrows, no shadows, monochrome palette with one accent color"
+- `modern` → `null` + notes: "Rounded steps, gradient fills, flat icons for each step"
+- `realistic` → `null` + notes: "Use realistic icons / photos for inputs/outputs alongside step boxes"
+- `3d-render` → `null` + notes: "Isometric 3D steps, depth shadows, vivid color scheme"
+
+---
+
+## Intent Routing
+
+Flowchart scenario is **always `illustration-only`** — routes exclusively to `illustrator`.
+
+No `data_plotter` involvement unless the user explicitly says "include a statistics summary panel" — in that case, treat as `composite-panel`.
+
+---
+
+## Flowchart Design Principles
+
+1. **Linear clarity**: Each step flows unambiguously to the next. Use consistent arrow direction.
+2. **Numbered steps** (optional but recommended for complex protocols): Step numbers in circles at top-left of each box.
+3. **Color coding by phase**: Use background zone colors to group related steps (e.g., "Sample Prep" = pale blue zone, "Analysis" = pale green zone).
+4. **Decision diamonds**: Use ⬥ diamond shape for conditional branches (Yes/No, Pass/Fail).
+5. **Icon enhancement**: Add small illustrative icons inside or above step boxes to aid quick recognition.
+6. **Consistent line weights**: Single line thickness for flow arrows; use arrowheads consistently.
+
+---
+
+## Workflow
+
+```
+<graph_settings> parse → layout detection (horizontal/vertical/circular)
+  → aspect ratio assignment
+  → brief.json (illustration-only)
+  → style_card.json (flowchart defaults)
+  → illustrator pipeline
+  → Phase 1 (Plan): enumerate all steps, group by phase, define connections
+  → Phase 2 (Style): apply zone colors, icon styles, arrow styles
+  → Phase 3 (Render): generate_image
+  → Phase 4 (Critic): verify step completeness, arrow correctness, label readability
+  → SVG vectorization (inkscape)
+  → delivery
+```
+
+### Step 1: Layout inference
+
+From `<graph_settings>.layout`:
+- `horizontal` → left-to-right sequential steps
+- `vertical` → top-to-bottom, like experimental protocol
+- `circular` → cyclic process (training loop, data pipeline cycle)
+- `2-part` / `3-part` → split into parallel branches
+
+Set aspect ratio accordingly in `brief.json.aspect_ratio`.
+
+### Step 2: Illustrator Phase 1 — step enumeration
+
+The Plan document must explicitly list every step:
+```
+Step 1: [label] — input: [what enters], output: [what exits]
+Step 2: [label] — ...
+Decision point: [condition] → Yes: Step X, No: Step Y
+Phase grouping: Steps 1-3 = "Data Preprocessing", Steps 4-6 = "Model Training"
+```
+
+### Step 3: SVG export
+
+Always request SVG (editable for downstream modification in Inkscape/Illustrator):
+```bash
+inkscape {input}.png --export-type=svg --export-filename={output}.svg
+```
+
+### Step 4: Critic — flowchart-specific checks
+
+- All steps present and correctly connected
+- No ambiguous arrows (every arrow has a clear destination)
+- Decision points have both Yes and No branches labeled
+- Labels are concise (≤ 5 words per step box)
+- Phase groupings visually distinct
+
+---
+
+## Quality Checklist
+
+- [ ] All steps from user description are present
+- [ ] Arrows have clear direction and destination
+- [ ] Decision branches labeled (Yes/No)
+- [ ] Phase groupings visually distinct
+- [ ] Labels ≤ 5 words per step
+- [ ] SVG export confirmed editable (vector text)
+- [ ] No caption text inside image

--- a/pantheon/factory/templates/skills/figure_styling/scenarios/graphical_abstract.md
+++ b/pantheon/factory/templates/skills/figure_styling/scenarios/graphical_abstract.md
@@ -1,0 +1,133 @@
+---
+id: graphical_abstract_scenario
+name: "Graphical Abstract Scenario"
+description: |
+  Workflow for producing journal graphical abstracts — a single visual
+  summary image that communicates the paper's key message at a glance.
+  Follows Cell Press / Nature / Elsevier guidelines.
+---
+
+# Graphical Abstract Scenario
+
+## When to Use
+
+- Frontend `scenarioId`: `"graphical-abstract"` (or `outputType: "graphical-abstract"`)
+- User says: "图形摘要", "graphical abstract", "visual abstract", "TOC graphic", "journal cover"
+- Goal: Single striking image summarizing the paper for journal submission header / TOC
+- Output: PNG (high-res) — no PDF/SVG required by most journals, but produce if asked
+
+---
+
+## Scenario Constraints
+
+| Parameter | Value |
+|-----------|-------|
+| `target` | `journal` |
+| `dpi_preview` | 300 |
+| `dpi_final` | 600 |
+| `export_formats` | `["png"]` (+ `"pdf"` if user says "投稿") |
+| `font_family` | Arial / Helvetica |
+
+**Size defaults by journal**:
+- Cell Press (Cell, Cell Reports, etc.): `[6.69, 2.36]` inches (169 × 60 mm, landscape)
+- Nature family: `[3.54, 2.36]` inches (90 × 60 mm, portrait/square-ish)
+- Elsevier (Molecular Cell etc.): `[5.12, 2.76]` inches (130 × 70 mm)
+- Default / unknown: `[5.5, 2.5]` inches landscape
+
+**Infer journal from user input**: "Cell" → Cell Press dims; "Nature" → Nature dims; default if unclear.
+
+---
+
+## Style Card Defaults
+
+```json
+{
+  "target": "journal",
+  "aesthetic_guide": "nature_figure",
+  "dpi_preview": 300,
+  "dpi_final": 600,
+  "figure_size_inches": { "single_column": [5.5, 2.5] },
+  "font_family": "Arial",
+  "font_size": { "label": 8, "annotation": 7, "panel_letter": 8 },
+  "colors": {
+    "categorical_palette": ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377", "#BBBBBB"]
+  },
+  "export_formats": ["png"]
+}
+```
+
+`aesthetic_guide: "nature_figure"` applies because graphical abstracts target CNS-family journals. This enforces 7–8pt Arial, Paul Tol bright palette, white background, and no gridlines — all appropriate for journal header visuals.
+
+**Override for ML-domain papers** (NeurIPS/ICML graphical abstracts): set `aesthetic_guide: "neurips_diagram"` in style_card to get the soft-pastel zone style instead.
+
+---
+
+## Graphical Abstract Design Principles
+
+A graphical abstract is **not** a figure from the paper — it is a **standalone communication piece**:
+
+1. **Single message**: One clear takeaway in ≤ 5 seconds of viewing
+2. **Minimal text**: Labels only — no sentences, no legend prose
+3. **Left → right narrative**: Input/problem on left, method/process in middle, result/impact on right
+4. **Bold visual hierarchy**: Key result or molecule/cell is the largest, most saturated element
+5. **White background**: Clean, minimal — no colored background zones unless used for grouping
+6. **No axes or chart furniture**: Even data elements (bars, dots) should be simplified/stylized
+
+**Structure template**:
+```
+[Context / Problem]  →  [Method / Mechanism]  →  [Key Result / Impact]
+     (icon/schematic)        (process arrow)         (outcome image)
+```
+
+---
+
+## Workflow
+
+```
+<graph_settings> parse → intent detection
+  → journal size inference (from user message)
+  → brief.json (illustration-only, single figure)
+  → style_card.json (graphical abstract defaults)
+  → illustrator pipeline (Plan → Style → Render → Critic)
+  → critic enforces: single-panel, no caption text, narrative flow
+  → quality check → delivery
+```
+
+### Step 1: Intent is almost always `illustration-only`
+
+Graphical abstracts are conceptual illustrations. Only route to `data_plotter` if user explicitly says "include actual data" (rare — usually a stylized version of a result plot, not raw data).
+
+### Step 2: Journal size detection
+
+Scan user message for journal name keywords:
+- "Cell", "Molecular Cell", "Cell Reports" → Cell Press: `[6.69, 2.36]`
+- "Nature", "Nature Methods", "Nature Communications" → `[3.54, 2.36]`
+- "Elsevier", "Journal of" → `[5.12, 2.76]`
+- No match → default `[5.5, 2.5]`
+
+Set in `style_card.figure_size_inches.single_column`.
+
+### Step 3: Illustrator Phase 1 (Plan) guidance
+
+Pass to `illustrator` in the instruction:
+> "This is a graphical abstract. The design must communicate ONE key message visually. Use a strict left-to-right narrative: context/problem → method → outcome. Minimize text to labels only. The most important result should be the visually dominant element."
+
+### Step 4: Critic guardrails (graphical abstract specific)
+
+Add to critic instructions:
+- Reject if more than one distinct narrative thread is present
+- Reject if text labels form sentences (should be ≤ 3 words each)
+- Reject if background is not white or very light
+- Reject if there is no clear left → right flow
+
+---
+
+## Quality Checklist
+
+- [ ] Single coherent message communicated in ≤ 5 seconds
+- [ ] Left → right narrative flow
+- [ ] No sentences — labels only (≤ 3 words each)
+- [ ] White or near-white background
+- [ ] Key result is the largest / most visually prominent element
+- [ ] Dimensions match target journal specs
+- [ ] No caption text embedded in image

--- a/pantheon/factory/templates/skills/figure_styling/scenarios/poster.md
+++ b/pantheon/factory/templates/skills/figure_styling/scenarios/poster.md
@@ -1,0 +1,171 @@
+---
+id: poster_scenario
+name: "Poster Scenario"
+description: |
+  Workflow for producing academic conference posters (A0/A1 portrait or
+  landscape), workshop teaching materials, and large-format displays.
+---
+
+# Poster Scenario
+
+## When to Use
+
+- Frontend `scenarioId`: `"poster"` (or `outputType: "poster"`)
+- User says: "学术海报", "conference poster", "会议海报", "A0 poster", "workshop poster"
+- Goal: Large-format poster for physical or digital display at conferences
+- Output: PNG (high-res) + PDF (print-ready)
+
+---
+
+## Scenario Constraints
+
+| Parameter | Value |
+|-----------|-------|
+| `target` | `slides` (large font, vivid color OK) |
+| `dpi_preview` | 150 |
+| `dpi_final` | 300 (sufficient for print at A0) |
+| `export_formats` | `["png", "pdf"]` |
+| `font_family` | Arial / Helvetica |
+| `font_size.body` | 24 pt minimum |
+| `font_size.heading` | 36–48 pt |
+| `font_size.title` | 60–72 pt |
+
+**Poster size defaults**:
+- A0 portrait: `[33.1, 46.8]` inches → use as guidance for aspect ratio
+- A0 landscape: `[46.8, 33.1]` inches
+- **Delivered as composite PNG**: agent composes all panels into one image
+
+**Aspect ratio rule**: Portrait posters → 0.7 : 1 (width : height). Landscape → 1.4 : 1.
+
+---
+
+## Style Card Defaults
+
+```json
+{
+  "target": "slides",
+  "aesthetic_guide": "neurips_diagram",
+  "dpi_preview": 150,
+  "dpi_final": 300,
+  "figure_size_inches": { "single_column": [8.0, 6.0], "panel": [7.0, 5.0] },
+  "font_family": "Arial",
+  "font_size": { "axis_label": 18, "tick": 14, "legend": 14, "title": 22, "panel_letter": 24 },
+  "export_formats": ["png", "pdf"]
+}
+```
+
+Override `aesthetic_guide`:
+- `nature-science` → keep `neurips_plot` but increase font sizes
+- `minimalist` → `null` + notes: "White background, thin lines, muted palette, generous whitespace"
+- `modern` → `null` + notes: "Bold accent color for section headers, flat icons, high contrast"
+
+---
+
+## Poster Structure (Standard Academic Layout)
+
+Posters typically follow a 3–4 column grid:
+
+```
+┌─────────────────────────────────────────┐
+│          TITLE  ·  Authors  ·  Logos    │ ← banner
+├───────────┬───────────┬─────────────────┤
+│ Background│  Method   │    Results      │
+│  & Motiv. │  Overview │  (main figure)  │
+├───────────┴───────────┼─────────────────┤
+│     Experiments       │  Conclusion &   │
+│     (sub-figures)     │  Future Work    │
+├───────────────────────┴─────────────────┤
+│  References  ·  QR Code  ·  Contact    │ ← footer
+└─────────────────────────────────────────┘
+```
+
+**Leader's job**: decompose the poster into sections, assign each section to `data_plotter` (for result figures) or `illustrator` (for method overview diagrams), then compose using `data_plotter`'s multi-panel composition.
+
+---
+
+## Workflow
+
+```
+<graph_settings> parse → brief.json (poster intent)
+  → style_card.json (poster defaults)
+  → decompose into sections (banner / method / results / conclusion)
+  → produce section figures in parallel
+  → compose full poster PNG via data_plotter (Pillow)
+  → export PDF via reportlab or inkscape
+  → quality check (readability at 1m distance)
+```
+
+### Step 1: Poster decomposition
+
+Based on user's input, infer which sections are needed. Write a section manifest in `brief.json`:
+
+```json
+{
+  "intent": "composite-panel",
+  "layout": "poster_3col",
+  "figures": [
+    { "id": "method_overview", "category": "agent_reasoning", ... },
+    { "id": "main_result", "category": "statistical_plot", ... },
+    { "id": "ablation", "category": "statistical_plot", ... }
+  ]
+}
+```
+
+### Step 2: Font size scaling
+
+Poster fonts must be legible from 1 meter. Use a **dynamic scale factor** based on the target poster size rather than a hardcoded 2.5×:
+
+```python
+# Dynamic font scale — based on target poster physical size vs. journal baseline
+# Journal baseline: single column 3.5" at 600 DPI
+# A0 poster at 300 DPI: 33.1" wide → scale ≈ 33.1 / 3.5 × (300/600) ≈ 4.7×
+# A1 poster at 300 DPI: 23.4" wide → scale ≈ 23.4 / 3.5 × (300/600) ≈ 3.3×
+# Digital display (1920px, 96 DPI): 20" wide → scale ≈ 20 / 3.5 × (96/600) ≈ 0.9× → use 2.5× min
+
+POSTER_WIDTH_INCHES = {
+    "A0": 33.1, "A1": 23.4, "A2": 16.5,
+    "custom": style.get("poster_width_inches", 33.1),
+}.get(style.get("poster_size", "A0"), 33.1)
+
+JOURNAL_COL_INCHES = 3.5
+DPI_RATIO = style["dpi_final"] / 600
+SCALE = max(2.5, (POSTER_WIDTH_INCHES / JOURNAL_COL_INCHES) * DPI_RATIO)
+
+# Apply to all font sizes
+for key in ["axes.labelsize", "xtick.labelsize", "ytick.labelsize", "legend.fontsize", "axes.titlesize"]:
+    mpl.rcParams[key] = round(mpl.rcParams[key] * SCALE)
+
+# Minimum sizes (readability floor)
+mpl.rcParams["axes.labelsize"] = max(18, mpl.rcParams["axes.labelsize"])
+mpl.rcParams["xtick.labelsize"] = max(14, mpl.rcParams["xtick.labelsize"])
+mpl.rcParams["ytick.labelsize"] = max(14, mpl.rcParams["ytick.labelsize"])
+```
+
+Use **`vibrant`** palette from `figure_styling/styles/color_palettes.md` for poster figures — more vivid than `bright`, better at distance.
+
+### Step 3: Color & contrast
+
+Vivid color is acceptable for posters. Use `<graph_settings>.colorScheme` to anchor primary/secondary. Ensure:
+- Title banner uses `colorScheme.colors[0]` as background or accent
+- Section headers use a lighter tint (~30%) of primary color
+
+### Step 4: Composition
+
+`data_plotter` composes all section images into the full poster:
+```python
+# Use Pillow for raster composition
+from PIL import Image
+# Place each section PNG at correct grid position
+# Export at 300 DPI → A0-ready print file
+```
+
+---
+
+## Quality Checklist
+
+- [ ] All text legible at 1 meter (≥ 24 pt equivalent)
+- [ ] Title clearly visible from across the room
+- [ ] Method diagram and main result figure are the visual focus
+- [ ] QR code / contact info in footer (if user provides)
+- [ ] DPI 300 minimum on final PNG
+- [ ] PDF export suitable for print shop

--- a/pantheon/factory/templates/skills/figure_styling/scenarios/presentation.md
+++ b/pantheon/factory/templates/skills/figure_styling/scenarios/presentation.md
@@ -1,0 +1,141 @@
+---
+id: presentation_scenario
+name: "Presentation Scenario"
+description: |
+  Workflow for producing slide figures — 16:9 widescreen format,
+  larger fonts, vivid palette. Targets oral presentations, group
+  meetings, and conference talks.
+---
+
+# Presentation Scenario
+
+## When to Use
+
+- Frontend `scenarioId`: `"presentation"` (or `outputType: "presentation"`)
+- User says: "幻灯片配图", "slides", "PPT图", "oral presentation", "演示", "组会图"
+- Goal: Figures optimized for projected display — large text, high contrast, 16:9
+- Output: PNG (screen-res + print-res)
+
+---
+
+## Scenario Constraints
+
+| Parameter | Value |
+|-----------|-------|
+| `target` | `slides` |
+| `dpi_preview` | 150 |
+| `dpi_final` | 300 |
+| `export_formats` | `["png"]` |
+| `font_family` | Arial / Helvetica |
+| `font_size.axis_label` | 14 pt |
+| `font_size.tick` | 12 pt |
+| `font_size.title` | 18 pt |
+| `font_size.annotation` | 13 pt |
+
+**Figure size defaults**:
+- Standard slide figure: `[10.0, 5.6]` inches (16:9, fills most of slide)
+- Half-slide (side-by-side): `[4.8, 5.0]` inches
+- Quarter panel: `[4.8, 2.7]` inches
+
+---
+
+## Style Card Defaults
+
+```json
+{
+  "target": "slides",
+  "aesthetic_guide": null,
+  "dpi_preview": 150,
+  "dpi_final": 300,
+  "figure_size_inches": { "single_column": [10.0, 5.6], "half": [4.8, 5.0] },
+  "font_family": "Arial",
+  "font_size": { "axis_label": 14, "tick": 12, "legend": 12, "title": 18, "panel_letter": 16 },
+  "colors": {
+    "categorical_palette": ["#EE7733", "#0077BB", "#33BBEE", "#EE3377", "#CC3311", "#009988", "#BBBBBB"]
+  },
+  "export_formats": ["png"]
+}
+```
+
+Default `categorical_palette` is Paul Tol **`vibrant`** (from `figure_styling/styles/color_palettes.md`) — more vivid than `bright`, better legibility at projection distance. Override with `bright` for accessibility-critical audiences or `high-vis` for colorblind-critical contexts.
+
+**`aesthetic_guide` based on `<graph_settings>.style`**:
+- `nature-science` → `neurips_plot` (scientific precision)
+- `modern` → `null` + notes: "Flat design, bold accent color, white background, clean spines-off style"
+- `minimalist` → `null` + notes: "White background, open spines, no grid, only key data elements"
+- `3d-render` → `null` + notes: "Isometric 3D perspective, clean shadows, vibrant colors"
+
+---
+
+## Slide Figure Design Principles
+
+Slide figures have different rules than journal figures:
+
+1. **Legibility at distance**: Viewer is 2–5 meters from screen. All text ≥ 14 pt.
+2. **One figure = one message**: Do not cram multi-panel unless each panel is truly simple.
+3. **High contrast**: Background white or very dark; data elements use saturated colors.
+4. **Minimal axis furniture**: Remove spines (top + right at minimum); reduce ticks.
+5. **Large markers**: Line chart markers ≥ 8 pt; bar chart bars wide with clear separation.
+6. **Animation-friendly**: For `data-only` plots, produce a clean base PNG (no progressive reveal — that's the presenter's job in PowerPoint).
+
+---
+
+## Workflow
+
+```
+<graph_settings> parse → intent triage
+  → brief.json (slide format, 16:9)
+  → style_card.json (slide defaults)
+  → figure production
+  → font size verification (all labels ≥ 12 pt)
+  → quality check → delivery
+```
+
+### Step 1: Figure size
+
+Always use 16:9 proportions: `[10.0, 5.6]` unless user specifies "half slide" or specific dims.
+
+Set in matplotlib:
+```python
+fig = plt.figure(figsize=(10.0, 5.6))
+```
+
+### Step 2: Font size scaling
+
+Apply slide-specific rcParams override on top of style_card baseline:
+```python
+mpl.rcParams.update({
+    "font.size": 13,
+    "axes.labelsize": 14,
+    "xtick.labelsize": 12,
+    "ytick.labelsize": 12,
+    "legend.fontsize": 12,
+    "axes.titlesize": 18,
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+    "axes.grid": True,
+    "grid.alpha": 0.2,
+})
+```
+
+### Step 3: Color
+
+Apply `<graph_settings>.colorScheme.colors[0]` as the dominant data color (first category, primary line, etc.). Use vivid / saturated version — acceptable for slides.
+
+### Step 4: Critic extra check
+
+Verify in Phase 4:
+- All axis labels ≥ 12 pt (observer check via `observe_images`)
+- No clutter: if more than 6 categories, flag for simplification
+- 16:9 aspect ratio confirmed
+
+---
+
+## Quality Checklist
+
+- [ ] 16:9 aspect ratio
+- [ ] All text ≥ 12 pt (readable projected)
+- [ ] High contrast — data visible against background
+- [ ] Minimal axis clutter (open spines, light grid)
+- [ ] Single clear message per figure
+- [ ] PNG at 300 DPI (crisp on large display)

--- a/pantheon/factory/templates/skills/figure_styling/styles/color_palettes.md
+++ b/pantheon/factory/templates/skills/figure_styling/styles/color_palettes.md
@@ -1,0 +1,213 @@
+---
+id: color_palettes
+name: Scientific Color Palettes
+description: |
+  Publication-safe color palettes for scientific figures. All palettes are
+  colorblind-accessible and print safely in grayscale. Based on Paul Tol's
+  color schemes via SciencePlots (garrettj403/SciencePlots, MIT).
+source: https://github.com/garrettj403/SciencePlots
+license: MIT
+---
+
+# Scientific Color Palettes
+
+> **Attribution**: All palettes from SciencePlots
+> ([github.com/garrettj403/SciencePlots](https://github.com/garrettj403/SciencePlots), MIT),
+> `scienceplots/styles/color/`. Original color schemes designed by
+> Paul Tol ([personal.sron.nl/~pault](https://personal.sron.nl/~pault/)).
+
+## When to Use Which Palette
+
+| Palette | Best for | Categories | Colorblind-safe |
+|---|---|---|---|
+| `bright` | Most scientific plots | ≤7 | ✅ |
+| `vibrant` | Presentation slides, posters | ≤7 | ✅ |
+| `muted` | Dense multi-category, earth tones | ≤9 | ✅ |
+| `high-vis` | Accessibility-critical, color-blind audiences | ≤7 | ✅ |
+| `retro` | Distinctive / unique look | ≤6 | Partial |
+| `std-colors` | Default matplotlib replacement | ≤7 | Partial |
+
+**Rule**: always use colorblind-safe palette unless user explicitly overrides. ~8% of readers have color vision deficiency.
+
+---
+
+## Palette Definitions
+
+### `bright` — Paul Tol Bright (recommended default)
+
+> From `scienceplots/styles/color/bright.mplstyle`
+
+```python
+BRIGHT = ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377", "#BBBBBB"]
+# Blue, Red, Green, Yellow, Cyan, Purple, Grey
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = cycler("color", [
+    "#4477AA",  # blue
+    "#EE6677",  # red
+    "#228833",  # green
+    "#CCBB44",  # yellow
+    "#66CCEE",  # cyan
+    "#AA3377",  # purple
+    "#BBBBBB",  # grey
+])
+```
+
+**Use with**: `science`, `nature_figure`, `neurips_plot` styles. Default recommendation for all CNS figures.
+
+---
+
+### `vibrant` — Paul Tol Vibrant
+
+> From `scienceplots/styles/color/vibrant.mplstyle`
+
+```python
+VIBRANT = ["#EE7733", "#0077BB", "#33BBEE", "#EE3377", "#CC3311", "#009988", "#BBBBBB"]
+# Orange, Blue, Cyan, Magenta, Red, Teal, Grey
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = cycler("color", [
+    "#EE7733",  # orange
+    "#0077BB",  # blue
+    "#33BBEE",  # cyan
+    "#EE3377",  # magenta
+    "#CC3311",  # red
+    "#009988",  # teal
+    "#BBBBBB",  # grey
+])
+```
+
+**Use with**: poster figures, slides, graphical abstracts — more vivid than `bright`.
+
+---
+
+### `muted` — Paul Tol Muted
+
+> From `scienceplots/styles/color/muted.mplstyle`
+
+```python
+MUTED = ["#CC6677", "#332288", "#DDCC77", "#117733",
+         "#88CCEE", "#882255", "#44AA99", "#999933", "#AA4499"]
+# Rose, Indigo, Sand, Green, Cyan, Wine, Teal, Olive, Purple
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = cycler("color", [
+    "#CC6677",  # rose
+    "#332288",  # indigo
+    "#DDCC77",  # sand
+    "#117733",  # green
+    "#88CCEE",  # cyan
+    "#882255",  # wine
+    "#44AA99",  # teal
+    "#999933",  # olive
+    "#AA4499",  # purple
+])
+```
+
+**Use with**: figures with many categories (7–9). More subdued — appropriate for dense comparison plots.
+
+---
+
+### `high-vis` — High Visibility (Paul Tol)
+
+> From `scienceplots/styles/color/high-vis.mplstyle`
+
+```python
+HIGH_VIS = ["#0077BB", "#33BBEE", "#009988", "#EE7733", "#CC3311", "#EE3377", "#BBBBBB"]
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = (
+    cycler("color", ["#0077BB", "#33BBEE", "#009988",
+                     "#EE7733", "#CC3311", "#EE3377", "#BBBBBB"]) +
+    cycler("ls", ["-", "--", "-.", ":", "-", "--", "-."])
+)
+# lines.linewidth: 1.5 (thicker for visibility)
+mpl.rcParams["lines.linewidth"] = 1.5
+```
+
+**Use with**: accessibility-critical contexts. Line style variation built in for B&W printing.
+
+---
+
+### `retro` — Retro
+
+> From `scienceplots/styles/color/retro.mplstyle`
+
+```python
+RETRO = ["#4165c0", "#e770a2", "#5ac3be", "#696969", "#f79a1e", "#ba7dde"]
+# Blue, Pink, Cyan, Grey, Orange, Purple
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = cycler("color", [
+    "#4165c0",  # blue
+    "#e770a2",  # pink
+    "#5ac3be",  # cyan
+    "#696969",  # grey
+    "#f79a1e",  # orange
+    "#ba7dde",  # purple
+])
+```
+
+**Use with**: distinctive aesthetic preference. Less common in CNS-type journals; more suited to preprints, blogs, data journalism.
+
+---
+
+### `std-colors` — Standard Scientific Colors
+
+```python
+STD_COLORS = ["#0C5DA5", "#00B945", "#FF9500", "#FF2C00", "#845B97", "#474747", "#9e9e9e"]
+# Blue, Green, Orange, Red, Purple, Dark Grey, Grey
+```
+
+This is the SciencePlots `science.mplstyle` default cycle — used by most of its journal styles including `nature.mplstyle` as the base before font/size overrides. A clean, professional look for general scientific use.
+
+---
+
+## Application in `style_card.json`
+
+Set `colors.categorical_palette` to the desired palette array:
+
+```json
+{
+  "colors": {
+    "categorical_palette": ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377"],
+    "diverging_cmap": "RdBu_r",
+    "sequential_cmap": "viridis"
+  }
+}
+```
+
+`data_plotter` reads `style_card.colors.categorical_palette` and uses it as the `axes.prop_cycle`.
+
+## Combining Palettes with Style Files
+
+SciencePlots design: palettes are **modular overlays**, not standalone styles.
+
+```python
+# Correct usage pattern:
+plt.style.use(["science"])          # base style (sizes, ticks, fonts)
+plt.style.use(["bright"])           # color overlay
+# Or combined:
+plt.style.use(["science", "bright"])
+```
+
+In our system:
+- `style_card.aesthetic_guide` → loads the base style file (neurips_plot / nature_figure / ieee_figure)
+- `style_card.colors.categorical_palette` → provides the color overlay
+- Sub-agents apply both independently
+
+## Sequential & Diverging (not cycler-based)
+
+| Use case | Colormap | Notes |
+|---|---|---|
+| Ordered data, heatmap | `viridis` | Default, perceptually uniform |
+| Intensity / density | `magma` or `plasma` | High contrast at extremes |
+| Positive / negative | `RdBu_r` | Diverging, white at zero |
+| Gene expression | `RdYlBu_r` or `PuOr` | Biology convention |
+| Genomics / ATAC | `Blues` or `YlOrRd` | Single-hue sequential |
+| **Avoid** | `jet`, `rainbow`, `hot` | Perceptually non-uniform, misleading |

--- a/pantheon/factory/templates/skills/figure_styling/styles/ieee_figure.md
+++ b/pantheon/factory/templates/skills/figure_styling/styles/ieee_figure.md
@@ -1,0 +1,128 @@
+---
+id: ieee_figure
+name: IEEE Figure Style
+description: |
+  Aesthetic guidelines for statistical plots targeting IEEE journals and
+  conferences (TPAMI, CVPR, ICCV, ICASSP, etc.). Based on SciencePlots
+  (garrettj403/SciencePlots, MIT) ieee.mplstyle. Black-and-white compatible,
+  600 DPI, Computer Modern serif, inward ticks with minor ticks visible.
+source: https://github.com/garrettj403/SciencePlots
+license: MIT
+---
+
+# IEEE Figure Style
+
+> **Attribution**: rcParams baseline directly from SciencePlots
+> ([github.com/garrettj403/SciencePlots](https://github.com/garrettj403/SciencePlots), MIT),
+> `scienceplots/styles/journals/ieee.mplstyle`.
+> Original content: `axes.prop_cycle : cycler('color', ['k', 'r', 'b', 'g']) +
+> cycler('ls', ['-', '--', ':', '-.'])`, figure.figsize 3.5×2.625,
+> font.family serif, font.serif cmr10/Computer Modern.
+
+## 1. The "IEEE Look"
+
+IEEE figures are defined by:
+- **Black-and-white compatibility first** — every series distinguished by line style, not just color
+- **Computer Modern serif** — cmr10 (same as LaTeX default), not Times New Roman
+- **Inward ticks on all 4 sides** — top + right ticks on, minor ticks visible
+- **No legend frame** — frameon = False
+- **3.5" single column** — slightly wider than Nature (3.3")
+
+## 2. rcParams Baseline (from `ieee.mplstyle`)
+
+```python
+from cycler import cycler
+import matplotlib as mpl
+
+mpl.rcParams.update({
+    # Color + line style + marker cycle — B&W compatible, ≥6 series distinguishable
+    # Source: scienceplots/styles/journals/ieee.mplstyle (color+ls) + marker added
+    "axes.prop_cycle": (
+        cycler("color", ["k", "r", "b", "g", "m", "c"]) +
+        cycler("ls", ["-", "--", ":", "-.", "-", "--"]) +
+        cycler("marker", ["o", "s", "^", "D", "v", "P"])
+    ),
+
+    # Figure size — 3.5" single column
+    "figure.figsize": [3.5, 2.625],
+
+    # Ticks — inward, all 4 sides, minor ticks on
+    "xtick.direction": "in",
+    "xtick.major.size": 3,
+    "xtick.major.width": 0.5,
+    "xtick.minor.size": 1.5,
+    "xtick.minor.width": 0.5,
+    "xtick.minor.visible": True,
+    "xtick.top": True,
+    "ytick.direction": "in",
+    "ytick.major.size": 3,
+    "ytick.major.width": 0.5,
+    "ytick.minor.size": 1.5,
+    "ytick.minor.width": 0.5,
+    "ytick.minor.visible": True,
+    "ytick.right": True,
+
+    # Line widths
+    "axes.linewidth": 0.5,
+    "grid.linewidth": 0.5,
+    "lines.linewidth": 1.0,
+    "lines.markersize": 4,  # small markers for dense plots
+
+    # Font — Computer Modern serif (LaTeX default)
+    "font.family": "serif",
+    "font.serif": ["cmr10", "Computer Modern Serif", "DejaVu Serif"],
+    "axes.formatter.use_mathtext": True,
+    "mathtext.fontset": "cm",
+    "font.size": 8,
+    "axes.labelsize": 8,
+    "xtick.labelsize": 8,
+    "ytick.labelsize": 8,
+
+    # No legend frame
+    "legend.frameon": False,
+
+    # Save
+    "savefig.bbox": "tight",
+    "savefig.pad_inches": 0.05,
+    "savefig.dpi": 600,
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
+    "svg.fonttype": "none",
+})
+```
+
+## 3. Figure Sizes
+
+| Format | Width × Height | Notes |
+|---|---|---|
+| Single column | 3.5" × 2.625" | Standard |
+| 1.5-column | 5.0" × 3.5" | Some journals allow |
+| Double column | 7.16" × 5.0" | Full-width |
+
+## 4. Color & Line Style Strategy
+
+**Primary rule**: every series must be distinguishable in grayscale print.
+
+The `axes.prop_cycle` in the rcParams baseline above pairs **color + line style + marker** automatically for up to 6 series. This triple encoding ensures B&W print, colorblind, and screen viewers can all distinguish data series.
+
+- Series 1: black solid circle `k-o`
+- Series 2: red dashed square `r--s`
+- Series 3: blue dotted triangle-up `b:^`
+- Series 4: green dash-dot diamond `g-.D`
+- Series 5: magenta solid triangle-down `m-v`
+- Series 6: cyan dashed plus `c--P`
+
+**For heatmaps**: grayscale (`plt.cm.Greys`) or single-hue sequential. Avoid multi-hue.
+
+## 5. Font Notes
+
+IEEE LaTeX templates use Computer Modern (`\usepackage{times}` is common but CM is acceptable). The `cmr10` entry in `font.serif` ensures matplotlib uses Computer Modern when available. If not installed, falls back to DejaVu Serif — acceptable for drafts.
+
+## 6. Common Pitfalls
+
+- ❌ Color as sole differentiator — IEEE prints/reviews in B&W
+- ❌ Sans-serif axis labels — CM serif is the house style
+- ❌ Missing minor ticks — all 4 sides should show both major and minor
+- ❌ Legend frame (`frameon=True`) — remove it
+- ❌ Figure wider than 3.5" single column — will be resized by production
+- ❌ Missing axis units — always `Accuracy (%)` not just `Accuracy`

--- a/pantheon/factory/templates/skills/figure_styling/styles/nature_figure.md
+++ b/pantheon/factory/templates/skills/figure_styling/styles/nature_figure.md
@@ -1,0 +1,146 @@
+---
+id: nature_figure
+name: "Nature / Cell / Science Figure Style"
+description: |
+  Aesthetic guidelines for publication-quality figures targeting Nature,
+  Cell, Science, and their family journals. Based on SciencePlots
+  (garrettj403/SciencePlots, MIT) nature.mplstyle, with Cell Press and
+  AAAS Science size specifications added.
+source: https://github.com/garrettj403/SciencePlots
+license: MIT
+---
+
+# Nature / Cell / Science Figure Style
+
+> **Attribution**: rcParams baseline from SciencePlots
+> ([github.com/garrettj403/SciencePlots](https://github.com/garrettj403/SciencePlots), MIT),
+> `scienceplots/styles/journals/nature.mplstyle`. Extended with Cell Press
+> and AAAS Science journal specifications from author guidelines.
+
+## 1. The "CNS Look"
+
+Three journals — Cell, Nature, Science — share a house style:
+- **7 pt body text** — the single most distinctive constraint; everything is small and precise
+- **Sans-serif throughout** — Arial/Helvetica exclusively (DejaVu Sans as fallback)
+- **No gridlines** — stark white background, no grid in most figure types
+- **Inward ticks on all 4 sides** — top and right ticks on, minor ticks visible
+- **Muted colorblind-safe palettes** — never Jet/Rainbow; prefer Paul Tol sets (see `color_palettes.md`)
+- **600 DPI final** — 300 DPI preview acceptable
+
+## 2. rcParams Baseline (from `nature.mplstyle`)
+
+```python
+import matplotlib as mpl
+
+mpl.rcParams.update({
+    # Figure size — Nature single column (max 3.5" wide)
+    "figure.figsize": [3.5, 2.625],
+
+    # Fonts — sans-serif, 7 pt body
+    "font.family": "sans-serif",
+    "font.sans-serif": ["Arial", "Helvetica", "DejaVu Sans"],
+    "font.size": 7,
+    "axes.labelsize": 7,
+    "xtick.labelsize": 7,
+    "ytick.labelsize": 7,
+    "legend.fontsize": 7,
+    "axes.titlesize": 8,
+    "mathtext.fontset": "dejavusans",
+
+    # Ticks — inward, all 4 sides, minor ticks on
+    "xtick.direction": "in",
+    "xtick.major.size": 3,
+    "xtick.major.width": 0.5,
+    "xtick.minor.size": 1.5,
+    "xtick.minor.width": 0.5,
+    "xtick.minor.visible": True,
+    "xtick.top": True,
+    "ytick.direction": "in",
+    "ytick.major.size": 3,
+    "ytick.major.width": 0.5,
+    "ytick.minor.size": 1.5,
+    "ytick.minor.width": 0.5,
+    "ytick.minor.visible": True,
+    "ytick.right": True,
+
+    # Lines
+    "axes.linewidth": 0.5,
+    "grid.linewidth": 0.5,
+    "lines.linewidth": 1.0,
+    "lines.markersize": 3,
+
+    # No legend frame
+    "legend.frameon": False,
+
+    # Save
+    "savefig.bbox": "tight",
+    "savefig.pad_inches": 0.01,
+    "savefig.dpi": 600,
+    "pdf.fonttype": 42,   # editable text in PDF
+    "ps.fonttype": 42,
+    "svg.fonttype": "none",  # editable text in SVG
+})
+```
+
+## 3. Figure Sizes by Journal
+
+| Journal | Single column | 1.5-column | Double column | Notes |
+|---|---|---|---|---|
+| **Nature family** | 3.5" × 2.625" | — | 7.2" × 5.0" | Max width 3.5" single |
+| **Cell Press** | 3.35" × 2.5" (85 mm) | 4.49" (114 mm) | 6.85" × 5.0" (174 mm) | Height flexible |
+| **AAAS Science** | 2.24" × 2.0" (57 mm) | 4.72" (120 mm) | 4.72" × 3.5" | Very narrow single |
+| **Default / unknown** | 3.5" × 2.625" | — | 7.0" × 5.0" | Safe fallback |
+
+**Graphical abstract sizes**:
+- Cell Press: 169 mm × 60 mm (6.65" × 2.36") landscape
+- Nature: 90 mm × 60 mm (3.54" × 2.36") portrait-ish
+- Elsevier: 130 mm × 70 mm (5.12" × 2.76")
+
+## 4. Recommended Color Palettes
+
+See `color_palettes.md` for the full Paul Tol palette library. Quick reference for CNS:
+
+**Categorical (colorblind-safe)**:
+```python
+# Paul Tol "bright" — recommended default for CNS
+BRIGHT = ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377", "#BBBBBB"]
+
+# Paul Tol "muted" — for dense multi-category plots
+MUTED = ["#CC6677", "#332288", "#DDCC77", "#117733", "#88CCEE", "#882255", "#44AA99"]
+```
+
+**Sequential / heatmap**:
+- `viridis` — default for all sequential data
+- `magma` / `plasma` — alternative perceptually uniform
+- `RdBu_r` — diverging (positive/negative splits)
+- Never `jet` / `rainbow`
+
+## 5. Panel Letters
+
+Nature style panel letters: **bold, 8 pt, upper-left corner** of each panel.
+
+```python
+ax.text(-0.15, 1.05, "a", transform=ax.transAxes,
+        fontsize=8, fontweight="bold", va="top", ha="right")
+```
+
+Cell Press uses lower-case bold: `a`, `b`, `c` at 8 pt.
+
+## 6. Multi-panel Figure Rules
+
+- All panels must use **identical font sizes** across a figure
+- **Align panel bottoms** on a common baseline (use `gridspec` with `hspace`)
+- **No whitespace waste** — pack panels tightly; Nature reviewers notice gaps
+- **Consistent axis ranges** when comparing conditions across panels
+- **Scale bars** instead of axis ticks for microscopy / spatial data
+
+## 7. Common Pitfalls
+
+- ❌ Font > 7 pt — wastes precious column width; reviewers notice
+- ❌ Gridlines — CNS almost never shows them in main figures
+- ❌ Both top/right spines visible but un-ticked — either add ticks or remove spines
+- ❌ Serif fonts on axes — DejaVu Sans, not Times
+- ❌ Figure wider than column spec — journal production will resize, destroying aspect ratio
+- ❌ Jet/Rainbow colormap — unacceptable in all three journals
+- ❌ Panel letters not bold — must be bold weight
+- ❌ Caption text inside figure — captions go in `figure_legends.md`

--- a/pantheon/factory/templates/skills/figure_styling/styles/neurips_plot.md
+++ b/pantheon/factory/templates/skills/figure_styling/styles/neurips_plot.md
@@ -89,6 +89,12 @@ The prevailing aesthetic is defined by **precision, accessibility, and high cont
 ## 5. Recommended matplotlib rcParams Baseline
 
 ```python
+from cycler import cycler
+import matplotlib as mpl
+
+# Paul Tol bright — colorblind-safe default (from color_palettes.md)
+BRIGHT = ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377", "#BBBBBB"]
+
 mpl.rcParams.update({
     "font.family": "sans-serif",
     "font.sans-serif": ["Helvetica", "Arial", "DejaVu Sans"],
@@ -101,12 +107,40 @@ mpl.rcParams.update({
     "axes.linewidth": 0.8,
     "lines.linewidth": 1.5,
     "lines.markersize": 5,
+
+    # Color cycle — Paul Tol bright
+    "axes.prop_cycle": cycler("color", BRIGHT),
+
+    # Grid — dashed, light, behind data
     "axes.grid": True,
     "grid.alpha": 0.3,
     "grid.linestyle": "--",
+    "grid.color": "#cccccc",
+
+    # Spines — open (top + right removed)
     "axes.spines.top": False,
     "axes.spines.right": False,
+
+    # Ticks — inward, minor ticks on bottom+left only
+    "xtick.direction": "in",
+    "xtick.major.size": 3,
+    "xtick.major.width": 0.5,
+    "xtick.minor.size": 1.5,
+    "xtick.minor.width": 0.5,
+    "xtick.minor.visible": True,
+    "ytick.direction": "in",
+    "ytick.major.size": 3,
+    "ytick.major.width": 0.5,
+    "ytick.minor.size": 1.5,
+    "ytick.minor.width": 0.5,
+    "ytick.minor.visible": True,
+
+    # Legend
+    "legend.frameon": False,
+
+    # Save
     "savefig.dpi": 600,
+    "savefig.bbox": "tight",
     "pdf.fonttype": 42,
     "ps.fonttype": 42,
     "svg.fonttype": "none",

--- a/pantheon/factory/templates/skills/figure_styling/styles/visual_quality_checklist.md
+++ b/pantheon/factory/templates/skills/figure_styling/styles/visual_quality_checklist.md
@@ -1,0 +1,116 @@
+---
+id: visual_quality_checklist
+name: Visual Quality Checklist (Nature/Cell Level)
+description: |
+  Publication-readiness checklist for scientific figures targeting Nature,
+  Cell, Science, and top ML venues. Covers data-ink ratio, typography,
+  color, layout, and accessibility. Derived from rougier/scientific-
+  visualization-book (CC BY-NC-SA) and Tufte's visual design principles.
+source: https://github.com/rougier/scientific-visualization-book
+license: CC BY-NC-SA 4.0
+---
+
+# Visual Quality Checklist (Nature / Cell Level)
+
+> **Attribution**: Principles adapted from *Scientific Visualization: Python + Matplotlib*
+> by Nicolas P. Rougier ([github.com/rougier/scientific-visualization-book](https://github.com/rougier/scientific-visualization-book),
+> CC BY-NC-SA 4.0), and Edward Tufte's *The Visual Display of Quantitative Information*.
+> Applied to the context of Nature/Cell/Science submission quality.
+
+## Purpose
+
+Used by `illustrator` (Phase 4 critic) and `data_plotter` (review loop) as a
+**supplementary quality gate** on top of `diagram_critic.md` / `plot_critic.md`.
+Run this checklist before reporting a figure as publication-ready.
+
+---
+
+## Tier 1 — Data Integrity (Hard failures — ALWAYS check)
+
+These failures mean the figure is **scientifically misleading**. Reject and regenerate.
+
+- [ ] **Axis zero baseline**: bar charts / area charts MUST start at zero unless data range makes it meaningless (e.g., 99.0–99.8% accuracy). Truncated Y axes misrepresent effect sizes.
+- [ ] **Error bar definition stated**: if error bars exist, the caption must specify what they represent (SD, SEM, 95% CI, range). Critic flags if ambiguous.
+- [ ] **No dual Y-axis distortion**: dual Y-axis plots are acceptable only when both scales have a principled relationship. Arbitrary scaling to make lines "appear" correlated is misleading.
+- [ ] **Sample size visible**: N must appear in panel, legend, or caption. A beautiful figure with N=3 is still publishable; a figure where N is hidden is not.
+- [ ] **Color encodes one dimension only**: a single color channel should not simultaneously encode two variables (e.g., both condition and significance level).
+
+---
+
+## Tier 2 — Data-Ink Ratio (Rougier / Tufte principle)
+
+Every pixel in a figure should carry information. Remove everything that does not.
+
+- [ ] **No chartjunk**: 3D perspective bars, drop shadows, gradient fills, decorative borders — all removed. None of these add information.
+- [ ] **No redundant legend**: if data series are directly labeled on the plot (direct annotation), the floating legend is redundant — remove it.
+- [ ] **No grid clutter**: gridlines, if present, must be light grey and dashed (never solid black). For CNS figures, gridlines are usually absent entirely.
+- [ ] **Minimal spines**: either "boxed" (all 4 sides, formal) or "open" (top + right removed, modern). Never mix arbitrarily.
+- [ ] **No unnecessary tick marks**: if a value is not referenced in the text or caption, its tick mark adds noise. Prune to the meaningful values.
+- [ ] **Axis labels are informative**: `Accuracy (%)` not `acc`; `Time (s)` not `t`; `Expression level (log2 CPM)` not `expr`.
+
+---
+
+## Tier 3 — Typography (Rougier hierarchy principle)
+
+Font hierarchy must be strictly enforced — readers use size to judge importance.
+
+- [ ] **Strict font size hierarchy**: title > axis label > tick label > legend > annotation. Specifically for CNS: title (if any) 8 pt, axis labels 7 pt, ticks 7 pt, legend 7 pt. No two elements the same importance should be the same size.
+- [ ] **Single font family throughout**: one figure, one family. Mixing Arial on axes with Times in legend is a common error.
+- [ ] **No font below 6 pt**: anything smaller is unreadable in print. Scale figure or simplify.
+- [ ] **Math in italic**: variables like *x*, *y*, *n*, *p* must be italic (LaTeX `$x$` or mathtext). Plain roman text `x` in a formula is typographically incorrect.
+- [ ] **Units always present**: `[ms]`, `(%)`, `(log₂ FC)` — never omit units from quantitative axes.
+
+---
+
+## Tier 4 — Color & Accessibility
+
+- [ ] **Colorblind-safe palette**: use Paul Tol `bright` or `vibrant` from `color_palettes.md`. Verify with a grayscale preview — all series must be distinguishable.
+- [ ] **No Jet/Rainbow**: perceptually non-uniform, creates false visual cliffs. Replace with `viridis`, `magma`, or `RdBu_r`.
+- [ ] **Color is not the only encoding**: for line charts, pair each color with a distinct marker shape; for bar charts, pair with hatch pattern when needed. This ensures B&W printing works.
+- [ ] **Sufficient contrast**: text on colored backgrounds must pass WCAG AA (contrast ratio ≥ 4.5:1). White text on dark bars; black text on light bars.
+- [ ] **Colorbar present for heatmaps**: every heatmap must have a visible colorbar with labeled min/max. Exception: small schematic heatmaps used purely for illustration.
+
+---
+
+## Tier 5 — Layout & Composition
+
+- [ ] **Aspect ratio is principled**: don't stretch a figure to fill a column if the data doesn't warrant it. Square for heatmaps; 1.6:1 for most line/bar charts; 2:1 for wide comparison panels.
+- [ ] **Panel letters are consistent**: all panels in a multi-panel figure use the same letter style — either all bold 8 pt top-left (Nature), or all bold 8 pt top-left (Cell). Never mix sizes.
+- [ ] **White space is deliberate**: panels tightly packed but not touching. Use `hspace` and `wspace` in gridspec to control precisely.
+- [ ] **Figure fits within column**: single-column figures ≤3.5" wide; double-column ≤7.2" wide. Figures that bleed into margins are rejected.
+- [ ] **Insets are legible**: if an inset panel exists, its text must still meet minimum font size. Inset axes are typically 50–70% of the parent axes size.
+
+---
+
+## Tier 6 — Reproducibility (Nature/Cell submission requirement)
+
+- [ ] **Data source referenced**: figure caption must indicate the data source (dataset name, accession number, or "n=X independent experiments").
+- [ ] **Statistical test named**: "Two-sided unpaired t-test" not just "p < 0.05". Nature requires the specific test in Methods or figure caption.
+- [ ] **Software version stated**: in Methods section, not in figure, but flagged here as a checklist item.
+- [ ] **Code available**: for computational figures, code must be available (GitHub / Zenodo). Figures generated from code that cannot be shared will face reviewer questions.
+
+---
+
+## Critic Usage
+
+`data_plotter` and `illustrator` run this checklist in their final review round.
+Output format (append to critic JSON):
+
+```json
+{
+  "visual_quality": {
+    "tier1_data_integrity": "pass | fail | warning",
+    "tier2_data_ink": "pass | fail | warning",
+    "tier3_typography": "pass | fail | warning",
+    "tier4_color": "pass | fail | warning",
+    "tier5_layout": "pass | fail | warning",
+    "tier6_reproducibility": "pass | N/A",
+    "blockers": ["list of Tier 1 failures that must be fixed before delivery"],
+    "warnings": ["list of Tier 2-5 issues that should be addressed"]
+  }
+}
+```
+
+**Tier 1 failures are hard blockers** — figure cannot be delivered until resolved.
+**Tier 2–5 warnings** — flag to leader; leader decides whether to re-delegate or note in delivery.
+**Tier 6** — informational; noted in `figure_legends.md` caption.

--- a/pantheon/factory/templates/skills/figure_styling/triage/SKILL.md
+++ b/pantheon/factory/templates/skills/figure_styling/triage/SKILL.md
@@ -1,0 +1,40 @@
+---
+id: figure_triage_index
+name: Figure Triage Rules Index
+description: |
+  Triage rules for figure type classification and routing decisions.
+  Run in Phase 1 (after input optimization, before production).
+  Adapted from SHALINS428/Codex-drawio-skill (MIT) and
+  bahayonghang/drawio-skills (MIT).
+---
+
+# Figure Triage Rules
+
+These rules help leader classify the user's request and make routing decisions
+before committing to sub-agent production.
+
+## Rules
+
+| Rule | File | Purpose | When to use |
+|---|---|---|---|
+| `figure_type_classifier` | [figure_type_classifier.md](./figure_type_classifier.md) | Classify into Architecture / Roadmap / Workflow / Plot | Every request before routing |
+| `granularity_rule` | [granularity_rule.md](./granularity_rule.md) | Decide if request should be split into multiple figures | When request mentions multiple concerns |
+
+## Usage (leader)
+
+```
+Phase 1: Intent Triage (after brief.json is initialized)
+
+1. Run figure_type_classifier on S_source_context + C_communicative_intent
+   → get figure_type (Architecture / Roadmap / Workflow / Statistical Plot /
+     Conceptual Framework / Schematic)
+   → write to brief.json as category
+
+2. If figure_type is ambiguous OR user mentions multiple concerns:
+   → run granularity_rule
+   → if should_split == true: decompose into multiple figure records in brief.json
+
+3. Route based on figure_type:
+   - Statistical Plot → data_plotter
+   - all others → illustrator (or composite if mixed)
+```

--- a/pantheon/factory/templates/skills/figure_styling/triage/figure_type_classifier.md
+++ b/pantheon/factory/templates/skills/figure_styling/triage/figure_type_classifier.md
@@ -1,0 +1,158 @@
+---
+id: figure_type_classifier
+name: Figure Type Classifier
+description: |
+  Classify user request into one of six figure types, each with distinct
+  routing, quality focus, and generation strategy.
+source: https://github.com/SHALINS428/Codex-drawio-skill
+license: MIT
+---
+
+# Figure Type Classifier
+
+> **Source**: Adapted from `skill/drawio/references/figure-types.md` in
+> [SHALINS428/Codex-drawio-skill](https://github.com/SHALINS428/Codex-drawio-skill)
+> (MIT), and `references/docs/academic-figure-playbook.md` in
+> [bahayonghang/drawio-skills](https://github.com/bahayonghang/drawio-skills) (MIT).
+
+## Purpose
+
+Classify the user's request into one of six figure types before routing to
+sub-agents. Each type has different routing, quality focus, and generation
+strategy.
+
+## Figure Types
+
+### System Architecture
+
+**Use when reader needs to understand**: what modules exist, how modules relate,
+where data enters/leaves, how runtime responsibilities are divided.
+
+**Typical nodes**: data source, preprocessing layer, model layer, retrieval
+layer, output/application layer.
+
+**Quality focus**: group major subsystems clearly; show boundaries and
+interaction paths, not procedural chronology; avoid turning architecture into
+a step-by-step flowchart.
+
+**GraphAgent routing**: `illustrator` (category: `agent_reasoning` or
+`generative_learning`)
+
+**Keywords**: 架构, 模块, 组件, 边界, 系统, architecture, module, component,
+system, subsystem
+
+---
+
+### Technical Roadmap
+
+**Use when reader needs to understand**: how study progresses, how one stage
+leads to next, what each stage produces, where validation appears.
+
+**Typical structure**: stage → key task → stage output.
+
+**Quality focus**: keep progression visually directional and stage-based;
+limit stage count to readable set; make outputs visible at end of each major
+stage.
+
+**GraphAgent routing**: `illustrator` (category: `science_applications`)
+
+**Keywords**: 阶段, 路线图, 推进, roadmap, phase, milestone, stage, timeline
+
+---
+
+### Workflow / Process
+
+**Use when reader needs to understand**: ordered steps, branching conditions,
+loops, trigger and fallback logic.
+
+**Typical nodes**: start, process, decision, fallback, output.
+
+**Quality focus**: make branching explicit; label ambiguous decisions; keep
+loops readable without tangled back-edges.
+
+**GraphAgent routing**: `illustrator` (category: `science_applications`,
+scenario: `flowchart`)
+
+**Keywords**: 流程, 步骤, 分支, 循环, workflow, process, step, branch,
+decision, loop, protocol
+
+---
+
+### Statistical Plot
+
+**Use when reader needs to understand**: quantitative results, comparisons,
+distributions, correlations.
+
+**Typical forms**: bar chart, line chart, scatter plot, heatmap, violin plot,
+UMAP, volcano plot.
+
+**Quality focus**: data accuracy, colorblind-safe palette, appropriate chart
+type for data structure.
+
+**GraphAgent routing**: `data_plotter`
+
+**Keywords**: 数据, 统计, 图表, bar, line, scatter, heatmap, violin, UMAP,
+volcano, box plot, plot, chart
+
+---
+
+### Conceptual Framework
+
+**Use when reader needs to understand**: theoretical relationships, abstract
+concepts, high-level system logic without implementation detail.
+
+**Typical forms**: mind map style, entity-relationship, ontology diagram.
+
+**Quality focus**: abstract level is clear; no implementation detail leaking
+into conceptual view.
+
+**GraphAgent routing**: `illustrator` (category: `agent_reasoning`)
+
+**Keywords**: 框架, 理论, 概念, 关系, framework, theory, concept, relationship,
+ontology
+
+---
+
+### Scientific Schematic
+
+**Use when reader needs to understand**: biological pathways, chemical reactions,
+experimental protocols, cellular mechanisms.
+
+**Typical forms**: signaling pathway, metabolic pathway, reaction scheme,
+cellular schematic, mechanism cartoon.
+
+**Quality focus**: biological/chemical accuracy; correct iconography conventions
+(T-bars for inhibition, arrows for activation); compartment boundaries.
+
+**GraphAgent routing**: `illustrator` (category: `science_applications`)
+
+**Keywords**: 通路, 信号, 代谢, 细胞, 机制, pathway, signaling, metabolic,
+cellular, mechanism, reaction, inhibition, activation
+
+---
+
+## Classification Logic
+
+```
+1. Scan S_source_context + C_communicative_intent + user message for keywords
+2. Match to figure type using keyword table above
+3. If ambiguous (≥2 types match) → run granularity_rule
+4. Write result to brief.json:
+   {
+     "figure_type": "<type>",
+     "routing": "<data_plotter | illustrator>",
+     "category": "<statistical_plot | agent_reasoning | science_applications | ...>"
+   }
+```
+
+## Output (add to brief.json)
+
+```json
+{
+  "figure_type": "System Architecture",
+  "routing": "illustrator",
+  "category": "agent_reasoning",
+  "classifier_confidence": "high",
+  "classifier_reasoning": "User mentions '模块', '数据输入输出', '系统边界' — all architecture keywords. No temporal progression or execution branches."
+}
+```

--- a/pantheon/factory/templates/skills/figure_styling/triage/granularity_rule.md
+++ b/pantheon/factory/templates/skills/figure_styling/triage/granularity_rule.md
@@ -1,0 +1,100 @@
+---
+id: granularity_rule
+name: Granularity Rule
+description: |
+  Determine if a user request should be split into multiple figures. Prevents
+  cramming structure + progression + execution into one unusable figure.
+source: https://github.com/SHALINS428/Codex-drawio-skill
+license: MIT
+---
+
+# Granularity Rule
+
+> **Source**: Adapted from `skill/drawio/references/figure-types.md` (Granularity Rule
+> section) in [SHALINS428/Codex-drawio-skill](https://github.com/SHALINS428/Codex-drawio-skill)
+> (MIT), and `references/docs/academic-figure-playbook.md` in
+> [bahayonghang/drawio-skills](https://github.com/bahayonghang/drawio-skills) (MIT).
+
+## The Rule
+
+Before drawing, ask: **Is this figure explaining structure, progression, or execution?**
+
+| Question | Figure type |
+|---|---|
+| What modules exist and how do they relate? | → System Architecture |
+| How does the study/method progress over time? | → Technical Roadmap |
+| What are the ordered steps and decision branches? | → Workflow / Process |
+
+**Do not collapse all three into one overloaded figure.**
+
+If a figure tries to explain structure, chronology, and detailed control flow
+simultaneously — split it into two or three figures.
+
+## Mixing Signals (split triggers)
+
+| Combination | Decision |
+|---|---|
+| "架构" + "流程" (structure + process) | **Split** |
+| "模块" + "步骤" (modules + steps) | **Split** |
+| "系统图" + "统计数据" (diagram + data plot) | **Split** |
+| "阶段" + "分支逻辑" (stages + branching) | **Split** |
+| "方法概述" + "实验结果" (method + results) | **Split** |
+| All elements belong to one concern | **Single figure** |
+
+## Detection Logic
+
+```
+1. Extract all figure-type keywords from user message + S_source_context
+2. Count how many distinct figure types are implied
+3. If count == 1 → single figure, proceed
+4. If count >= 2 → should_split = true, suggest decomposition
+```
+
+## Output (add to brief.json)
+
+**Should not split:**
+```json
+{
+  "should_split": false,
+  "reason": "All elements are structural — modules, boundaries, data flows. No temporal progression or execution branches."
+}
+```
+
+**Should split:**
+```json
+{
+  "should_split": true,
+  "reason": "Request mixes System Architecture (系统架构) + Technical Roadmap (四个阶段) + Statistical Plot (损失曲线).",
+  "suggested_split": [
+    {
+      "figure_id": "Fig1",
+      "figure_type": "System Architecture",
+      "scope": "Overall system modules and data boundaries",
+      "routing": "illustrator"
+    },
+    {
+      "figure_id": "Fig2",
+      "figure_type": "Technical Roadmap",
+      "scope": "Four-stage training pipeline progression",
+      "routing": "illustrator"
+    },
+    {
+      "figure_id": "Fig3",
+      "figure_type": "Statistical Plot",
+      "scope": "Training and validation loss curves",
+      "routing": "data_plotter"
+    }
+  ]
+}
+```
+
+## Leader Action When `should_split == true`
+
+If the split is obvious (≥2 clearly distinct concerns) → decompose into
+multiple figure records in `brief.json` and proceed without asking the user.
+
+If the split is ambiguous → surface one-liner to user:
+> "您的需求包含多个图型（架构图 + 流程图），建议生成 2 张图。是否继续？"
+
+If user declines → generate as single composite-panel figure and note in
+`figure_legends.md` that the figure combines multiple concerns.

--- a/pantheon/factory/templates/teams/graph_maker_team.md
+++ b/pantheon/factory/templates/teams/graph_maker_team.md
@@ -69,15 +69,17 @@ Leader infers `export_formats` from message intent and writes it into `style_car
 
 Every task begins with a canonical `{workdir}/inputs/style_card.json` — the single source of truth for DPI, colors, fonts, figure dimensions, and export formats. Sub-agents MUST read and apply the style card; leader enforces consistency across figures.
 
-The `aesthetic_guide` field in `style_card.json` names a style file distributed via the **`figure_styling` skill** (`skills/figure_styling/styles/<aesthetic_guide>.md`). Sub-agents load that file on demand — it is NOT inlined into their system prompts. Built-in style files:
+The `aesthetic_guide` field in `style_card.json` names a style file distributed via the **`figure_styling` skill** (`skills/figure_styling/styles/<aesthetic_guide>.md`). Sub-agents load that file on demand — it is NOT inlined into their system prompts.
 
 | aesthetic_guide | Target | Figure class |
 |---|---|---|
-| `neurips_diagram` | NeurIPS / top ML venues | Methodology / framework / pipeline diagrams |
-| `neurips_plot` | NeurIPS / top ML venues | Statistical plots |
+| `neurips_diagram` | NeurIPS / ICML / ICLR / CVPR | Methodology / framework diagrams |
+| `neurips_plot` | NeurIPS / ICML / ICLR / CVPR | Statistical plots |
+| `nature_figure` | Nature / Cell / Science / life-science | Publication-grade scientific figures |
+| `ieee_figure` | IEEE / ACM / engineering | Engineering / systems publication figures |
 | `custom` / `null` | — | Rely only on `style_card.json` + agent defaults |
 
-Users can extend with additional files (e.g., `nature_figure.md`, `ieee_figure.md`) and reference them by id in `style_card.json`. Conflict priority: **user references > style_card.json > figure_styling/<aesthetic_guide> > agent defaults**.
+Conflict priority: **user references > style_card.json > figure_styling/<aesthetic_guide> > agent defaults**.
 
 ## Canvas Integration
 

--- a/pantheon/factory/templates/teams/graph_maker_team.md
+++ b/pantheon/factory/templates/teams/graph_maker_team.md
@@ -148,15 +148,16 @@ Leader infers execution depth from message language — no explicit mode flag.
 2. **Reference detection**: Scan user message for reference figures/URLs/documents; if found, `researcher` normalizes them.
 3. **Style card**: Author `inputs/style_card.json` with DPI, fonts, colors, figure sizes, and `export_formats`.
 4. **Canvas state** (if canvas.json exists): read relevant frame/node slice based on CANVAS_CONTEXT.
-5. **Environment audit** (optional, only if tools missing): `researcher` checks matplotlib/seaborn/plotly/svgutils/Pillow/inkscape.
-6. **Figure production** (parallelized across independent figures):
+5. **Figure production** (parallelized across independent figures):
    - Data panels → `data_plotter` with style card injection
    - Conceptual panels → `illustrator` → if publication, `researcher` vectorizes PNG to SVG/PDF
-7. **Composition** (composite intent): `data_plotter` composes via svgutils; exports per `export_formats`.
-8. **Verification**: leader runs `observe_images` on each PNG; re-delegates on failure.
-9. **agent_output.json**: leader writes canvas node declarations for all produced figures with positions, origins, and intents.
-10. **Manifest + legends**: write `.canvas/figure_manifest.json` and `.canvas/figure_legends.md`.
-11. **Delivery**: concise summary of figure paths returned to user.
+6. **Composition** (composite intent): `data_plotter` composes via svgutils; exports per `export_formats`.
+7. **Verification**: leader runs `observe_images` on each PNG; re-delegates on failure.
+8. **agent_output.json**: leader writes canvas node declarations for all produced figures with positions, origins, and intents.
+9. **Manifest + legends**: write `.canvas/figure_manifest.json` and `.canvas/figure_legends.md`.
+10. **Delivery**: concise summary of figure paths returned to user.
+
+> **Environment check**: not a separate step. `data_plotter` handles missing packages on first `ImportError` in its notebook; `illustrator` verifies `generate_image` availability on first use. No default `researcher` call for tooling.
 
 ## Agent Call Relationships
 

--- a/pantheon/factory/templates/teams/graph_maker_team.md
+++ b/pantheon/factory/templates/teams/graph_maker_team.md
@@ -107,13 +107,19 @@ When there is no canvas UI, CANVAS_CONTEXT is absent and canvas.json may not exi
 
 ## Execution Depth
 
-Leader infers execution depth from message language — no explicit mode flag.
+Leader infers execution depth from message language — no explicit mode flag. Sub-agents receive `execution_depth` in their delegation payload and adapt quality loading accordingly.
 
-| Signal | Behavior |
+| Depth | Reads heavy quality skills? | Critic rounds | Output |
+|---|---|---|---|
+| **quick** | No — skip `plot_critic.md` / `diagram_critic.md` / `figure_caption.md` | T=0 (single shot) | PNG |
+| **draft** | No unless explicitly requested | T≤1 | PNG |
+| **publication** | Yes — load `plot_critic.md` or `diagram_critic.md` per figure type; load `figure_caption.md` for legends | T≤3 | PNG + optional PDF/SVG |
+
+| Signal | Inferred depth |
 |---|---|
-| quick / sketch / try / draft / show me | Single-shot sub-agent call, skip multi-round critic, return immediately |
-| publication / paper / journal / final / polished | Full Plan→Style→Render→Critic loop (2–3 rounds), AskUserQuestion at key decision points, cross-frame visual consistency check |
-| Unclear | Lightweight; offer thorough version at end if output looks insufficient |
+| quick / sketch / try / draft / show me | quick |
+| (no signal, unclear) | draft |
+| publication / paper / journal / final / polished | publication |
 
 ## Workdir Layout
 


### PR DESCRIPTION
## Summary

This PR is a complete clean GraphAgent candidate that integrates the Graph Maker harness cleanup, figure styling skills, optional input / triage / scenario skills, and style-quality wiring.

It is intended as a clean final candidate / preview branch, not a direct continuation of the large #105 PR.

## What this includes

### 1. Harness cleanup

- Makes `researcher` truly on-demand.
- Keeps routine data preparation / EDA under `data_plotter`.
- Unifies Graph Maker artifact paths under `.canvas/`.
- Aligns leader workdir template with actual canvas artifact contracts.

### 2. Figure styling skills

- Adds Nature / IEEE / NeurIPS style guides.
- Adds color palettes and visual quality checklist.
- Adds plot / diagram critic skills.
- Adds caption generation guidance.
- Adds clear `When to load` routing guidance.

### 3. Optional skill pack

- Adds optional input skills:
  - context enrichment
  - caption sharpening
  - reference retrieval
- Adds optional triage skills:
  - figure type classification
  - granularity rules
- Adds optional scenario skills:
  - figure
  - flowchart
  - graphical abstract
  - poster
  - presentation
- Adds extended quality skills for planning, styling, visualization, refinement, and format linting.

### 4. Style-quality wiring

- Leader routes `style_card.aesthetic_guide` to:
  - `nature_figure`
  - `ieee_figure`
  - `neurips_plot`
  - `neurips_diagram`
- Leader passes `execution_depth` and `aesthetic_guide` to sub-agents.
- `data_plotter` loads `plot_critic.md` only for publication/final depth.
- `illustrator` loads `diagram_critic.md` only for publication/final depth.
- Quick/draft paths skip heavy quality prompts by default.
- Final delivery can use `figure_caption.md`.

## Harness rationale

This version keeps GraphAgent layered:

- `leader` handles routing and orchestration.
- `data_plotter` owns data-driven plotting and routine EDA.
- `illustrator` owns conceptual / schematic figures.
- `researcher` stays on-demand for external references, unknown venues, and unfamiliar plot types.
- `figure_styling` contains reusable skills, style guides, optional scenario contracts, and quality gates.
- Heavy quality prompts are depth-gated to avoid unnecessary token/context cost.

## Validation

- [x] No `paper_writing` / `paper_write` files included.
- [x] No Leader Step references in figure styling skills.
- [x] No residual `outputs/figure_legends.md`, `outputs/figures`, or `outputs/figure_manifest.json`.
- [x] Researcher is not called by default for environment audit or routine EDA.
- [x] Data plotter remains responsible for plotting prep / EDA.
- [x] `nature_figure` and `ieee_figure` are listed in team style table.
- [x] Leader can route to Nature / IEEE / NeurIPS style guides.
- [x] Quick/draft paths skip heavy quality skills.
- [x] Publication/final paths use critic skills.
- [x] Final candidate audit reports P0/P1/P2 = 0.

## Relationship to existing PRs

This branch integrates the clean pieces from:

- #111 Graph Maker harness cleanup
- #106 figure_styling skills-only work
- selected Graph-related skills extracted from #105

It intentionally does not include:

- `paper_writing/**`
- `paper_write/**`
- frontend integration
- large leader rewrites from #105
- poster executable Python/Pillow code

## Files changed

34 files, +3,261 / −82 lines.

| Category | Files |
|----------|-------|
| `agents/graph_maker/` | 3 |
| `teams/graph_maker_team.md` | 1 |
| `skills/figure_styling/` | 30 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
