### PR TITLE
Use runtime factory template fallback

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # Include package data
-recursive-include pantheon/factory/templates *.md *.json *.example
+recursive-include pantheon/factory/templates *.md *.json *.example *.js *.css *.py .gitkeep
 recursive-include pantheon/toolsets/database_api/schemas *.json
 
 # Include documentation

--- a/README.md
+++ b/README.md
@@ -124,13 +124,12 @@ docker pull nanguage/pantheon-agents:latest
 # Run in standalone mode (for local use)
 docker run -it --rm \
   -e PANTHEON_MODE=standalone \
-  -e PANTHEON_TEMPLATE_SYNC_SCOPE=project \
   -v $(pwd)/workspace:/workspace \
   -p 8080:8080 \
   nanguage/pantheon-agents:latest
 ```
 
-After startup, copy the displayed connection URL to your browser and start using Pantheon. The Docker image stores factory templates, skills, and user edits under the mounted `/workspace/.pantheon/` project directory by default, so they persist across container restarts when you reuse the same workspace mount.
+After startup, copy the displayed connection URL to your browser and start using Pantheon. The Docker image reads factory templates directly from the running image, so startup does not copy templates into `/workspace` or container home. User-created project overrides still persist under the mounted `/workspace/.pantheon/` directory.
 
 For detailed Docker usage, deployment modes, and configuration options, see the [Docker documentation](https://github.com/aristoteleo/PantheonOS/tree/main/pantheon-agents/docker).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -267,9 +267,9 @@ ENV PATH="${VENV_PATH}/bin:$PATH" \
     # Install playwright browsers to an explicit path outside /root/.cache.
     # This prevents accidental deletion and makes the installation location unambiguous.
     PLAYWRIGHT_BROWSERS_PATH=/usr/local/share/ms-playwright \
-    # Docker containers usually persist /workspace, not /root. Keep factory
-    # templates, skills, and hash stamps in the mounted project area by default.
-    PANTHEON_TEMPLATE_SYNC_SCOPE=project
+    # Do not copy factory templates into ephemeral HOME on sandbox startup.
+    # Runtime loaders fall back to the packaged templates inside the image.
+    PANTHEON_FACTORY_TEMPLATE_MODE=runtime
 
 # Layer C — Playwright browsers (~300-400MB, stable): only rebuilt when Playwright version changes.
 # Using chromium is sufficient for most web scraping/automation tasks.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -266,10 +266,7 @@ ENV PATH="${VENV_PATH}/bin:$PATH" \
     UV_CACHE_DIR=/app/.uv-cache \
     # Install playwright browsers to an explicit path outside /root/.cache.
     # This prevents accidental deletion and makes the installation location unambiguous.
-    PLAYWRIGHT_BROWSERS_PATH=/usr/local/share/ms-playwright \
-    # Do not copy factory templates into ephemeral HOME on sandbox startup.
-    # Runtime loaders fall back to the packaged templates inside the image.
-    PANTHEON_FACTORY_TEMPLATE_MODE=runtime
+    PLAYWRIGHT_BROWSERS_PATH=/usr/local/share/ms-playwright
 
 # Layer C — Playwright browsers (~300-400MB, stable): only rebuilt when Playwright version changes.
 # Using chromium is sufficient for most web scraping/automation tasks.

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,6 @@ Run Pantheon AI agents in a containerized environment with everything pre-config
 ```bash
 docker run -it --rm \
   -e PANTHEON_MODE=standalone \
-  -e PANTHEON_TEMPLATE_SYNC_SCOPE=project \
   -e OPENAI_API_KEY="sk-your-key" \
   -v $(pwd)/workspace:/workspace \
   -p 8080:8080 \
@@ -40,7 +39,6 @@ docker run -it --rm \
 ```bash
 docker run -it --rm \
   -e PANTHEON_MODE=standalone \
-  -e PANTHEON_TEMPLATE_SYNC_SCOPE=project \
   -v $(pwd)/workspace:/workspace \
   -p 8080:8080 \
   nanguage/pantheon-agents:latest
@@ -51,7 +49,6 @@ docker run -it --rm \
 ```bash
 docker run -it --rm \
   -e PANTHEON_MODE=standalone \
-  -e PANTHEON_TEMPLATE_SYNC_SCOPE=project \
   -e OPENAI_API_KEY="sk-your-key" \
   -e ANTHROPIC_API_KEY="sk-ant-your-key" \
   -v $(pwd)/workspace:/workspace \
@@ -64,7 +61,6 @@ docker run -it --rm \
 ```bash
 docker run -it --rm \
   -e PANTHEON_MODE=standalone \
-  -e PANTHEON_TEMPLATE_SYNC_SCOPE=project \
   -e NATS_EXTERNAL_PORT=9000 \
   -v $(pwd)/workspace:/workspace \
   -p 9000:8080 \
@@ -79,8 +75,9 @@ The connection URL will automatically use port 9000 instead of 8080.
 |----------|-------------|---------|
 | `PANTHEON_MODE` | Set to `standalone` for local use | `hub` |
 | `NATS_EXTERNAL_PORT` | External port for NATS WebSocket | `8080` |
-| `PANTHEON_TEMPLATE_SYNC_SCOPE` | Factory agents/teams/prompts/skills **always** sync to the **global** scope (container home) so they track the running image and refresh on every start. The **project** scope (`/workspace/.pantheon/`) is reserved for user-created content, which overrides factory defaults via the `project → global → factory` read order. Set to `none` to skip factory sync entirely. (Previously `project` copied factory templates into `/workspace`, which froze them on a persistent volume — bootstrap now auto-reclaims any such stale copies.) | `global` |
-| `PANTHEON_RESET_TEMPLATES` | Hub mode only. Set to `true` to hard-clear `/workspace/.pantheon/` factory dirs and force-sync — **destructive: also deletes user-created project content.** Rarely needed now: bootstrap automatically reclaims stale factory-origin templates from the project scope (preserving user-created and user-modified files). Unset after one successful start. | - |
+| `PANTHEON_FACTORY_TEMPLATE_MODE` | Factory template materialization mode. `runtime` reads factory agents/teams/prompts/skills directly from the running image without startup copies. `global` or `project` explicitly copy factory templates to that scope for legacy workflows. | `runtime` |
+| `PANTHEON_TEMPLATE_SYNC_SCOPE` | Legacy alias for `global`, `project`, or `none` materialization. Leave unset for runtime factory fallback. | - |
+| `PANTHEON_RESET_TEMPLATES` | Hub mode only. Set to `true` to hard-clear `/workspace/.pantheon/` factory dirs before a forced sync — **destructive: also deletes user-created project content.** Rarely needed now: bootstrap automatically reclaims stale factory-origin templates from the project scope (preserving user-created and user-modified files). Unset after one successful start. | - |
 | `OPENAI_API_KEY` | OpenAI API key | - |
 | `ANTHROPIC_API_KEY` | Anthropic API key | - |
 | `GEMINI_API_KEY` | Google Gemini API key | - |
@@ -96,9 +93,9 @@ The container creates a `workspace` directory for your files:
 workspace/
 ├── .pantheon/          # Pantheon configuration
 │   ├── .env           # API keys (auto-created)
-│   ├── agents/        # Project-scoped factory/user agents
-│   ├── teams/         # Project-scoped factory/user teams
-│   ├── prompts/       # Project-scoped prompt snippets
+│   ├── agents/        # Project-scoped agent overrides
+│   ├── teams/         # Project-scoped team overrides
+│   ├── prompts/       # Project-scoped prompt overrides
 │   ├── skills/        # Project-scoped skills and LiveView adapters
 │   └── memory/        # Agent memory
 ├── your-code/         # Your code files
@@ -110,10 +107,11 @@ Mount your local directory to persist data:
 -v $(pwd)/workspace:/workspace
 ```
 
