### PR TITLE
feat(figure-styling): add lightweight outputType recipes for default-agent use

### DIFF
--- a/pantheon/factory/templates/skills/figure_styling/SKILL.md
+++ b/pantheon/factory/templates/skills/figure_styling/SKILL.md
@@ -2,33 +2,106 @@
 id: figure_styling_skills_index
 name: Figure Styling Skills Index
 description: |
-  Aesthetic guidelines for scientific figure production. Each style file
-  specifies palettes, typography, layout, and domain-specific sub-styles
-  for a given target venue (NeurIPS, Nature, IEEE, etc.) and figure class
-  (methodology diagram vs. statistical plot). Used by the Graph Maker
-  Team's `illustrator` and `data_plotter` agents.
+  Aesthetic guidelines and output-type recipes for scientific figure production.
+  Supports lightweight default-agent use through SKILL.md + one outputType recipe,
+  with optional venue-specific style guides when requested. Also serves as the
+  Graph Maker Team's style index when the full harness is in use.
 ---
 
-# Figure Styling Skills
+# Figure Styling
 
-Resources for the Graph Maker Team's `illustrator` (diagram) and `data_plotter` (plot) agents. The leader writes `aesthetic_guide: <style_id>` into `style_card.json`; the producing agent then loads the matching style file listed below.
+General scientific figure styling skill for default agents and graph-generation tasks.
 
-## Available styles
+This skill has two layers:
 
-| Style ID | File | Target | Figure class |
+1. **OutputType recipes** — self-contained recipes for default-agent use (`SKILL.md` + one recipe file).
+2. **Optional style guides** — venue- or aesthetic-specific refinement, loaded only when requested.
+
+**Lightweight read rule**: For normal use, read only this `SKILL.md` and one outputType recipe. Do not load `styles/`, `quality/`, `input/`, or `triage/` unless explicitly needed.
+
+---
+
+## Route by outputType
+
+| outputType | Read | Rendering mode | Use for |
 |---|---|---|---|
-| `neurips_diagram` | [styles/neurips_diagram.md](./styles/neurips_diagram.md) | NeurIPS / top ML venues | Methodology / framework / pipeline diagrams |
-| `neurips_plot` | [styles/neurips_plot.md](./styles/neurips_plot.md) | NeurIPS / top ML venues | Statistical plots (bar, line, scatter, heatmap, …) |
+| `figure` | `figure.md` | code-first | paper figures, data plots, multi-panel figures |
+| `poster` | `poster.md` | mixed | academic posters |
+| `graphical-abstract` | `graphical-abstract.md` | AI-first | graphical abstracts, TOC figures |
+| `presentation` | `presentation.md` | mixed | slide visuals |
+| `flowchart` | `flowchart.md` | AI-first | workflow diagrams, process diagrams |
 
-## How to use
+---
 
-1. Leader sets `aesthetic_guide: "<style_id>"` in `{workdir}/inputs/style_card.json`.
-2. Sub-agent (illustrator / data_plotter) consults this skill index, then reads the style file whose id matches `aesthetic_guide`.
-3. Agent applies the guidance alongside `style_card.json`. Priority chain for conflicts:
-   **user references > style_card.json > figure_styling/<style_id> > internal defaults**.
+## Optional style guides
 
-If `aesthetic_guide` is `custom` or `null`, sub-agents do not load any file from this skill — they rely purely on `style_card.json` and their internal defaults.
+Read these only when the user explicitly requests a venue/style or a `style_id` is provided.
+If a listed file is not present, continue with the outputType recipe and report the missing file.
+
+| style_id | File | Use for |
+|---|---|---|
+| `neurips_diagram` | `styles/neurips_diagram.md` | ML methodology diagrams (NeurIPS / ICML / ICLR / CVPR) |
+| `neurips_plot` | `styles/neurips_plot.md` | ML/statistical plots (NeurIPS / ICML / ICLR / CVPR) |
+| `nature_figure` | `styles/nature_figure.md` | Nature / Cell / Science-style scientific figures |
+| `ieee_figure` | `styles/ieee_figure.md` | IEEE journal / conference figures |
+| `color_palettes` | `styles/color_palettes.md` | Colorblind-safe palette reference (Paul Tol) |
+
+---
+
+## Scientific visual language
+
+Use concrete visual schemas instead of generic scientific prompts.
+
+**Prefer:**
+- Flat vector scientific illustration
+- Clean white or very light background
+- Short accurate labels
+- Explicit entities and connections
+- Editable-looking vector composition
+- Journal-grade readability
+- Clear module hierarchy
+- Restrained scientific palette
+
+**Avoid:**
+- Generic AI art
+- Decorative 3D or photorealistic glow
+- Fake charts, fake axes, fake data in AI diagrams
+- Dense tiny text or unreadable legends
+- Abstract boxes without scientific meaning
+- Childish cartoon style
+- Heavy shadows or decorative gradients
+
+---
+
+## Domain adaptation rule
+
+Do not assume a fixed scientific domain.
+
+When the user provides a domain, instantiate the visual schema with that domain's concrete entities, structures, labels, and relationships.
+
+Examples (not defaults):
+- **3D genomics**: TAD, chromatin loop, boundary insulation, enhancer, promoter, CTCF/cohesin, Hi-C contact map, genome-browser tracks
+- **Cell biology**: nucleus, mitochondria, ER, Golgi, membrane receptors, signaling pathway
+- **Immunology**: T cell, antigen-presenting cell, receptor, cytokine, immune synapse
+- **Neuroscience**: neuron, synapse, axon, dendrite, action potential
+- **ML/systems**: encoder, decoder, attention, pipeline stage, data flow
+
+These are domain instantiation examples, not default assumptions.
+
+---
+
+## Legacy compatibility
+
+Existing Graph Maker Team workflows may continue to use `styles/` as venue-specific style guides via `aesthetic_guide` in `style_card.json`.
+
+Default-agent use does not require:
+- Graph Maker Team
+- `leader`, `data_plotter`, or `illustrator` agents
+- `canvas` or `workdir`
+- `style_card.json`
+
+The outputType recipes are self-contained.
 
 ## Custom styles
 
-Users can drop additional `.md` files into `styles/` (e.g. `nature_figure.md`, `ieee_figure.md`, `my_lab_style.md`) following the same section structure as the NeurIPS guides. Set `aesthetic_guide: "<new_style_id>"` in `style_card.json` to activate.
+Additional `.md` style files may be added to `styles/` following the existing file structure. Set `aesthetic_guide: "<style_id>"` in `style_card.json` to activate for Graph Maker Team use.

--- a/pantheon/factory/templates/skills/figure_styling/figure.md
+++ b/pantheon/factory/templates/skills/figure_styling/figure.md
@@ -1,0 +1,199 @@
+# Figure Recipe
+
+| Field | Value |
+|---|---|
+| UI outputType | `figure` |
+| Primary rendering mode | code-first |
+| Best for | paper figures, data plots, statistical charts, multi-panel figures |
+| Do not use for | conceptual diagrams, mechanism illustrations, non-data visuals |
+| Read path | `SKILL.md` + this file |
+
+---
+
+## Visual goal
+
+A publication-ready scientific figure: real data, clean axes, colorblind-safe palette, exportable as PNG (preview) + PDF/SVG (publication). Suitable for Nature/Science-style journals.
+
+---
+
+## Research figure schema
+
+For code-first scientific figures, define panels by evidence type, not decoration.
+
+| Panel role | Use for | Common visual |
+|---|---|---|
+| Structure / image-like data | spatial matrix, microscopy, contact map, heatmap | heatmap or image panel |
+| Evidence tracks | signal tracks, measurements, omics layers | stacked tracks or aligned line plots |
+| Quantitative comparison | condition comparison | box, violin, bar, paired plot |
+| Relationship / model support | association between variables | scatter, regression, summary plot |
+
+---
+
+## Recipe
+
+1. Identify chart type from data and goal (bar, scatter, line, box, violin, heatmap, UMAP, volcano).
+2. Map data to panel roles above.
+3. Apply style defaults below.
+4. Write matplotlib/seaborn code directly — do not plan intermediate steps.
+5. Export PNG (300 dpi) for preview, PDF or SVG for publication.
+6. Run quick self-check.
+
+**Multi-panel sub-case**: If user asks for multiple related panels (A/B/C), use `plt.subplots()` with shared axes where appropriate. Add A/B/C panel labels at top-left of each subplot (`ax.text(-0.15, 1.05, 'A', ...)`). Keep consistent spacing (`fig.tight_layout()`).
+
+---
+
+## Style defaults
+
+```python
+FIGURE_DEFAULTS = {
+    # Size and resolution
+    "figsize": (6, 4.5),          # single-column (inches); double-column: (12, 4.5)
+    "dpi": 300,
+
+    # Typography
+    "font_family": "Arial",
+    "font_size": 9,               # axis tick labels
+    "label_size": 10,             # axis labels
+    "title_size": 11,
+    "legend_fontsize": 8,
+
+    # Lines and markers
+    "linewidth": 1.2,
+    "markersize": 4,
+    "capsize": 3,                 # error bar cap size
+
+    # Axes
+    "spine_top": False,           # remove top spine
+    "spine_right": False,         # remove right spine
+    "tick_length": 3,
+    "tick_width": 0.6,
+    "axis_linewidth": 0.8,
+
+    # Legend
+    "legend_frameon": False,
+    "legend_loc": "best",
+
+    # Grid
+    "grid": False,                # off by default; use for line/time-series if helpful
+
+    # Color
+    "palette": "colorblind",      # seaborn 'colorblind' or matplotlib 'tab10'
+    # Heatmap: 'RdBu_r' (diverging) or 'Blues' (sequential)
+    # Never use red/green as primary contrast pair
+
+    # Export
+    "output_formats": ["png", "pdf"],   # PNG for preview, PDF for publication
+    "bbox_inches": "tight",
+    "pad_inches": 0.05,
+}
+```
+
+---
+
+## Minimal code stub
+
+```python
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import seaborn as sns
+
+mpl.rcParams.update({
+    "font.family": "Arial",
+    "font.size": 9,
+    "axes.labelsize": 10,
+    "axes.linewidth": 0.8,
+    "xtick.major.size": 3,
+    "xtick.major.width": 0.6,
+    "ytick.major.size": 3,
+    "ytick.major.width": 0.6,
+    "legend.frameon": False,
+})
+palette = sns.color_palette("colorblind")
+
+fig, ax = plt.subplots(figsize=(6, 4.5), dpi=300)
+
+# --- plot here ---
+
+ax.spines["top"].set_visible(False)
+ax.spines["right"].set_visible(False)
+ax.set_xlabel("X label (units)", fontsize=10)
+ax.set_ylabel("Y label (units)", fontsize=10)
+ax.set_title("Title", fontsize=11)
+
+fig.tight_layout(pad=0.5)
+fig.savefig("figure.png", dpi=300, bbox_inches="tight")
+fig.savefig("figure.pdf", bbox_inches="tight")
+```
+
+---
+
+## Common chart types
+
+| Chart | When to use |
+|---|---|
+| bar + error | group means with SEM/SD |
+| box / violin | distribution comparison |
+| scatter | two continuous variables, correlation |
+| line | time series, dose-response |
+| heatmap | correlation matrix, expression matrix |
+| UMAP / PCA | dimensionality reduction |
+| volcano | differential expression (log2FC vs -log10p) |
+
+---
+
+## Domain-specific example: 3D genomics
+
+When the user asks for 3D genomics figures:
+- **Structure panel**: Hi-C / Micro-C contact map. Use `imshow` with `RdBu_r` or `hot` colormap. Add TAD boundary as dashed blue vertical/horizontal lines. Mark loops as white square overlays. Use triangular display if appropriate.
+- **Evidence tracks**: Genome-browser tracks (CTCF ChIP-seq, H3K27ac, ATAC-seq, RNA-seq). Stack tracks vertically. Share x-axis (genomic coordinates). Set per-track height ~0.5–1 inch. Use `fill_between` for signal area.
+- **Quantitative comparison**: Loop strength, insulation score, compartment score, TAD size distribution. Use box/violin for group comparisons.
+- **Relationship**: Expression change vs chromatin change. Use scatter with regression line.
+
+*This is a domain example only — the recipe applies to any scientific field.*
+
+---
+
+## Code-first guardrail
+
+Use code rendering for real data plots. Do not use AI image generation to invent data, axes, p-values, heatmaps, contact maps, genome tracks, or statistical relationships.
+
+Synthetic data is acceptable for testing only and must be labeled as synthetic in the caption.
+
+---
+
+## Statistical annotation convention
+
+```
+ns   not significant
+*    p < 0.05
+**   p < 0.01
+***  p < 0.001
+```
+
+Draw brackets above bars/boxes with `statannotations` or manual matplotlib brackets.
+
+---
+
+## Negative constraints
+
+Avoid:
+- AI-generated synthetic data presented as real
+- DPI < 300
+- Red/green as primary contrast pair (colorblind-inaccessible)
+- Cluttered multi-panel with no shared axes
+- Missing units on axis labels
+- Top/right spines left visible
+- Saving only PNG without a vector format
+
+---
+
+## Quick self-check
+
+- [ ] Real data used (or clearly labeled synthetic)
+- [ ] DPI = 300
+- [ ] Colorblind-safe palette
+- [ ] Top/right spines removed
+- [ ] Axis labels have units
+- [ ] Legend frameon = False
+- [ ] Multi-panel: A/B/C labels present and consistent spacing
+- [ ] Exported as PNG + PDF/SVG