-The Docker image defaults to `PANTHEON_TEMPLATE_SYNC_SCOPE=project` so factory
-templates and hash stamps are stored under `/workspace/.pantheon/`. This keeps
-templates, skills, and user edits persistent across `docker run --rm` restarts
-as long as you mount the same workspace directory.
+The Docker image defaults to runtime factory fallback. Factory templates are
+read from the running image, so image upgrades automatically expose the latest
+defaults without copying them into `/workspace`. User-created project overrides
+and edits persist across `docker run --rm` restarts as long as you mount the
+same workspace directory.
 
 ---
 
@@ -206,7 +204,6 @@ For production Kubernetes deployments with centralized NATS server:
 docker run -d \
   -e ID_HASH=agent-001 \
   -e NATS_SERVERS=nats://hub-nats:4222 \
-  -e PANTHEON_TEMPLATE_SYNC_SCOPE=project \
   -v $(pwd)/workspace:/workspace \
   nanguage/pantheon-agents:latest
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -75,8 +75,7 @@ The connection URL will automatically use port 9000 instead of 8080.
 |----------|-------------|---------|
 | `PANTHEON_MODE` | Set to `standalone` for local use | `hub` |
 | `NATS_EXTERNAL_PORT` | External port for NATS WebSocket | `8080` |
-| `PANTHEON_FACTORY_TEMPLATE_MODE` | Factory template materialization mode. `runtime` reads factory agents/teams/prompts/skills directly from the running image without startup copies. `global` or `project` explicitly copy factory templates to that scope for legacy workflows. | `runtime` |
-| `PANTHEON_TEMPLATE_SYNC_SCOPE` | Legacy alias for `global`, `project`, or `none` materialization. Leave unset for runtime factory fallback. | - |
+| `PANTHEON_FACTORY_TEMPLATE_MODE` | Factory template materialization mode. `runtime` reads factory agents/teams/prompts/skills directly from the running image without startup copies. `global` explicitly copies factory templates to global for legacy workflows. | `runtime` |
 | `PANTHEON_RESET_TEMPLATES` | Hub mode only. Set to `true` to hard-clear `/workspace/.pantheon/` factory dirs before a forced sync — **destructive: also deletes user-created project content.** Rarely needed now: bootstrap automatically reclaims stale factory-origin templates from the project scope (preserving user-created and user-modified files). Unset after one successful start. | - |
 | `OPENAI_API_KEY` | OpenAI API key | - |
 | `ANTHROPIC_API_KEY` | Anthropic API key | - |

--- a/docker/docker-entrypoint-dual-mode.sh
+++ b/docker/docker-entrypoint-dual-mode.sh
@@ -228,8 +228,9 @@ else
     mkdir -p /workspace/.pantheon
     echo "✓ Ensured .pantheon directory exists"
 
-    # Clear stale project-level templates before forcing a factory sync with the
-    # current PANTHEON_TEMPLATE_SYNC_SCOPE.
+    # Clear stale project-level templates before forcing an explicit factory
+    # materialization. Normal startup uses runtime factory fallback and does not
+    # copy factory templates.
     if [ "${PANTHEON_RESET_TEMPLATES}" = "true" ]; then
         echo "Clearing stale project-level templates..."
         rm -rf /workspace/.pantheon/agents /workspace/.pantheon/teams /workspace/.pantheon/prompts /workspace/.pantheon/skills /workspace/.pantheon/.factory_hashes.json

--- a/docs/source/configuration/settings.rst
+++ b/docs/source/configuration/settings.rst
@@ -138,7 +138,7 @@ the runtime fallback order ``project → global → factory``. No startup copy i
 needed for agents, teams, prompts, or skills.
 
 When factory templates are explicitly materialized with
-``PANTHEON_FACTORY_TEMPLATE_MODE=global`` or ``project``, this setting controls
+``PANTHEON_FACTORY_TEMPLATE_MODE=global``, this setting controls
 whether unchanged factory copies can be updated. The materialization uses
 **hash-based change detection** to avoid overwriting user modifications:
 

--- a/docs/source/configuration/settings.rst
+++ b/docs/source/configuration/settings.rst
@@ -133,8 +133,14 @@ Template Auto-Update
      "default_template_auto_update": true
    }
 
-When ``true`` (default), factory templates are synced to your ``.pantheon/`` directory on startup.
-The sync uses **hash-based change detection** to avoid overwriting user modifications:
+By default, factory templates are read directly from the installed package using
+the runtime fallback order ``project → global → factory``. No startup copy is
+needed for agents, teams, prompts, or skills.
+
+When factory templates are explicitly materialized with
+``PANTHEON_FACTORY_TEMPLATE_MODE=global`` or ``project``, this setting controls
+whether unchanged factory copies can be updated. The materialization uses
+**hash-based change detection** to avoid overwriting user modifications:
 
 - If only the factory template changed, it is updated automatically.
 - If you modified a template (e.g. via ``/model``), your changes are preserved even when the factory version updates.

--- a/pantheon/__main__.py
+++ b/pantheon/__main__.py
@@ -119,10 +119,10 @@ def update_templates():
 
 
 def sync_templates():
-    """Force-sync all factory templates (agents, teams, prompts, skills) to ~/.pantheon/.
+    """Force-sync all factory templates (agents, teams, prompts, skills).
 
     Non-interactive. Clears hash tracking and overwrites all factory-origin files.
-    Useful after image upgrades to ensure latest templates are in use.
+    In runtime fallback mode this materializes to ~/.pantheon/ for legacy workflows.
     """
     from pantheon.factory.template_manager import get_template_manager
 

--- a/pantheon/__main__.py
+++ b/pantheon/__main__.py
@@ -122,7 +122,7 @@ def sync_templates():
     """Force-sync all factory templates (agents, teams, prompts, skills).
 
     Non-interactive. Clears hash tracking and overwrites all factory-origin files.
-    In runtime fallback mode this materializes to ~/.pantheon/ for legacy workflows.
+    Materializes packaged factory templates to ~/.pantheon/ for legacy workflows.
     """
     from pantheon.factory.template_manager import get_template_manager
 

--- a/pantheon/factory/template_manager.py
+++ b/pantheon/factory/template_manager.py
@@ -105,10 +105,9 @@ class TemplateManager:
         self._ensure_default_templates()
 
         # Reclaim: older builds copied factory templates into the PROJECT scope
-        # (PANTHEON_TEMPLATE_SYNC_SCOPE=project). On Modal those froze on the
-        # persistent volume and shadowed the fresh factory fallback. Remove
-        # factory-origin project files, preserving user-created and user-modified
-        # content.
+        # On Modal those froze on the persistent volume and shadowed the fresh
+        # factory fallback. Remove factory-origin project files, preserving
+        # user-created and user-modified content.
         self._reclaim_factory_from_project(pre_sync_hashes)
 
         logger.info("Template system bootstrap complete")
@@ -146,57 +145,23 @@ class TemplateManager:
 
         Default is runtime fallback: do not copy factory templates anywhere at
         startup. Loading resolves project -> global -> packaged factory.
-
-        Backwards compatibility:
-        - PANTHEON_TEMPLATE_SYNC_SCOPE=global/project still requests materialization.
-        - PANTHEON_TEMPLATE_SYNC_SCOPE=none skips materialization.
-        - PANTHEON_FACTORY_TEMPLATE_MODE can explicitly set runtime/global/project/off.
         """
-        raw_mode = os.environ.get("PANTHEON_FACTORY_TEMPLATE_MODE")
-        if raw_mode is not None:
-            mode = raw_mode.strip().lower()
-            if not mode:
-                return "runtime"
-            aliases = {"fallback": "runtime", "none": "runtime"}
-            mode = aliases.get(mode, mode)
-            if mode not in {"runtime", "global", "project", "off"}:
-                logger.warning(
-                    f"Invalid PANTHEON_FACTORY_TEMPLATE_MODE={mode!r}; falling back to 'runtime'"
-                )
-                return "runtime"
-            return mode
-
-        scope = os.environ.get("PANTHEON_TEMPLATE_SYNC_SCOPE", "").strip().lower()
-        if not scope:
+        raw_mode = os.environ.get("PANTHEON_FACTORY_TEMPLATE_MODE", "")
+        mode = raw_mode.strip().lower()
+        if not mode:
             return "runtime"
-        if scope not in {"global", "project", "none"}:
+        if mode not in {"runtime", "global"}:
             logger.warning(
-                f"Invalid PANTHEON_TEMPLATE_SYNC_SCOPE={scope!r}; falling back to 'runtime'"
+                f"Invalid PANTHEON_FACTORY_TEMPLATE_MODE={mode!r}; falling back to 'runtime'"
             )
             return "runtime"
-        return "off" if scope == "none" else scope
+        return mode
 
-    def _legacy_sync_scope_is_none(self) -> bool:
-        return (
-            "PANTHEON_FACTORY_TEMPLATE_MODE" not in os.environ
-            and os.environ.get("PANTHEON_TEMPLATE_SYNC_SCOPE", "").strip().lower() == "none"
-        )
-
-    def _factory_template_targets(self, *, default_mode: str | None = None) -> list[tuple[str, Path, str]]:
+    def _factory_template_targets(self, *, mode: str | None = None) -> list[tuple[str, Path, str]]:
         """Return optional factory template copy targets for materialization."""
-        mode = self._factory_template_mode()
-        if mode in {"runtime", "off"} and default_mode is not None:
-            mode = default_mode
-        if mode in {"runtime", "off"}:
+        mode = self._factory_template_mode() if mode is None else mode
+        if mode != "global":
             return []