--- a/pantheon/factory/templates/skills/figure_styling/flowchart.md
+++ b/pantheon/factory/templates/skills/figure_styling/flowchart.md
@@ -1,0 +1,149 @@
+# Flowchart Recipe
+
+| Field | Value |
+|---|---|
+| UI outputType | `flowchart` |
+| Primary rendering mode | AI-first |
+| Best for | workflow diagrams, process diagrams, mechanisms, pipelines |
+| Do not use for | data plots, statistical charts, contact maps |
+| Read path | `SKILL.md` + this file |
+
+---
+
+## Visual goal
+
+A clean scientific workflow diagram: clear process stages, unambiguous arrows, short labels, flat vector composition, journal or slide grade.
+
+---
+
+## Workflow schema
+
+Use a clear scientific process structure:
+
+| Stage | Meaning |
+|---|---|
+| Input | sample, material, dataset, or initial condition |
+| Assay / acquisition | experiment, measurement, or data collection |
+| Processing | sequencing, imaging, computation, or preprocessing |
+| Feature extraction | called peaks, domains, clusters, events, or measurements |
+| Integration | combining evidence layers or modalities |
+| Interpretation | biological, clinical, computational, or engineering conclusion |
+
+Not every workflow needs all stages — use only what the user's process contains.
+
+---
+
+## Arrow semantics
+
+- **Solid arrow** = main process flow
+- **Dashed arrow** = optional integration or supporting evidence
+- **Curved arrow** = iteration or feedback, only when explicitly requested
+- Do not use inhibition arrows unless the prompt asks for repression
+
+---
+
+## Visual Schema
+
+| Zone | Content |
+|---|---|
+| Top / left entry | input materials or initial conditions |
+| Middle pathway | main process steps in order |
+| Branch nodes | parallel or optional sub-processes |
+| Right / bottom exit | outputs, results, or biological conclusion |
+
+Use spatial grouping to show parallel processes. Use indentation or column alignment to show hierarchical steps.
+
+---
+
+## Structured prompt scaffold
+
+```
+[STYLE]
+Flat vector scientific workflow diagram, clean white background, restrained palette, editable-looking nodes, journal-grade clarity.
+
+[LAYOUT]
+Describe the stage sequence and any branches.
+
+[NODES]
+List concrete process steps with short labels.
+
+[ARROWS]
+Describe connections: solid flow, dashed evidence branch, or iteration loop.
+
+[LABELS]
+Short labels only — <= 8 words per node.
+
+[NEGATIVE]
+No decorative icons unrelated to scientific steps, no 3D glow, no artistic illustration, no fake data panels.
+```
+
+---
+
+## Node style rules
+
+| Node type | Shape |
+|---|---|
+| Process step | rectangle |
+| Decision point | diamond |
+| Input / output | rounded rectangle |
+| Sub-process group | dashed container rectangle |
+
+Use a consistent color scheme:
+- Node background: light gray or white
+- Active / key step: accent color (single hue, e.g. #3A7BD5)
+- Text: dark gray, short, readable at 9–10pt
+
+---
+
+## Label rules
+
+- <= 8 words per node
+- Use domain-specific step names, not generic placeholders
+- No abbreviations unless universally standard in the field
+- Short verb + noun: "Extract DNA", "Align Reads", "Call Peaks"
+
+---
+
+## Negative constraints
+
+Avoid:
+- Decorative icons unrelated to the scientific process
+- Generic AI art or clipart
+- 3D nodes or shadows
+- Dense paragraph text inside nodes
+- Inconsistent node sizes
+- Ambiguous arrows (missing arrowheads)
+- Abstract boxes without scientific meaning
+- More than 12 nodes without grouping
+
+---
+
+## Domain-specific example: 3D genomics workflow
+
+For 3D genomics, the process typically follows:
+
+```
+Input (cells / tissue)
+→ Hi-C / Micro-C / Capture-C library preparation
+→ Sequencing
+→ Contact map generation
+→ TAD / loop / compartment calling
+→ Integration with ATAC-seq / ChIP-seq / RNA-seq
+→ Biological interpretation
+```
+
+Node labels should use domain vocabulary: "Hi-C Library Prep", "Contact Map", "TAD Calling", "Loop Anchors", "Compartment A/B", "Enhancer–Promoter Interaction".
+
+This is a domain example only — apply the same schema to any scientific workflow.
+
+---
+
+## Quick self-check
+
+- [ ] Clear stage sequence
+- [ ] Arrow types match semantics (solid / dashed / curved)
+- [ ] Node labels <= 8 words
+- [ ] No decorative 3D or clipart
+- [ ] Consistent node shapes and colors
+- [ ] Single clear entry and exit
+- [ ] Grouped parallel steps if needed

--- a/pantheon/factory/templates/skills/figure_styling/graphical-abstract.md
+++ b/pantheon/factory/templates/skills/figure_styling/graphical-abstract.md
@@ -1,0 +1,188 @@
+# Graphical Abstract Recipe
+
+## Purpose
+Single-panel visual summary of a paper's key finding. Readers scan in <5 s; every element must earn its place.
+
+---
+
+## Visual Schema
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  TITLE ZONE (top, ≤12 words)                            │
+├──────────────┬──────────────┬──────────────┬────────────┤
+│  INPUT/      │   PROCESS /  │   OUTPUT /   │  IMPACT    │
+│  CONTEXT     │   METHOD     │   RESULT     │  (opt)     │
+│  (Zone A)    │   (Zone B)   │   (Zone C)   │  (Zone D)  │
+├──────────────┴──────────────┴──────────────┴────────────┤
+│  CAPTION ZONE (bottom, ≤20 words)                       │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Zone rules**
+- Zone A–C are mandatory; Zone D is optional (use for clinical/translational work)
+- Each zone = one visual unit (icon, schematic, chart, or micrograph)
+- Connections between zones: directional arrows or gradient bands only
+
+---
+
+## Canvas Spec
+
+| Property | Value |
+|----------|-------|
+| Size | 85 mm × 85 mm (square) or 170 mm × 85 mm (landscape) |
+| Resolution | 300 dpi for print; 150 dpi for web |
+| Background | White `#FFFFFF` or very light grey `#F8F8F8` |
+| Safe margin | 4 mm all sides |
+
+---
+
+## Typography
+
+| Element | Font | Size (pt) | Weight |
+|---------|------|-----------|--------|
+| Title | Sans-serif (Helvetica / Arial) | 9–10 | Bold |
+| Zone label | Sans-serif | 7–8 | Regular |
+| Data label | Sans-serif | 6–7 | Regular |
+| Caption | Sans-serif | 6–7 | Regular |
+
+- No more than **2 font sizes** in the main panel
+- Avoid italics except for gene/species names
+
+---
+
+## Color Palette
+
+Use a **3-color sequential or diverging palette** maximum:
+
+```python
+# Recommended palettes (colorblind-safe)
+VIRIDIS_3  = ["#440154", "#21908C", "#FDE725"]
+COOL_WARM  = ["#4575B4", "#FFFFBF", "#D73027"]
+TEAL_AMBER = ["#009E73", "#F0E442", "#D55E00"]
+```
+
+- **Accent color**: one bold hue for the key result (Zone C)
+- **Background objects**: desaturated or grey
+- Never use red + green as the only distinguishing pair
+
+---
+
+## Icon & Illustration Guidelines
+
+- Use **flat line icons** (stroke 1.5–2 pt); avoid gradients on icons
+- Cell/tissue schematics: simplified, 2–3 color max
+- Molecules: schematic ribbon/surface, not atomic detail
+- Arrows: 2–3 pt weight; filled arrowhead; angle ≤45° preferred
+- No drop shadows, glows, or 3D bevels
+
+---
+
+## Layout Constraints
+
+1. **One message per zone** — do not split a concept across zones
+2. **Left-to-right reading order** matches narrative flow
+3. **Zone widths** may vary (e.g., 30 / 40 / 30) to weight the key result
+4. **Whitespace** between zones ≥ 3 mm
+5. If adding a mini bar/line chart: max 4 bars or 2 lines; no legend inside chart (use direct labels)
+
+---
+
+## Connection Symbols
+
+| Relationship | Symbol |
+|-------------|--------|
+| Causes / leads to | `→` solid arrow |
+| Inhibits | `⊣` flat-head arrow |
+| Bidirectional | `↔` double arrow |
+| Parallel process | horizontal bracket |
+| Temporal sequence | numbered circles `①②③` |
+
+---
+
+## Domain-Specific Examples
+
+### Genomics / Epigenomics
+- Zone A: genome/chromatin schematic
+- Zone B: assay pipeline icon (ChIP-seq, Hi-C loop)
+- Zone C: heatmap or arc plot of key locus
+- Accent color on regulatory element of interest
+
+### Clinical / Translational
+- Zone A: patient cohort icon
+- Zone B: treatment/intervention schematic
+- Zone C: Kaplan-Meier or forest plot thumbnail
+- Zone D: clinical implication icon (organ, patient outcome)
+
+### Cell Biology
+- Zone A: cell cross-section with pathway entry
+- Zone B: signaling cascade (3–4 nodes max)
+- Zone C: phenotypic outcome (microscopy panel or bar chart)
+
+---
+
+## Matplotlib Quickstart
+
+```python
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib.patches import FancyArrowPatch
+
+fig, axes = plt.subplots(1, 3, figsize=(6.7, 3.35))  # 170mm × 85mm at 100dpi
+fig.patch.set_facecolor('#FFFFFF')
+
+for ax in axes:
+    ax.set_xticks([]); ax.set_yticks([])
+    ax.spines[:].set_visible(False)
+
+# Zone A — context icon (placeholder)
+axes[0].text(0.5, 0.5, 'Zone A\nInput', ha='center', va='center',
+             fontsize=9, fontweight='bold', color='#333333')
+
+# Zone B — method schematic
+axes[1].text(0.5, 0.5, 'Zone B\nProcess', ha='center', va='center',
+             fontsize=9, fontweight='bold', color='#009E73')
+
+# Zone C — key result
+axes[2].text(0.5, 0.5, 'Zone C\nResult', ha='center', va='center',
+             fontsize=9, fontweight='bold', color='#D55E00')
+
+# Connecting arrows between subplots
+for i in range(2):
+    fig.add_artist(mpatches.FancyArrowPatch(
+        (0.355 + i*0.315, 0.5), (0.38 + i*0.315, 0.5),
+        transform=fig.transFigure,
+        arrowstyle='->', mutation_scale=15,
+        color='#555555', linewidth=1.5
+    ))
+
+fig.suptitle('Paper Title in ≤12 Words', fontsize=9, fontweight='bold', y=0.97)
+plt.tight_layout(rect=[0, 0.03, 1, 0.93])
+plt.savefig('graphical_abstract.png', dpi=300, bbox_inches='tight')
+```
+
+---
+
+## Common Mistakes to Avoid
+
+| Mistake | Fix |
+|---------|-----|
+| Too much text | ≤5 words per zone label |
+| Inconsistent icon style | Pick one icon library / style |
+| No clear left→right flow | Reorder zones; add directional arrows |
+| Overloaded Zone C | Split into two sub-panels only if absolutely necessary |
+| Low contrast labels | Ensure WCAG AA contrast ratio ≥4.5:1 |
+| Missing scale bar on micrograph | Always add scale bar if using microscopy image |
+
+---
+
+## Checklist Before Export
+
+- [ ] ≤3 colors used (+ black/white)
+- [ ] All text ≥6 pt
+- [ ] Arrows indicate direction clearly
+- [ ] Title ≤12 words
+- [ ] Caption ≤20 words
+- [ ] 300 dpi / correct canvas size
+- [ ] Colorblind-safe palette verified
+- [ ] No copyrighted icons or clip art

--- a/pantheon/factory/templates/skills/figure_styling/poster.md
+++ b/pantheon/factory/templates/skills/figure_styling/poster.md
@@ -1,0 +1,167 @@
+# Poster Recipe
+
+| Field | Value |
+|---|---|
+| UI outputType | `poster` |
+| Primary rendering mode | mixed |
+| Best for | conference posters, workshop posters, teaching displays |
+| Do not use for | single data plots, journal figures, slide decks |
+| Read path | `SKILL.md` + this file |
+
+---
+
+## Visual goal
+
+An academic conference poster readable from 1–2 meters. Combines code-rendered data panels with a flat schematic model. Clean layout, minimal text, high visual impact.
+
+---
+
+## Poster zones
+
+Use a clear academic poster structure:
+
+| Zone | Content |
+|---|---|
+| Title strip | title (≤18 words), authors, affiliation, logos |
+| Column 1 | background + methods schematic |
+| Column 2 | main results — code-rendered data panels |
+| Column 3 | model schematic + interpretation + take-home message |
+
+**Mixed rendering rule:**
+- Column 2 data panels → code-first (matplotlib/seaborn)
+- Column 1 and Column 3 schematics → AI-first (flat vector illustration)
+
+---
+
+## Layout metadata
+
+| Property | Value |
+|---|---|
+| Dimensions | A0 (841×1189 mm) or 48×36 inches |
+| Orientation | landscape (horizontal) preferred |
+| Resolution | 150–200 dpi minimum |
+| Columns | 3 (equal width) |
+| Margins | ≥20mm outer, ≥15mm between columns |
+| Background | white or very light grey (#f8f8f8) |
+
+---
+
+## Word limits (readable at 1–2 m distance)
+
+| Element | Limit |
+|---|---|
+| Title | ≤18 words |
+| Section heading | ≤5 words |
+| Body block | ≤45–60 words |
+| Figure caption | ≤25 words |
+| Take-home message | ≤20 words |
+
+---
+
+## Typography
+
+| Element | Font size |
+|---|---|
+| Title | ≥70pt |
+| Section heading | ≥36pt |
+| Body text | ≥24pt |
+| Figure caption | ≥18pt |
+| Take-home message | ≥28pt, bold |
+
+Font: Arial, Helvetica, or similar clean sans-serif. Never use decorative fonts.
+
+---
+
+## Color and visual consistency
+
+- Use 1–2 accent colors throughout; never >4 total colors.
+- Data panels use colorblind-safe palette (seaborn `colorblind` or `tab10`).
+- Schematics use the same accent colors as the data panels.
+- White or very light background for all panels.
+- Avoid gradients in main layout areas.
+
+---
+
+## Code panel defaults
+
+Use `figure.md` style defaults for all code-rendered data panels:
+
+```python
+POSTER_PANEL_DEFAULTS = {
+    "figsize": (5, 4),          # per panel; adjust for column width
+    "dpi": 150,
+    "font_family": "Arial",
+    "font_size": 11,            # larger than journal — needs visibility
+    "label_size": 12,
+    "title_size": 13,
+    "spine_top": False,
+    "spine_right": False,
+    "palette": "colorblind",
+    "legend_frameon": False,
+}
+```
+
+---
+
+## AI schematic prompt pattern
+
+For Column 1 and Column 3 schematic panels, use the flat vector scientific style:
+
+```
+[STYLE]
+Flat vector scientific illustration. Clean white background. Restrained palette (2-3 colors + black). Editable-looking vector composition. Journal-grade clarity. No shadows or 3D effects.
+
+[LAYOUT]
+Describe the schematic composition and spatial zones.
+
+[ENTITIES]
+List concrete domain entities with their visual form (e.g., "oval = domain, circle = cell, rectangle = process step").
+
+[CONNECTIONS]
+Describe arrows and interactions. Solid arrow = flow/activation. Dashed = modulation/inhibition.
+
+[LABELS]
+Short labels only. No full sentences. Max 3–5 words per label.
+
+[NEGATIVE]
+No decorative 3D, no photorealistic glow, no fake charts or axes, no dense text blocks, no abstract boxes without domain meaning, no cartoon animals.
+```
+
+---
+
+## Domain-specific example: 3D genomics poster
+
+For a 3D genomics poster:
+- Column 1: experimental workflow schematic (Hi-C library prep → sequencing → contact map) + brief methods text
+- Column 2: contact map panel, TAD boundary analysis, insulation score comparison, or loop strength quantification
+- Column 3: regulatory mechanism schematic (chromatin topology → enhancer–promoter interaction → transcriptional outcome) + take-home message
+
+Entities for Column 3 schematic: chromatin loop, TAD boundary, enhancer (filled circle), promoter (rounded rectangle), CTCF/cohesin, gene body, transcription arrows.
+
+*This is a domain example only — the recipe works for any scientific field.*
+
+---
+
+## Common mistakes
+
+- Font size <18pt — unreadable at poster distance.
+- Too much text — poster is not a paper.
+- Mismatch between schematic style and data panel palette.
+- Missing take-home message.
+- Data panels not exported at ≥150 dpi.
+- Mixing >4 colors across the poster.
+- Using data panels from papers directly without reformatting for poster scale.
+
+---
+
+## Quick self-check
+
+- [ ] Title ≤18 words
+- [ ] Section headings ≤5 words
+- [ ] All body text ≥24pt
+- [ ] Data panels ≥150 dpi
+- [ ] Colorblind-safe palette in data panels
+- [ ] Schematic uses flat vector style (no 3D/glow)
+- [ ] Take-home message present and ≤20 words
+- [ ] ≤4 total colors across poster
+- [ ] Column 1/3 schematics match color scheme of Column 2 data panels

--- a/pantheon/factory/templates/skills/figure_styling/presentation.md
+++ b/pantheon/factory/templates/skills/figure_styling/presentation.md
@@ -1,0 +1,237 @@
+# Presentation Recipe
+
+| Field | Value |
+|---|---|
+| UI outputType | `presentation` |
+| Primary rendering mode | mixed |
+| Best for | slide visuals, oral presentation figures, seminar slides |
+| Do not use for | journal paper figures, conference posters, standalone data plots |
+| Read path | `SKILL.md` + this file |
+
+---
+
+## Visual goal
+
+Scientific slides that communicate one clear message per visual. Readable at distance, high contrast, minimal text. Combines code-rendered data panels with flat schematic visuals.
+
+---
+
+## Mixed slide schema
+
+For scientific slides, prefer a three-zone 16:9 layout:
+
+| Zone | Content |
+|---|---|
+| Left | code-rendered data panel (primary evidence) |
+| Center | simplified summary plot or state map |
+| Right | flat mechanism schematic or takeaway model |
+
+Not every slide uses all three zones. Assign zones based on the message, not the template.
+
+---
+
+## Recipe
+
+1. Identify the message the slide must communicate in one sentence.
+2. Choose slide layout (data-only / schematic-only / mixed).
+3. For data panels: use code rendering with presentation-scale defaults.
+4. For schematic panels: use structured prompt with flat visual style.
+5. Export PNG at 150 dpi minimum.
+6. Run screen readability check.
+
+---
+
+## Style defaults (code panels)
+
+```python
+SLIDE_DEFAULTS = {
+    # Size — wide format matches 16:9 slide
+    "figsize": (8, 4.5),          # single panel, 16:9 ratio
+    "dpi": 150,                   # screen: 150; print: 300
+
+    # Typography — must be readable at 5–10 meters
+    "font_family": "Arial",
+    "font_size": 14,              # axis tick labels (slide must be larger than paper)
+    "label_size": 16,             # axis labels
+    "title_size": 18,
+    "legend_fontsize": 12,
+
+    # Lines and markers
+    "linewidth": 2.0,
+    "markersize": 7,
+
+    # Axes
+    "spine_top": False,
+    "spine_right": False,
+    "tick_length": 4,
+    "tick_width": 0.8,
+    "axis_linewidth": 1.0,
+
+    # Grid
+    "grid": False,
+
+    # Color
+    "palette": "colorblind",      # seaborn colorblind or tab10
+    # Heatmap: 'RdBu_r' diverging
+
+    # Export
+    "output_formats": ["png"],
+    "bbox_inches": "tight",
+}
+```
+
+---
+
+## Slide layout templates
+
+### Layout A: full-width data panel
+```
+┌──────────────────────────────────────────────┐
+│  Title                                       │
+│  ┌──────────────────────────────────────┐    │
+│  │         Code-rendered figure          │    │
+│  └──────────────────────────────────────┘    │
+│  One-line takeaway callout                   │
+└──────────────────────────────────────────────┘
+```
+
+### Layout B: data + schematic
+```
+┌──────────────────────────────────────────────┐
+│  Title                                       │
+│  ┌──────────────┐  ┌──────────────────────┐  │
+│  │ Code panel   │  │  Flat schematic (AI) │  │
+│  └──────────────┘  └──────────────────────┘  │
+│  Callout                                     │
+└──────────────────────────────────────────────┘
+```
+
+### Layout C: three-zone
+```
+┌──────────────────────────────────────────────┐
+│  Title                                       │
+│  ┌──────────┐  ┌──────────┐  ┌───────────┐  │
+│  │ Data     │  │ Summary  │  │ Schematic │  │
+│  └──────────┘  └──────────┘  └───────────┘  │
+└──────────────────────────────────────────────┘
+```
+
+---
+
+## Schematic panel prompt scaffold (AI-first zone)
+
+For schematic panels within mixed slides:
+
+```
+[STYLE]
+Flat vector scientific illustration, white background, restrained palette, editable-looking, no decorative 3D, no photorealistic glow.
+
+[SIZE]
+Landscape, 4:3 or 16:9 panel proportion.
+
+[LAYOUT]
+[Describe the spatial arrangement of the mechanism or model.]
+
+[ENTITIES]
+[List concrete domain entities: molecules, cells, structures, states, conditions.]
+
+[CONNECTIONS]
+[Describe directional relationships: arrows for causation, brackets for comparison, dashed lines for association.]
+
+[LABELS]
+Use short labels. Maximum 3–5 words per label. Avoid complete sentences.
+
+[NEGATIVE]
+No fake charts, no decorative 3D, no photorealistic glow, no dense paragraphs, no unreadable labels, no generic clipart, no gradient backgrounds, no childish cartoon style.
+```
+
+---
+
+## Screen readability
+
+Slides need larger text than journal figures and must be legible from 5–10 meters.
+
+- Title: ≤ 12 words
+- Main callouts: max 3 per slide
+- Axis labels: simplified, no full sentences
+- Legends: minimal or directly labeled on plot
+- Use high contrast (dark text on white, or white text on dark)
+- Avoid compressing multi-panel paper figures into one slide
+- Remove top and right spines
+- No footnotes or fine print on slides
+
+---
+
+## Code stub (matplotlib)
+
+```python
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import seaborn as sns
+
+mpl.rcParams.update({
+    "font.family": "Arial",
+    "font.size": 14,
+    "axes.labelsize": 16,
+    "axes.titlesize": 18,
+    "axes.linewidth": 1.0,
+    "xtick.major.size": 4,
+    "xtick.major.width": 0.8,
+    "ytick.major.size": 4,
+    "ytick.major.width": 0.8,
+    "legend.frameon": False,
+    "legend.fontsize": 12,
+})
+palette = sns.color_palette("colorblind")
+
+fig, ax = plt.subplots(figsize=(8, 4.5), dpi=150)
+
+# --- plot here ---
+
+ax.spines["top"].set_visible(False)
+ax.spines["right"].set_visible(False)
+ax.set_xlabel("X label", fontsize=16)
+ax.set_ylabel("Y label", fontsize=16)
+
+fig.tight_layout(pad=0.5)
+fig.savefig("slide_panel.png", dpi=150, bbox_inches="tight")
+```
+
+---
+
+## Domain-specific example: 3D genomics slide
+
+For a 3D genomics presentation:
+- Left data panel can show compartment switching (A/B), loop strength comparison, or TAD boundary insulation score across conditions.
+- Center panel can show cell-state grouping or UMAP with condition labels.
+- Right schematic can show chromatin architecture change (intact TAD vs disrupted boundary) leading to altered gene expression state.
+
+This is only an example. The same layout applies to any domain.
+
+---
+
+## Negative constraints
+
+Avoid:
+- Generic AI art that looks like stock illustration
+- Decorative 3D or photorealistic glow
+- Dense text paragraphs on slides
+- Fake charts or fake axes
+- Unreadable labels at presentation scale
+- Compressing paper-style multi-panel figures onto one slide
+- Abstract boxes without domain meaning
+- Gradient backgrounds
+- Inconsistent icon styles
+
+---
+
+## Quick self-check
+
+- [ ] One message per slide
+- [ ] Font size ≥ 14pt for body, ≥ 16pt for axis labels
+- [ ] High contrast — readable at distance
+- [ ] Top/right spines removed
+- [ ] Code panels use presentation-scale figsize and dpi
+- [ ] Schematic panels use flat vector style
+- [ ] No dense text blocks
+- [ ] Exported as PNG

--- a/pantheon/factory/templates/skills/figure_styling/styles/color_palettes.md
+++ b/pantheon/factory/templates/skills/figure_styling/styles/color_palettes.md
@@ -1,0 +1,213 @@
+---
+id: color_palettes
+name: Scientific Color Palettes
+description: |
+  Publication-safe color palettes for scientific figures. All palettes are
+  colorblind-accessible and print safely in grayscale. Based on Paul Tol's
+  color schemes via SciencePlots (garrettj403/SciencePlots, MIT).
+source: https://github.com/garrettj403/SciencePlots
+license: MIT
+---
+
+# Scientific Color Palettes
+
+> **Attribution**: All palettes from SciencePlots
+> ([github.com/garrettj403/SciencePlots](https://github.com/garrettj403/SciencePlots), MIT),
+> `scienceplots/styles/color/`. Original color schemes designed by
+> Paul Tol ([personal.sron.nl/~pault](https://personal.sron.nl/~pault/)).
+
+## When to Use Which Palette
+
+| Palette | Best for | Categories | Colorblind-safe |
+|---|---|---|---|
+| `bright` | Most scientific plots | ≤7 | ✅ |
+| `vibrant` | Presentation slides, posters | ≤7 | ✅ |
+| `muted` | Dense multi-category, earth tones | ≤9 | ✅ |
+| `high-vis` | Accessibility-critical, color-blind audiences | ≤7 | ✅ |
+| `retro` | Distinctive / unique look | ≤6 | Partial |
+| `std-colors` | Default matplotlib replacement | ≤7 | Partial |
+
+**Rule**: always use colorblind-safe palette unless user explicitly overrides. ~8% of readers have color vision deficiency.
+
+---
+
+## Palette Definitions
+
+### `bright` — Paul Tol Bright (recommended default)
+
+> From `scienceplots/styles/color/bright.mplstyle`
+
+```python
+BRIGHT = ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377", "#BBBBBB"]
+# Blue, Red, Green, Yellow, Cyan, Purple, Grey
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = cycler("color", [
+    "#4477AA",  # blue
+    "#EE6677",  # red
+    "#228833",  # green
+    "#CCBB44",  # yellow
+    "#66CCEE",  # cyan
+    "#AA3377",  # purple
+    "#BBBBBB",  # grey
+])
+```
+
+**Use with**: `science`, `nature_figure`, `neurips_plot` styles. Default recommendation for all CNS figures.
+
+---
+
+### `vibrant` — Paul Tol Vibrant
+
+> From `scienceplots/styles/color/vibrant.mplstyle`
+
+```python
+VIBRANT = ["#EE7733", "#0077BB", "#33BBEE", "#EE3377", "#CC3311", "#009988", "#BBBBBB"]
+# Orange, Blue, Cyan, Magenta, Red, Teal, Grey
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = cycler("color", [
+    "#EE7733",  # orange
+    "#0077BB",  # blue
+    "#33BBEE",  # cyan
+    "#EE3377",  # magenta
+    "#CC3311",  # red
+    "#009988",  # teal
+    "#BBBBBB",  # grey
+])
+```
+
+**Use with**: poster figures, slides, graphical abstracts — more vivid than `bright`.
+
+---
+
+### `muted` — Paul Tol Muted
+
+> From `scienceplots/styles/color/muted.mplstyle`
+
+```python
+MUTED = ["#CC6677", "#332288", "#DDCC77", "#117733",
+         "#88CCEE", "#882255", "#44AA99", "#999933", "#AA4499"]
+# Rose, Indigo, Sand, Green, Cyan, Wine, Teal, Olive, Purple
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = cycler("color", [
+    "#CC6677",  # rose
+    "#332288",  # indigo
+    "#DDCC77",  # sand
+    "#117733",  # green
+    "#88CCEE",  # cyan
+    "#882255",  # wine
+    "#44AA99",  # teal
+    "#999933",  # olive
+    "#AA4499",  # purple
+])
+```
+
+**Use with**: figures with many categories (7–9). More subdued — appropriate for dense comparison plots.
+
+---
+
+### `high-vis` — High Visibility (Paul Tol)
+
+> From `scienceplots/styles/color/high-vis.mplstyle`
+
+```python
+HIGH_VIS = ["#0077BB", "#33BBEE", "#009988", "#EE7733", "#CC3311", "#EE3377", "#BBBBBB"]
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = (
+    cycler("color", ["#0077BB", "#33BBEE", "#009988",
+                     "#EE7733", "#CC3311", "#EE3377", "#BBBBBB"]) +
+    cycler("ls", ["-", "--", "-.", ":", "-", "--", "-."])
+)
+# lines.linewidth: 1.5 (thicker for visibility)
+mpl.rcParams["lines.linewidth"] = 1.5
+```
+
+**Use with**: accessibility-critical contexts. Line style variation built in for B&W printing.
+
+---
+
+### `retro` — Retro
+
+> From `scienceplots/styles/color/retro.mplstyle`
+
+```python
+RETRO = ["#4165c0", "#e770a2", "#5ac3be", "#696969", "#f79a1e", "#ba7dde"]
+# Blue, Pink, Cyan, Grey, Orange, Purple
+```
+
+```python
+mpl.rcParams["axes.prop_cycle"] = cycler("color", [
+    "#4165c0",  # blue
+    "#e770a2",  # pink
+    "#5ac3be",  # cyan
+    "#696969",  # grey
+    "#f79a1e",  # orange
+    "#ba7dde",  # purple
+])
+```
+
+**Use with**: distinctive aesthetic preference. Less common in CNS-type journals; more suited to preprints, blogs, data journalism.
+
+---
+
+### `std-colors` — Standard Scientific Colors
+
+```python
+STD_COLORS = ["#0C5DA5", "#00B945", "#FF9500", "#FF2C00", "#845B97", "#474747", "#9e9e9e"]
+# Blue, Green, Orange, Red, Purple, Dark Grey, Grey
+```
+
+This is the SciencePlots `science.mplstyle` default cycle — used by most of its journal styles including `nature.mplstyle` as the base before font/size overrides. A clean, professional look for general scientific use.
+
+---
+
+## Application in `style_card.json`
+
+Set `colors.categorical_palette` to the desired palette array:
+
+```json
+{
+  "colors": {
+    "categorical_palette": ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377"],
+    "diverging_cmap": "RdBu_r",
+    "sequential_cmap": "viridis"
+  }
+}
+```
+
+`data_plotter` reads `style_card.colors.categorical_palette` and uses it as the `axes.prop_cycle`.
+
+## Combining Palettes with Style Files
+
+SciencePlots design: palettes are **modular overlays**, not standalone styles.
+
+```python
+# Correct usage pattern:
+plt.style.use(["science"])          # base style (sizes, ticks, fonts)
+plt.style.use(["bright"])           # color overlay
+# Or combined:
+plt.style.use(["science", "bright"])
+```
+
+In our system:
+- `style_card.aesthetic_guide` → loads the base style file (neurips_plot / nature_figure / ieee_figure)
+- `style_card.colors.categorical_palette` → provides the color overlay
+- Sub-agents apply both independently
+
+## Sequential & Diverging (not cycler-based)
+
+| Use case | Colormap | Notes |
+|---|---|---|
+| Ordered data, heatmap | `viridis` | Default, perceptually uniform |
+| Intensity / density | `magma` or `plasma` | High contrast at extremes |
+| Positive / negative | `RdBu_r` | Diverging, white at zero |
+| Gene expression | `RdYlBu_r` or `PuOr` | Biology convention |
+| Genomics / ATAC | `Blues` or `YlOrRd` | Single-hue sequential |
+| **Avoid** | `jet`, `rainbow`, `hot` | Perceptually non-uniform, misleading |

--- a/pantheon/factory/templates/skills/figure_styling/styles/ieee_figure.md
+++ b/pantheon/factory/templates/skills/figure_styling/styles/ieee_figure.md
@@ -1,0 +1,128 @@
+---
+id: ieee_figure
+name: IEEE Figure Style
+description: |
+  Aesthetic guidelines for statistical plots targeting IEEE journals and
+  conferences (TPAMI, CVPR, ICCV, ICASSP, etc.). Based on SciencePlots
+  (garrettj403/SciencePlots, MIT) ieee.mplstyle. Black-and-white compatible,
+  600 DPI, Computer Modern serif, inward ticks with minor ticks visible.
+source: https://github.com/garrettj403/SciencePlots
+license: MIT
+---
+
+# IEEE Figure Style
+
+> **Attribution**: rcParams baseline directly from SciencePlots
+> ([github.com/garrettj403/SciencePlots](https://github.com/garrettj403/SciencePlots), MIT),
+> `scienceplots/styles/journals/ieee.mplstyle`.
+> Original content: `axes.prop_cycle : cycler('color', ['k', 'r', 'b', 'g']) +
+> cycler('ls', ['-', '--', ':', '-.'])`, figure.figsize 3.5×2.625,
+> font.family serif, font.serif cmr10/Computer Modern.
+
+## 1. The "IEEE Look"
+
+IEEE figures are defined by:
+- **Black-and-white compatibility first** — every series distinguished by line style, not just color
+- **Computer Modern serif** — cmr10 (same as LaTeX default), not Times New Roman
+- **Inward ticks on all 4 sides** — top + right ticks on, minor ticks visible
+- **No legend frame** — frameon = False
+- **3.5" single column** — slightly wider than Nature (3.3")
+
+## 2. rcParams Baseline (from `ieee.mplstyle`)
+
+```python
+from cycler import cycler
+import matplotlib as mpl
+
+mpl.rcParams.update({
+    # Color + line style + marker cycle — B&W compatible, ≥6 series distinguishable
+    # Source: scienceplots/styles/journals/ieee.mplstyle (color+ls) + marker added
+    "axes.prop_cycle": (
+        cycler("color", ["k", "r", "b", "g", "m", "c"]) +
+        cycler("ls", ["-", "--", ":", "-.", "-", "--"]) +
+        cycler("marker", ["o", "s", "^", "D", "v", "P"])
+    ),
+
+    # Figure size — 3.5" single column
+    "figure.figsize": [3.5, 2.625],
+
+    # Ticks — inward, all 4 sides, minor ticks on
+    "xtick.direction": "in",
+    "xtick.major.size": 3,
+    "xtick.major.width": 0.5,
+    "xtick.minor.size": 1.5,
+    "xtick.minor.width": 0.5,
+    "xtick.minor.visible": True,
+    "xtick.top": True,
+    "ytick.direction": "in",
+    "ytick.major.size": 3,
+    "ytick.major.width": 0.5,
+    "ytick.minor.size": 1.5,
+    "ytick.minor.width": 0.5,
+    "ytick.minor.visible": True,
+    "ytick.right": True,
+
+    # Line widths
+    "axes.linewidth": 0.5,
+    "grid.linewidth": 0.5,
+    "lines.linewidth": 1.0,
+    "lines.markersize": 4,  # small markers for dense plots
+
+    # Font — Computer Modern serif (LaTeX default)
+    "font.family": "serif",
+    "font.serif": ["cmr10", "Computer Modern Serif", "DejaVu Serif"],
+    "axes.formatter.use_mathtext": True,
+    "mathtext.fontset": "cm",
+    "font.size": 8,
+    "axes.labelsize": 8,
+    "xtick.labelsize": 8,
+    "ytick.labelsize": 8,
+
+    # No legend frame
+    "legend.frameon": False,
+
+    # Save
+    "savefig.bbox": "tight",
+    "savefig.pad_inches": 0.05,
+    "savefig.dpi": 600,
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
+    "svg.fonttype": "none",
+})
+```
+
+## 3. Figure Sizes
+
+| Format | Width × Height | Notes |
+|---|---|---|
+| Single column | 3.5" × 2.625" | Standard |
+| 1.5-column | 5.0" × 3.5" | Some journals allow |
+| Double column | 7.16" × 5.0" | Full-width |
+
+## 4. Color & Line Style Strategy
+
+**Primary rule**: every series must be distinguishable in grayscale print.
+
+The `axes.prop_cycle` in the rcParams baseline above pairs **color + line style + marker** automatically for up to 6 series. This triple encoding ensures B&W print, colorblind, and screen viewers can all distinguish data series.
+
+- Series 1: black solid circle `k-o`
+- Series 2: red dashed square `r--s`
+- Series 3: blue dotted triangle-up `b:^`
+- Series 4: green dash-dot diamond `g-.D`
+- Series 5: magenta solid triangle-down `m-v`
+- Series 6: cyan dashed plus `c--P`
+
+**For heatmaps**: grayscale (`plt.cm.Greys`) or single-hue sequential. Avoid multi-hue.
+
+## 5. Font Notes
+
+IEEE LaTeX templates use Computer Modern (`\usepackage{times}` is common but CM is acceptable). The `cmr10` entry in `font.serif` ensures matplotlib uses Computer Modern when available. If not installed, falls back to DejaVu Serif — acceptable for drafts.
+
+## 6. Common Pitfalls
+
+- ❌ Color as sole differentiator — IEEE prints/reviews in B&W
+- ❌ Sans-serif axis labels — CM serif is the house style
+- ❌ Missing minor ticks — all 4 sides should show both major and minor
+- ❌ Legend frame (`frameon=True`) — remove it
+- ❌ Figure wider than 3.5" single column — will be resized by production
+- ❌ Missing axis units — always `Accuracy (%)` not just `Accuracy`

--- a/pantheon/factory/templates/skills/figure_styling/styles/nature_figure.md
+++ b/pantheon/factory/templates/skills/figure_styling/styles/nature_figure.md
@@ -1,0 +1,146 @@
+---
+id: nature_figure
+name: "Nature / Cell / Science Figure Style"
+description: |
+  Aesthetic guidelines for publication-quality figures targeting Nature,
+  Cell, Science, and their family journals. Based on SciencePlots
+  (garrettj403/SciencePlots, MIT) nature.mplstyle, with Cell Press and
+  AAAS Science size specifications added.
+source: https://github.com/garrettj403/SciencePlots
+license: MIT
+---
+
+# Nature / Cell / Science Figure Style
+
+> **Attribution**: rcParams baseline from SciencePlots
+> ([github.com/garrettj403/SciencePlots](https://github.com/garrettj403/SciencePlots), MIT),
+> `scienceplots/styles/journals/nature.mplstyle`. Extended with Cell Press
+> and AAAS Science journal specifications from author guidelines.
+
+## 1. The "CNS Look"
+
+Three journals — Cell, Nature, Science — share a house style:
+- **7 pt body text** — the single most distinctive constraint; everything is small and precise
+- **Sans-serif throughout** — Arial/Helvetica exclusively (DejaVu Sans as fallback)
+- **No gridlines** — stark white background, no grid in most figure types
+- **Inward ticks on all 4 sides** — top and right ticks on, minor ticks visible
+- **Muted colorblind-safe palettes** — never Jet/Rainbow; prefer Paul Tol sets (see `color_palettes.md`)
+- **600 DPI final** — 300 DPI preview acceptable
+
+## 2. rcParams Baseline (from `nature.mplstyle`)
+
+```python
+import matplotlib as mpl
+
+mpl.rcParams.update({
+    # Figure size — Nature single column (max 3.5" wide)
+    "figure.figsize": [3.5, 2.625],
+
+    # Fonts — sans-serif, 7 pt body
+    "font.family": "sans-serif",
+    "font.sans-serif": ["Arial", "Helvetica", "DejaVu Sans"],
+    "font.size": 7,
+    "axes.labelsize": 7,
+    "xtick.labelsize": 7,
+    "ytick.labelsize": 7,
+    "legend.fontsize": 7,
+    "axes.titlesize": 8,
+    "mathtext.fontset": "dejavusans",
+
+    # Ticks — inward, all 4 sides, minor ticks on
+    "xtick.direction": "in",
+    "xtick.major.size": 3,
+    "xtick.major.width": 0.5,
+    "xtick.minor.size": 1.5,
+    "xtick.minor.width": 0.5,
+    "xtick.minor.visible": True,
+    "xtick.top": True,
+    "ytick.direction": "in",
+    "ytick.major.size": 3,
+    "ytick.major.width": 0.5,
+    "ytick.minor.size": 1.5,
+    "ytick.minor.width": 0.5,
+    "ytick.minor.visible": True,
+    "ytick.right": True,
+
+    # Lines
+    "axes.linewidth": 0.5,
+    "grid.linewidth": 0.5,
+    "lines.linewidth": 1.0,
+    "lines.markersize": 3,
+
+    # No legend frame
+    "legend.frameon": False,
+
+    # Save
+    "savefig.bbox": "tight",
+    "savefig.pad_inches": 0.01,
+    "savefig.dpi": 600,
+    "pdf.fonttype": 42,   # editable text in PDF
+    "ps.fonttype": 42,
+    "svg.fonttype": "none",  # editable text in SVG
+})
+```
+
+## 3. Figure Sizes by Journal
+
+| Journal | Single column | 1.5-column | Double column | Notes |
+|---|---|---|---|---|
+| **Nature family** | 3.5" × 2.625" | — | 7.2" × 5.0" | Max width 3.5" single |
+| **Cell Press** | 3.35" × 2.5" (85 mm) | 4.49" (114 mm) | 6.85" × 5.0" (174 mm) | Height flexible |
+| **AAAS Science** | 2.24" × 2.0" (57 mm) | 4.72" (120 mm) | 4.72" × 3.5" | Very narrow single |
+| **Default / unknown** | 3.5" × 2.625" | — | 7.0" × 5.0" | Safe fallback |
+
+**Graphical abstract sizes**:
+- Cell Press: 169 mm × 60 mm (6.65" × 2.36") landscape
+- Nature: 90 mm × 60 mm (3.54" × 2.36") portrait-ish
+- Elsevier: 130 mm × 70 mm (5.12" × 2.76")
+
+## 4. Recommended Color Palettes
+
+See `color_palettes.md` for the full Paul Tol palette library. Quick reference for CNS:
+
+**Categorical (colorblind-safe)**:
+```python
+# Paul Tol "bright" — recommended default for CNS
+BRIGHT = ["#4477AA", "#EE6677", "#228833", "#CCBB44", "#66CCEE", "#AA3377", "#BBBBBB"]
+
+# Paul Tol "muted" — for dense multi-category plots
+MUTED = ["#CC6677", "#332288", "#DDCC77", "#117733", "#88CCEE", "#882255", "#44AA99"]
+```
+
+**Sequential / heatmap**:
+- `viridis` — default for all sequential data
+- `magma` / `plasma` — alternative perceptually uniform
+- `RdBu_r` — diverging (positive/negative splits)
+- Never `jet` / `rainbow`
+
+## 5. Panel Letters
+
+Nature style panel letters: **bold, 8 pt, upper-left corner** of each panel.
+
+```python
+ax.text(-0.15, 1.05, "a", transform=ax.transAxes,
+        fontsize=8, fontweight="bold", va="top", ha="right")
+```
+
+Cell Press uses lower-case bold: `a`, `b`, `c` at 8 pt.
+
+## 6. Multi-panel Figure Rules
+
+- All panels must use **identical font sizes** across a figure
+- **Align panel bottoms** on a common baseline (use `gridspec` with `hspace`)
+- **No whitespace waste** — pack panels tightly; Nature reviewers notice gaps
+- **Consistent axis ranges** when comparing conditions across panels
+- **Scale bars** instead of axis ticks for microscopy / spatial data
+
+## 7. Common Pitfalls
+
+- ❌ Font > 7 pt — wastes precious column width; reviewers notice
+- ❌ Gridlines — CNS almost never shows them in main figures
+- ❌ Both top/right spines visible but un-ticked — either add ticks or remove spines
+- ❌ Serif fonts on axes — DejaVu Sans, not Times
+- ❌ Figure wider than column spec — journal production will resize, destroying aspect ratio
+- ❌ Jet/Rainbow colormap — unacceptable in all three journals
+- ❌ Panel letters not bold — must be bold weight
+- ❌ Caption text inside figure — captions go in `figure_legends.md`


### PR DESCRIPTION
## Summary

- Update `SKILL.md`: add outputType routing table, lightweight read rule, scientific visual language, domain adaptation rule, and legacy compatibility note
- Add 5 self-contained outputType recipes for default-agent use: `figure.md`, `poster.md`, `graphical-abstract.md`, `presentation.md`, `flowchart.md`
- Add 3 optional venue style files cherry-picked from #106: `styles/nature_figure.md`, `styles/ieee_figure.md`, `styles/color_palettes.md`
- Preserve existing `styles/neurips_diagram.md` and `styles/neurips_plot.md` untouched

## What changed

| File | Change | Notes |
|---|---|---|
| `SKILL.md` | Updated | Adds outputType routing; preserves Graph Maker Team legacy path |
| `figure.md` | Added | Code-first recipe with Research figure schema |
| `poster.md` | Added | Mixed recipe with Poster zones and Word limits |
| `graphical-abstract.md` | Added | AI-first recipe with Visual Schema + structured prompt scaffold |
| `presentation.md` | Added | Mixed recipe with Mixed slide schema + Screen readability |
| `flowchart.md` | Added | AI-first recipe with Workflow schema + Arrow semantics |
| `styles/nature_figure.md` | Added | Nature/Cell/Science style guide (from #106) |
| `styles/ieee_figure.md` | Added | IEEE style guide (from #106) |
| `styles/color_palettes.md` | Added | Paul Tol colorblind-safe palettes (from #106) |

## Design decisions

- **Default read path is `SKILL.md` + one recipe** — no quality/, input/, triage/, or styles/ loaded by default
- **Recipes are self-contained** — no dependency on Graph Maker Team, leader, data_plotter, illustrator, canvas, workdir, or style_card.json
- **Styles are optional** — loaded only when user explicitly requests a venue/style or style_id is provided
- **Domain-neutral** — recipes include 3D genomics as an instantiation example only, not as a default domain

## Relation to open PRs

- Supersedes the `SKILL.md` changes in #105, #106, and #112 (those PRs' `SKILL.md` diffs bind the skill to the heavy Graph Maker Team harness)
- The quality/, input/, triage/, and scenarios/ from #105/#112 are intentionally excluded from this PR and can be introduced separately
- #111 (harness-cleanup) does not touch figure_styling — no conflict

## Test plan

- [ ] Verify `SKILL.md` routes to correct recipe by outputType
- [ ] Verify each recipe file loads standalone without Graph Maker Team context
- [ ] Verify `styles/neurips_diagram.md` and `styles/neurips_plot.md` are unchanged