-
-        if mode == "project":
-            return [
-                ("agents", self.agents_dir, "agent(s)"),
-                ("teams", self.teams_dir, "team(s)"),
-                ("prompts", self.prompts_dir, "prompt(s)"),
-                ("skills", self.skills_dir, "skill(s)"),
-            ]
 
         return [
             ("agents", self.settings.global_agents_dir, "agent(s)"),
@@ -376,7 +341,7 @@ class TemplateManager:
         project → global (~/.pantheon/) → packaged factory.
         """
         mode = self._factory_template_mode()
-        if mode in {"runtime", "off"}:
+        if mode == "runtime":
             logger.info(
                 "PANTHEON_FACTORY_TEMPLATE_MODE=runtime: using packaged factory fallback; "
                 "skipping startup template sync"
@@ -390,7 +355,7 @@ class TemplateManager:
                 f"agents/teams/prompts/skills with latest factory defaults (mode={mode})"
             )
 
-        for subdir, dest_dir, label in self._factory_template_targets():
+        for subdir, dest_dir, label in self._factory_template_targets(mode=mode):
             try:
                 self._copy_missing_templates(
                     self.system_templates_dir / subdir, dest_dir, label, overwrite=overwrite
@@ -459,30 +424,24 @@ class TemplateManager:
             )
 
     def force_sync_factory_templates(self):
-        """Force-sync ALL factory templates (including skills) to the configured scope.
+        """Force-sync ALL factory templates (including skills) to global.
 
         Clears hash tracking and copies everything with overwrite=True.
         Used for image upgrades where stale templates need to be replaced.
         """
-        mode = self._factory_template_mode()
-        if self._legacy_sync_scope_is_none():
-            logger.info("PANTHEON_TEMPLATE_SYNC_SCOPE=none: skipping force-sync")
-            return 0
-        sync_mode = "global" if mode in {"runtime", "off"} else mode
-
         hash_file = self.settings.pantheon_dir / ".factory_hashes.json"
         if hash_file.exists():
             hash_file.unlink()
 
         total = 0
-        for subdir, dest_dir, label in self._factory_template_targets(default_mode=sync_mode):
+        for subdir, dest_dir, label in self._factory_template_targets(mode="global"):
             try:
                 total += self._copy_missing_templates(
                     self.system_templates_dir / subdir, dest_dir, label, overwrite=True
                 )
             except Exception as e:
                 logger.error(f"Failed to force-sync {label}: {e}")
-        logger.info(f"Force-sync complete: {total} file(s) synced (mode={sync_mode})")
+        logger.info(f"Force-sync complete: {total} file(s) synced (mode=global)")
         return total
 
     def _ensure_settings(self):

--- a/pantheon/factory/template_manager.py
+++ b/pantheon/factory/template_manager.py
@@ -96,21 +96,19 @@ class TemplateManager:
         self._ensure_settings()
         self._ensure_mcp_config()
 
-        # Snapshot the factory hashes BEFORE the global sync overwrites them, so
-        # reclaim can tell a user-MODIFIED project file (changed since its last
-        # sync) from a merely-stale factory copy.
+        # Snapshot hashes before any optional materialization so reclaim can
+        # distinguish a user-modified project override from a stale factory copy.
         pre_sync_hashes = self._load_factory_hashes()
 
-        # Ensure packaged templates exist locally (copy missing ones).
-        # Factory content now syncs to GLOBAL (see _factory_template_targets).
+        # Optional materialization. The default is runtime factory fallback, so
+        # sandbox startup does not copy package templates into ephemeral HOME.
         self._ensure_default_templates()
 
         # Reclaim: older builds copied factory templates into the PROJECT scope
         # (PANTHEON_TEMPLATE_SYNC_SCOPE=project). On Modal those froze on the
-        # persistent volume and shadowed the fresh global copies. Remove the
-        # factory-origin project files (now served from global), preserving
-        # user-created and user-modified content. Runs after the global sync so
-        # nothing is lost.
+        # persistent volume and shadowed the fresh factory fallback. Remove
+        # factory-origin project files, preserving user-created and user-modified
+        # content.
         self._reclaim_factory_from_project(pre_sync_hashes)
 
         logger.info("Template system bootstrap complete")
@@ -143,35 +141,62 @@ class TemplateManager:
         hash_file = self.settings.pantheon_dir / ".factory_hashes.json"
         hash_file.write_text(json.dumps(hashes, indent=2), encoding="utf-8")
 
-    def _template_sync_scope(self) -> str:
-        """Return where factory templates should be synced on startup."""
-        scope = os.environ.get("PANTHEON_TEMPLATE_SYNC_SCOPE", "global").strip().lower()
+    def _factory_template_mode(self) -> str:
+        """Return how factory templates are materialized on startup.
+
+        Default is runtime fallback: do not copy factory templates anywhere at
+        startup. Loading resolves project -> global -> packaged factory.
+
+        Backwards compatibility:
+        - PANTHEON_TEMPLATE_SYNC_SCOPE=global/project still requests materialization.
+        - PANTHEON_TEMPLATE_SYNC_SCOPE=none skips materialization.
+        - PANTHEON_FACTORY_TEMPLATE_MODE can explicitly set runtime/global/project/off.
+        """
+        raw_mode = os.environ.get("PANTHEON_FACTORY_TEMPLATE_MODE")
+        if raw_mode is not None:
+            mode = raw_mode.strip().lower()
+            if not mode:
+                return "runtime"
+            aliases = {"fallback": "runtime", "none": "runtime"}
+            mode = aliases.get(mode, mode)
+            if mode not in {"runtime", "global", "project", "off"}:
+                logger.warning(
+                    f"Invalid PANTHEON_FACTORY_TEMPLATE_MODE={mode!r}; falling back to 'runtime'"
+                )
+                return "runtime"
+            return mode
+
+        scope = os.environ.get("PANTHEON_TEMPLATE_SYNC_SCOPE", "").strip().lower()
         if not scope:
-            return "global"
+            return "runtime"
         if scope not in {"global", "project", "none"}:
             logger.warning(
-                f"Invalid PANTHEON_TEMPLATE_SYNC_SCOPE={scope!r}; falling back to 'global'"
+                f"Invalid PANTHEON_TEMPLATE_SYNC_SCOPE={scope!r}; falling back to 'runtime'"
             )
-            return "global"
-        return scope
+            return "runtime"
+        return "off" if scope == "none" else scope
 
-    def _factory_template_targets(self) -> list[tuple[str, Path, str]]:
-        """Return factory template copy targets.
+    def _legacy_sync_scope_is_none(self) -> bool:
+        return (
+            "PANTHEON_FACTORY_TEMPLATE_MODE" not in os.environ
+            and os.environ.get("PANTHEON_TEMPLATE_SYNC_SCOPE", "").strip().lower() == "none"
+        )
 
-        Factory templates (agents/teams/prompts/skills) ALWAYS sync to the
-        GLOBAL scope so they track the running image — on Modal that means
-        ephemeral HOME, refreshed every start; on local it's the hash-tracked
-        smart-overwrite. The persisted PROJECT scope is reserved for
-        user-created content, which still wins via the project -> global ->
-        factory read fallback.
-
-        Previously PANTHEON_TEMPLATE_SYNC_SCOPE=project wrote factory templates
-        into the project scope; on Modal that pinned them on the persistent
-        volume and FROZE them (they never tracked image upgrades, and the stale
-        project copies shadowed the fresh global ones). `none` still skips sync.
-        """
-        if self._template_sync_scope() == "none":
+    def _factory_template_targets(self, *, default_mode: str | None = None) -> list[tuple[str, Path, str]]:
+        """Return optional factory template copy targets for materialization."""
+        mode = self._factory_template_mode()
+        if mode in {"runtime", "off"} and default_mode is not None:
+            mode = default_mode
+        if mode in {"runtime", "off"}:
             return []
+
+        if mode == "project":
+            return [
+                ("agents", self.agents_dir, "agent(s)"),
+                ("teams", self.teams_dir, "team(s)"),
+                ("prompts", self.prompts_dir, "prompt(s)"),
+                ("skills", self.skills_dir, "skill(s)"),
+            ]
 
         return [
             ("agents", self.settings.global_agents_dir, "agent(s)"),
@@ -338,7 +363,7 @@ class TemplateManager:
         self._save_factory_hashes(factory_hashes)
 
     def _ensure_default_templates(self):
-        """Sync factory defaults according to PANTHEON_TEMPLATE_SYNC_SCOPE.
+        """Optionally materialize factory defaults according to factory mode.
 
         Respects the `default_template_auto_update` setting for all categories
         (agents/teams/prompts/skills):
@@ -347,24 +372,22 @@ class TemplateManager:
           updated to the latest version.
         - False: only copy files that don't exist yet (preserves all user edits).
 
-        Default scope is global so local/desktop behavior keeps the same
-        3-layer fallback:
-        project → global (~/.pantheon/) → factory
-
-        Modal sandboxes can set PANTHEON_TEMPLATE_SYNC_SCOPE=project so the
-        copied factory templates and their hashes live on the persisted
-        workspace volume instead of ephemeral HOME.
+        Default mode is runtime fallback, which performs no startup copy:
+        project → global (~/.pantheon/) → packaged factory.
         """
-        scope = self._template_sync_scope()
-        if scope == "none":
-            logger.info("PANTHEON_TEMPLATE_SYNC_SCOPE=none: skipping factory template sync")
+        mode = self._factory_template_mode()
+        if mode in {"runtime", "off"}:
+            logger.info(
+                "PANTHEON_FACTORY_TEMPLATE_MODE=runtime: using packaged factory fallback; "
+                "skipping startup template sync"
+            )
             return
 
         overwrite = self.settings.default_template_auto_update
         if overwrite:
             logger.info(
                 "default_template_auto_update=true: smart-overwriting "
-                f"agents/teams/prompts/skills with latest factory defaults (scope={scope})"
+                f"agents/teams/prompts/skills with latest factory defaults (mode={mode})"
             )
 
         for subdir, dest_dir, label in self._factory_template_targets():
@@ -377,15 +400,15 @@ class TemplateManager:
 
     def _reclaim_factory_from_project(self, prior_hashes: dict | None = None):
         """Remove factory-origin templates that an older build copied into the
-        PROJECT scope, so they stop shadowing the fresh GLOBAL copies (read
+        PROJECT scope, so they stop shadowing the fresh FACTORY fallback (read
         order is project -> global -> factory).
 
         Safety:
         - A project file is only removed when the SAME relative path exists in
           the packaged factory (factory-origin). User-created files with no
           factory counterpart (e.g. project-specific skills) are preserved.
-        - It is only removed once its GLOBAL counterpart exists, so the content
-          is never lost (the global scope serves it from the current image).
+        - It is only removed when packaged factory still has the same relative
+          path, so the content is still served by runtime factory fallback.
         - User-MODIFIED factory files are preserved: `prior_hashes` is the hash
           snapshot from BEFORE this run's global sync; if a file has a recorded
           hash and no longer matches it, the user edited it on purpose (a
@@ -394,13 +417,13 @@ class TemplateManager:
         """
         factory_hashes = prior_hashes if prior_hashes is not None else self._load_factory_hashes()
         targets = [
-            (self.agents_dir, self.system_templates_dir / "agents", self.settings.global_agents_dir, "agent(s)"),
-            (self.teams_dir, self.system_templates_dir / "teams", self.settings.global_teams_dir, "team(s)"),
-            (self.prompts_dir, self.system_templates_dir / "prompts", self.settings.global_prompts_dir, "prompt(s)"),
-            (self.skills_dir, self.system_templates_dir / "skills", self.settings.global_skills_dir, "skill(s)"),
+            (self.agents_dir, self.system_templates_dir / "agents", "agent(s)"),
+            (self.teams_dir, self.system_templates_dir / "teams", "team(s)"),
+            (self.prompts_dir, self.system_templates_dir / "prompts", "prompt(s)"),
+            (self.skills_dir, self.system_templates_dir / "skills", "skill(s)"),
         ]
         removed = 0
-        for project_dir, factory_dir, global_dir, label in targets:
+        for project_dir, factory_dir, label in targets:
             if not project_dir.exists() or not factory_dir.exists():
                 continue
             for project_file in list(project_dir.rglob("*")):
@@ -409,8 +432,6 @@ class TemplateManager:
                 rel = project_file.relative_to(project_dir)
                 if not (factory_dir / rel).exists():
                     continue  # user-created → keep
-                if not (global_dir / rel).exists():
-                    continue  # global doesn't serve it yet → don't risk data loss
                 # Preserve USER-MODIFIED factory files: if a last-synced hash is
                 # recorded and the project copy no longer matches it, the user
                 # edited it on purpose (an override) — keep it. Files with no
@@ -434,7 +455,7 @@ class TemplateManager:
         if removed:
             logger.info(
                 f"Reclaimed {removed} factory-origin file(s) from the project scope; "
-                "now served from the image-tracked global scope."
+                "now served from packaged factory fallback."
             )
 
     def force_sync_factory_templates(self):
@@ -443,24 +464,25 @@ class TemplateManager:
         Clears hash tracking and copies everything with overwrite=True.
         Used for image upgrades where stale templates need to be replaced.
         """
-        scope = self._template_sync_scope()
-        if scope == "none":
+        mode = self._factory_template_mode()
+        if self._legacy_sync_scope_is_none():
             logger.info("PANTHEON_TEMPLATE_SYNC_SCOPE=none: skipping force-sync")
             return 0
+        sync_mode = "global" if mode in {"runtime", "off"} else mode
 
         hash_file = self.settings.pantheon_dir / ".factory_hashes.json"
         if hash_file.exists():
             hash_file.unlink()
 
         total = 0
-        for subdir, dest_dir, label in self._factory_template_targets():
+        for subdir, dest_dir, label in self._factory_template_targets(default_mode=sync_mode):
             try:
                 total += self._copy_missing_templates(
                     self.system_templates_dir / subdir, dest_dir, label, overwrite=True
                 )
             except Exception as e:
                 logger.error(f"Failed to force-sync {label}: {e}")
-        logger.info(f"Force-sync complete: {total} file(s) synced (scope={scope})")
+        logger.info(f"Force-sync complete: {total} file(s) synced (mode={sync_mode})")
         return total
 
     def _ensure_settings(self):

--- a/pantheon/internal/learning_system/runtime.py
+++ b/pantheon/internal/learning_system/runtime.py
@@ -29,11 +29,19 @@ class LearningRuntime:
 
     def initialize(self, pantheon_dir: Path, global_pantheon_dir: Path | None = None) -> None:
         """Initialize all components."""
+        from pantheon.settings import get_settings
+
         skills_dir = resolve_skills_dir(pantheon_dir)
         runtime_dir = resolve_skills_runtime_dir(pantheon_dir)
         global_skills_dir = resolve_skills_dir(global_pantheon_dir) if global_pantheon_dir else None
+        factory_skills_dir = get_settings().factory_skills_dir
 
-        self.store = SkillStore(skills_dir, runtime_dir, global_skills_dir=global_skills_dir)
+        self.store = SkillStore(
+            skills_dir,
+            runtime_dir,
+            global_skills_dir=global_skills_dir,
+            factory_skills_dir=factory_skills_dir,
+        )
         self.injector = SkillInjector(
             self.store,
             disabled_skills=self.config.get("disabled_skills"),

--- a/pantheon/internal/learning_system/store.py
+++ b/pantheon/internal/learning_system/store.py
@@ -28,58 +28,57 @@ MAX_SKILLS = 200
 class SkillStore:
     """Skill filesystem management with atomic writes and validation.
 
-    Supports layered scanning: project skills override global skills.
+    Supports layered scanning: project skills override global skills, which
+    override packaged factory skills.
     """
 
-    def __init__(self, skills_dir: Path, runtime_dir: Path, global_skills_dir: Path | None = None):
+    def __init__(
+        self,
+        skills_dir: Path,
+        runtime_dir: Path,
+        global_skills_dir: Path | None = None,
+        factory_skills_dir: Path | None = None,
+    ):
         self.skills_dir = skills_dir
         self.runtime_dir = runtime_dir
         self.global_skills_dir = global_skills_dir
+        self.factory_skills_dir = factory_skills_dir
         self.skills_dir.mkdir(parents=True, exist_ok=True)
         self.runtime_dir.mkdir(parents=True, exist_ok=True)
 
     # ── Discovery ──
 
     def scan_headers(self) -> list[SkillHeader]:
-        """Scan all SKILL.md files from project + global, project overrides global."""
+        """Scan all SKILL.md files from project, global, and factory."""
         headers: list[SkillHeader] = []
         seen_paths: set[str] = set()
 
-        # Project skills first (higher priority)
-        for skill_md in self._iter_skill_files(self.skills_dir):
-            header = parse_frontmatter_only(skill_md, skills_dir=self.skills_dir)
-            if header:
-                header.scope = "project"
-                headers.append(header)
-                seen_paths.add(header.path)
-
-        # Global skills (lower priority, skip duplicates)
-        if self.global_skills_dir and self.global_skills_dir.exists():
-            for skill_md in self._iter_skill_files(self.global_skills_dir):
-                header = parse_frontmatter_only(skill_md, skills_dir=self.global_skills_dir)
+        for base_dir, scope in self._skill_layers():
+            if not base_dir or not base_dir.exists():
+                continue
+            for skill_md in self._iter_skill_files(base_dir):
+                header = parse_frontmatter_only(skill_md, skills_dir=base_dir)
                 if header and header.path not in seen_paths:
-                    header.scope = "global"
+                    header.scope = scope
                     headers.append(header)
+                    seen_paths.add(header.path)
 
         headers.sort(key=lambda h: h.mtime, reverse=True)
         return headers[:MAX_SKILLS]
 
     def load_skill(self, name: str) -> SkillEntry | None:
-        """Load full skill content by name (project overrides global)."""
-        # Try project first
-        skill_dir = self._find_skill_dir_in(name, self.skills_dir)
-        base_dir = self.skills_dir
-        # Fallback to global
-        if not skill_dir and self.global_skills_dir:
-            skill_dir = self._find_skill_dir_in(name, self.global_skills_dir)
-            base_dir = self.global_skills_dir
-        if not skill_dir:
+        """Load full skill content by name using project -> global -> factory."""
+        found = self._find_skill_dir_with_base(name)
+        if not found:
             return None
+        skill_dir, base_dir, scope = found
         skill_md = skill_dir / "SKILL.md"
         if not skill_md.exists():
             return None
         try:
-            return parse_skill_file(skill_md, skills_dir=base_dir)
+            entry = parse_skill_file(skill_md, skills_dir=base_dir)
+            entry.scope = scope
+            return entry
         except Exception as e:
             logger.warning(f"Failed to parse skill '{name}': {e}")
             return None
@@ -173,7 +172,7 @@ class SkillStore:
         if err:
             raise ValueError(err)
 
-        skill_dir = self._find_skill_dir(name)
+        skill_dir = self._find_writable_skill_dir(name)
         if not skill_dir:
             raise ValueError(f"Skill '{name}' not found.")
 
@@ -198,7 +197,7 @@ class SkillStore:
 
         Returns path to patched SKILL.md.
         """
-        skill_dir = self._find_skill_dir(name)
+        skill_dir = self._find_writable_skill_dir(name)
         if not skill_dir:
             raise ValueError(f"Skill '{name}' not found.")
 
@@ -237,7 +236,7 @@ class SkillStore:
 
     def delete_skill(self, name: str) -> bool:
         """Delete a skill directory entirely."""
-        skill_dir = self._find_skill_dir(name)
+        skill_dir = self._find_writable_skill_dir(name)
         if not skill_dir:
             return False
 
@@ -265,7 +264,7 @@ class SkillStore:
         if len(content.encode("utf-8")) > MAX_FILE_SIZE:
             raise ValueError(f"File exceeds {MAX_FILE_SIZE:,} byte limit.")
 
-        skill_dir = self._find_skill_dir(name)
+        skill_dir = self._find_writable_skill_dir(name)
         if not skill_dir:
             raise ValueError(f"Skill '{name}' not found.")
 
@@ -284,7 +283,7 @@ class SkillStore:
         if err:
             raise ValueError(err)
 
-        skill_dir = self._find_skill_dir(name)
+        skill_dir = self._find_writable_skill_dir(name)
         if not skill_dir:
             return False
 
@@ -309,11 +308,35 @@ class SkillStore:
     # ── Internal ──
 
     def _find_skill_dir(self, name: str) -> Path | None:
-        """Find a skill directory by name (project > global)."""
+        """Find a skill directory by name (project > global > factory)."""
+        found = self._find_skill_dir_with_base(name)
+        return found[0] if found else None
+
+    def _find_writable_skill_dir(self, name: str) -> Path | None:
+        """Find a mutable skill directory by name (project > global).
+
+        Factory skills are read-only fallback content and must not be patched,
+        deleted, or receive supporting files.
+        """
         result = self._find_skill_dir_in(name, self.skills_dir)
         if not result and self.global_skills_dir:
             result = self._find_skill_dir_in(name, self.global_skills_dir)
         return result
+
+    def _find_skill_dir_with_base(self, name: str) -> tuple[Path, Path, str] | None:
+        for base_dir, scope in self._skill_layers():
+            result = self._find_skill_dir_in(name, base_dir)
+            if result:
+                return result, base_dir, scope
+        return None
+
+    def _skill_layers(self) -> list[tuple[Path, str]]:
+        layers: list[tuple[Path, str]] = [(self.skills_dir, "project")]
+        if self.global_skills_dir:
+            layers.append((self.global_skills_dir, "global"))
+        if self.factory_skills_dir:
+            layers.append((self.factory_skills_dir, "factory"))
+        return layers
 
     @staticmethod
     def _find_skill_dir_in(name: str, base_dir: Path) -> Path | None:

--- a/pantheon/internal/learning_system/types.py
+++ b/pantheon/internal/learning_system/types.py
@@ -45,7 +45,7 @@ class SkillHeader:
     related_skills: list[str] = field(default_factory=list)
     agent_scope: list[str] | None = None  # None = all agents
     mtime: float = 0.0
-    scope: str = "project"  # "project" or "global"
+    scope: str = "project"  # "project", "global", or "factory"
 
 
 @dataclass

--- a/pantheon/settings.py
+++ b/pantheon/settings.py
@@ -252,6 +252,10 @@ class Settings:
         return self.user_home / "agents"
 
     @property
+    def factory_agents_dir(self) -> Path:
+        return self.package_templates / "agents"
+
+    @property
     def teams_dir(self) -> Path:
         return self.pantheon_dir / "teams"
 
@@ -260,12 +264,20 @@ class Settings:
         return self.user_home / "teams"
 
     @property
+    def factory_teams_dir(self) -> Path:
+        return self.package_templates / "teams"
+
+    @property
     def prompts_dir(self) -> Path:
         return self.pantheon_dir / "prompts"
 
     @property
     def global_prompts_dir(self) -> Path:
         return self.user_home / "prompts"
+
+    @property
+    def factory_prompts_dir(self) -> Path:
+        return self.package_templates / "prompts"
 
     @property
     def memory_dir(self) -> Path:
@@ -286,6 +298,10 @@ class Settings:
     @property
     def global_skills_dir(self) -> Path:
         return self.user_home / "skills"
+
+    @property
+    def factory_skills_dir(self) -> Path:
+        return self.package_templates / "skills"
 
     @property
     def learning_dir(self) -> Path:
@@ -715,7 +731,7 @@ class Settings:
 
     @property
     def default_template_auto_update(self) -> bool:
-        """Whether to overwrite factory templates (agents/prompts/teams) on startup. Defaults to True."""
+        """Whether explicit factory materialization can update unchanged copies. Defaults to True."""
         self._ensure_loaded()
         return self._settings.get("default_template_auto_update", True)
 

--- a/pantheon/toolsets/live_view/toolset.py
+++ b/pantheon/toolsets/live_view/toolset.py
@@ -151,6 +151,7 @@ class LiveViewToolSet(ToolSet):
             pass
         roots.append(s.skills_dir)
         roots.append(s.global_skills_dir)
+        roots.append(s.factory_skills_dir)
         return roots
 
     async def _ensure_data_server(self):
@@ -182,6 +183,7 @@ class LiveViewToolSet(ToolSet):
         candidates = [
             s.skills_dir / "live_view" / name / "adapter.js",
             s.global_skills_dir / "live_view" / name / "adapter.js",
+            s.factory_skills_dir / "live_view" / name / "adapter.js",
         ]
         adapter = next((p for p in candidates if p.exists()), None)
         if adapter is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,10 @@ packages = {find = {where = ["."], exclude = ["tests*", "examples*", "tmp*", "tr
 "pantheon.factory" = [
     "templates/**/*.md",
     "templates/**/*.json",
+    "templates/**/*.js",
+    "templates/**/*.css",
+    "templates/**/*.py",
+    "templates/**/.gitkeep",
     "templates/*.json",
     "templates/*.example",
 ]

--- a/tests/test_learning_system/test_injector.py
+++ b/tests/test_learning_system/test_injector.py
@@ -64,8 +64,12 @@ class TestRuntimeIntegration:
         assert "## Skills" in guidance
         assert "skill_manage" in guidance
 
-    def test_no_guidance_when_empty(self, runtime_config, tmp_pantheon_dir):
+    def test_no_guidance_when_empty(self, monkeypatch, runtime_config, tmp_pantheon_dir, tmp_path):
         from pantheon.internal.learning_system.runtime import LearningRuntime
+        from pantheon.settings import get_settings
+
+        settings = get_settings()
+        monkeypatch.setattr(settings, "package_templates", tmp_path / "empty_factory")
 
         rt = LearningRuntime(runtime_config)
         rt.initialize(tmp_pantheon_dir)

--- a/tests/test_learning_system/test_runtime.py
+++ b/tests/test_learning_system/test_runtime.py
@@ -25,7 +25,11 @@ class TestInitialization:
 
 
 class TestBuildGuidance:
-    def test_empty(self, runtime_config, tmp_pantheon_dir):
+    def test_empty(self, monkeypatch, runtime_config, tmp_pantheon_dir, tmp_path):
+        from pantheon.settings import get_settings
+
+        settings = get_settings()
+        monkeypatch.setattr(settings, "package_templates", tmp_path / "empty_factory")
         rt = LearningRuntime(runtime_config)
         rt.initialize(tmp_pantheon_dir)
         assert rt.build_skill_guidance() == ""
@@ -36,6 +40,14 @@ class TestBuildGuidance:
         rt.store.create_skill("test", MINIMAL_SKILL.replace("minimal", "test"))
         guidance = rt.build_skill_guidance()
         assert "test" in guidance
+
+    def test_includes_factory_skills_by_default(self, runtime_config, tmp_pantheon_dir):
+        rt = LearningRuntime(runtime_config)
+        rt.initialize(tmp_pantheon_dir)
+
+        guidance = rt.build_skill_guidance()
+
+        assert "live_view" in guidance or "omics" in guidance
 
 
 class TestMaybeExtractSkillsCounter:

--- a/tests/test_learning_system/test_store.py
+++ b/tests/test_learning_system/test_store.py
@@ -112,6 +112,30 @@ class TestScanHeaders:
         assert len(headers) == 2
         assert headers[0].name == "skill-b"  # newer first
 
+    def test_scan_factory_headers_when_project_and_global_empty(self, tmp_path):
+        factory_skills = tmp_path / "factory" / "skills"
+        skill = factory_skills / "factory-only" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text(
+            "---\n"
+            "name: factory-only\n"
+            "description: Factory fallback skill\n"
+            "---\n\n"
+            "Use the packaged factory skill.\n",
+            encoding="utf-8",
+        )
+        store = SkillStore(
+            tmp_path / "project" / "skills",
+            tmp_path / "project" / "runtime",
+            global_skills_dir=tmp_path / "global" / "skills",
+            factory_skills_dir=factory_skills,
+        )
+
+        headers = store.scan_headers()
+
+        assert [header.name for header in headers] == ["factory-only"]
+        assert headers[0].scope == "factory"
+
 
 class TestLoadSkill:
     def test_load_success(self, store_with_skill):
@@ -122,6 +146,32 @@ class TestLoadSkill:
 
     def test_load_not_found(self, store):
         assert store.load_skill("nonexistent") is None
+
+    def test_load_factory_skill_when_project_and_global_empty(self, tmp_path):
+        factory_skills = tmp_path / "factory" / "skills"
+        skill = factory_skills / "factory-only" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text(
+            "---\n"
+            "name: factory-only\n"
+            "description: Factory fallback skill\n"
+            "---\n\n"
+            "Use the packaged factory skill.\n",
+            encoding="utf-8",
+        )
+        store = SkillStore(
+            tmp_path / "project" / "skills",
+            tmp_path / "project" / "runtime",
+            global_skills_dir=tmp_path / "global" / "skills",
+            factory_skills_dir=factory_skills,
+        )
+
+        entry = store.load_skill("factory-only")
+
+        assert entry is not None
+        assert entry.scope == "factory"
+        assert entry.path == "factory-only"
+        assert "packaged factory skill" in entry.content
 
 
 class TestSupportingFiles:

--- a/tests/test_learning_system/test_toolset.py
+++ b/tests/test_learning_system/test_toolset.py
@@ -10,7 +10,11 @@ from .conftest import SAMPLE_SKILL_CONTENT, MINIMAL_SKILL
 
 
 @pytest.fixture
-def toolset(runtime_config, tmp_pantheon_dir):
+def toolset(monkeypatch, runtime_config, tmp_pantheon_dir, tmp_path):
+    from pantheon.settings import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "package_templates", tmp_path / "empty_factory")
     rt = LearningRuntime(runtime_config)
     rt.initialize(tmp_pantheon_dir)
     return SkillToolSet(rt)

--- a/tests/test_live_view_factory_fallback.py
+++ b/tests/test_live_view_factory_fallback.py
@@ -1,0 +1,40 @@
+import pytest
+
+from pantheon.toolsets.live_view.toolset import LiveViewToolSet
+
+
+@pytest.mark.asyncio
+async def test_resolve_viewer_falls_back_to_factory_skills(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+
+    from pantheon.settings import get_settings, reset_settings
+
+    reset_settings()
+    settings = get_settings()
+    factory_skills = tmp_path / "factory" / "skills"
+    adapter = factory_skills / "live_view" / "factory_view" / "adapter.js"
+    adapter.parent.mkdir(parents=True)
+    adapter.write_text("export function setup() {}\n", encoding="utf-8")
+
+    toolset = LiveViewToolSet()
+
+    class FakeServer:
+        def url_for(self, path):
+            assert path == adapter.resolve()
+            return "http://data.local/factory_view/adapter.js"
+
+    async def fake_data_server():
+        return FakeServer()
+
+    monkeypatch.setattr(toolset, "_ensure_data_server", fake_data_server)
+    settings.package_templates = factory_skills.parent
+
+    try:
+        url, demo, error = await toolset._resolve_viewer("factory_view")
+    finally:
+        reset_settings()
+
+    assert url == "http://data.local/factory_view/adapter.js"
+    assert demo is None
+    assert error is None

--- a/tests/test_startup_defaults.py
+++ b/tests/test_startup_defaults.py
@@ -84,7 +84,6 @@ def test_factory_templates_do_not_sync_to_global_in_runtime_mode(monkeypatch, tm
     # Sandbox startup should not copy factory templates into ephemeral HOME.
     # Runtime loading falls back to the packaged factory templates instead.
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.delenv("PANTHEON_TEMPLATE_SYNC_SCOPE", raising=False)
     monkeypatch.delenv("PANTHEON_FACTORY_TEMPLATE_MODE", raising=False)
 
     manager = TemplateManager(work_dir=tmp_path / "workspace")
@@ -95,7 +94,6 @@ def test_factory_templates_do_not_sync_to_global_in_runtime_mode(monkeypatch, tm
 
 def test_force_sync_materializes_to_global_from_runtime_mode(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.delenv("PANTHEON_TEMPLATE_SYNC_SCOPE", raising=False)
     monkeypatch.delenv("PANTHEON_FACTORY_TEMPLATE_MODE", raising=False)
 
     manager = TemplateManager(work_dir=tmp_path / "workspace")
@@ -107,15 +105,24 @@ def test_force_sync_materializes_to_global_from_runtime_mode(monkeypatch, tmp_pa
     assert (manager.settings.global_teams_dir / "default.md").exists()
 
 
-def test_legacy_sync_scope_none_disables_force_sync(monkeypatch, tmp_path):
+def test_global_mode_materializes_to_global_on_startup(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.setenv("PANTHEON_TEMPLATE_SYNC_SCOPE", "none")
-    monkeypatch.delenv("PANTHEON_FACTORY_TEMPLATE_MODE", raising=False)
+    monkeypatch.setenv("PANTHEON_FACTORY_TEMPLATE_MODE", "global")
 
     manager = TemplateManager(work_dir=tmp_path / "workspace")
 
-    assert manager.force_sync_factory_templates() == 0
+    assert (manager.settings.global_teams_dir / "default.md").exists()
+    assert not (manager.teams_dir / "default.md").exists()
+
+
+def test_project_mode_is_not_supported_for_factory_materialization(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PANTHEON_FACTORY_TEMPLATE_MODE", "project")
+
+    manager = TemplateManager(work_dir=tmp_path / "workspace")
+
     assert not (manager.settings.global_teams_dir / "default.md").exists()
+    assert not (manager.teams_dir / "default.md").exists()
 
 
 def test_bootstrap_reclaims_stale_factory_skill_from_project_keeps_user_skill(monkeypatch, tmp_path):
@@ -124,7 +131,6 @@ def test_bootstrap_reclaims_stale_factory_skill_from_project_keeps_user_skill(mo
     # reclaim the factory-origin one (now served fresh from factory fallback)
     # and keep the user-created one.
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.delenv("PANTHEON_TEMPLATE_SYNC_SCOPE", raising=False)
     monkeypatch.delenv("PANTHEON_FACTORY_TEMPLATE_MODE", raising=False)
     pdir = tmp_path / "workspace" / ".pantheon"
     gosling = pdir / "skills" / "live_view" / "gosling" / "gosling.md"
@@ -142,9 +148,9 @@ def test_bootstrap_reclaims_stale_factory_skill_from_project_keeps_user_skill(mo
     assert user_skill.exists()  # user-created skill preserved
 
 
-def test_project_template_sync_preserves_user_modified_files(monkeypatch, tmp_path):
+def test_global_template_sync_preserves_user_modified_files(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.setenv("PANTHEON_TEMPLATE_SYNC_SCOPE", "project")
+    monkeypatch.setenv("PANTHEON_FACTORY_TEMPLATE_MODE", "global")
 
     manager = TemplateManager(work_dir=tmp_path / "workspace")
     factory_dir = tmp_path / "factory"
@@ -154,13 +160,13 @@ def test_project_template_sync_preserves_user_modified_files(monkeypatch, tmp_pa
     manager.system_templates_dir = factory_dir
     manager.force_sync_factory_templates()
 
-    project_team = manager.teams_dir / "default.md"
-    project_team.write_text("user edited\n", encoding="utf-8")
+    global_team = manager.settings.global_teams_dir / "default.md"
+    global_team.write_text("user edited\n", encoding="utf-8")
     (factory_dir / "teams" / "default.md").write_text("factory v2\n", encoding="utf-8")
 
     manager._ensure_default_templates()
 
-    assert project_team.read_text(encoding="utf-8") == "user edited\n"
+    assert global_team.read_text(encoding="utf-8") == "user edited\n"
 
 
 @pytest.mark.asyncio

--- a/tests/test_startup_defaults.py
+++ b/tests/test_startup_defaults.py
@@ -35,6 +35,24 @@ def test_default_team_keeps_package_for_lazy_dynamic_start():
     assert "package" in leader.toolsets
 
 
+def test_factory_runtime_fallback_assets_are_included_in_package_metadata():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    manifest = Path(__file__).resolve().parents[1] / "MANIFEST.in"
+
+    pyproject_text = pyproject.read_text(encoding="utf-8")
+    manifest_text = manifest.read_text(encoding="utf-8")
+
+    for pattern in [
+        '"templates/**/*.js"',
+        '"templates/**/*.css"',
+        '"templates/**/*.py"',
+        '"templates/**/.gitkeep"',
+    ]:
+        assert pattern in pyproject_text
+
+    assert "recursive-include pantheon/factory/templates *.md *.json *.example *.js *.css *.py .gitkeep" in manifest_text
+
+
 def test_startup_profile_logs_default_enabled(monkeypatch):
     monkeypatch.delenv("PANTHEON_STARTUP_PROFILE", raising=False)
 
@@ -62,27 +80,52 @@ def test_startup_profile_log_helper_respects_disabled_env(monkeypatch):
     assert emitted == []
 
 
-def test_factory_templates_sync_to_global_even_under_project_scope(monkeypatch, tmp_path):
-    # Factory templates ALWAYS sync to the GLOBAL scope (image-tracked), even
-    # when PANTHEON_TEMPLATE_SYNC_SCOPE=project. The project scope is reserved
-    # for user-created content; this avoids freezing factory copies on a
-    # persistent volume (the Modal staleness bug).
+def test_factory_templates_do_not_sync_to_global_in_runtime_mode(monkeypatch, tmp_path):
+    # Sandbox startup should not copy factory templates into ephemeral HOME.
+    # Runtime loading falls back to the packaged factory templates instead.
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.setenv("PANTHEON_TEMPLATE_SYNC_SCOPE", "project")
+    monkeypatch.delenv("PANTHEON_TEMPLATE_SYNC_SCOPE", raising=False)
+    monkeypatch.delenv("PANTHEON_FACTORY_TEMPLATE_MODE", raising=False)
 
     manager = TemplateManager(work_dir=tmp_path / "workspace")
 
-    assert (manager.settings.global_teams_dir / "default.md").exists()
+    assert not (manager.settings.global_teams_dir / "default.md").exists()
     assert not (manager.teams_dir / "default.md").exists()
+
+
+def test_force_sync_materializes_to_global_from_runtime_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("PANTHEON_TEMPLATE_SYNC_SCOPE", raising=False)
+    monkeypatch.delenv("PANTHEON_FACTORY_TEMPLATE_MODE", raising=False)
+
+    manager = TemplateManager(work_dir=tmp_path / "workspace")
+    assert not (manager.settings.global_teams_dir / "default.md").exists()
+
+    total = manager.force_sync_factory_templates()
+
+    assert total > 0
+    assert (manager.settings.global_teams_dir / "default.md").exists()
+
+
+def test_legacy_sync_scope_none_disables_force_sync(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PANTHEON_TEMPLATE_SYNC_SCOPE", "none")
+    monkeypatch.delenv("PANTHEON_FACTORY_TEMPLATE_MODE", raising=False)
+
+    manager = TemplateManager(work_dir=tmp_path / "workspace")
+
+    assert manager.force_sync_factory_templates() == 0
+    assert not (manager.settings.global_teams_dir / "default.md").exists()
 
 
 def test_bootstrap_reclaims_stale_factory_skill_from_project_keeps_user_skill(monkeypatch, tmp_path):
     # Reproduces the Modal-freeze state: a stale factory-origin skill + a
     # user-created skill, both pre-seeded in the PROJECT scope. bootstrap should
-    # reclaim the factory-origin one (now served fresh from global) and keep the
-    # user-created one.
+    # reclaim the factory-origin one (now served fresh from factory fallback)
+    # and keep the user-created one.
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.setenv("PANTHEON_TEMPLATE_SYNC_SCOPE", "project")
+    monkeypatch.delenv("PANTHEON_TEMPLATE_SYNC_SCOPE", raising=False)
+    monkeypatch.delenv("PANTHEON_FACTORY_TEMPLATE_MODE", raising=False)
     pdir = tmp_path / "workspace" / ".pantheon"
     gosling = pdir / "skills" / "live_view" / "gosling" / "gosling.md"
     gosling.parent.mkdir(parents=True)
@@ -94,7 +137,8 @@ def test_bootstrap_reclaims_stale_factory_skill_from_project_keeps_user_skill(mo
     manager = TemplateManager(work_dir=tmp_path / "workspace")
 
     assert not gosling.exists()  # factory-origin reclaimed from project
-    assert (manager.settings.global_skills_dir / "live_view" / "gosling" / "gosling.md").exists()
+    assert (manager.system_templates_dir / "skills" / "live_view" / "gosling" / "gosling.md").exists()
+    assert not (manager.settings.global_skills_dir / "live_view" / "gosling" / "gosling.md").exists()
     assert user_skill.exists()  # user-created skill preserved
 
 


### PR DESCRIPTION
## Summary
- Switch factory templates to runtime fallback by default so sandbox startup no longer copies packaged agents, teams, prompts, or skills into global/project storage.
- Add packaged factory fallback for learning-system skills and LiveView adapters while preserving project/global override order.
- Update Docker/docs/package data and add regression coverage for runtime fallback, force sync compatibility, stale project reclaim, and LiveView factory adapters.

## Test Plan
- [x] `uv run pytest tests/test_startup_defaults.py tests/test_learning_system/test_store.py tests/test_learning_system/test_runtime.py tests/test_learning_system/test_injector.py tests/test_learning_system/test_toolset.py tests/test_live_view_factory_fallback.py -q`
- [x] `git diff --check`
