### PR TITLE
fix(deps): vendor executor-engine/funcdesc/cmd2func (PyPI supply-chain attack); install from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ PantheonOS is an **evolvable and privacy-preserving multi-agent framework** desi
 
 ## `3` [Installation](#3-installation)
 
+> [!WARNING]
+> **Security notice (June 2026) — install from source, not PyPI.**
+> The PyPI account that published `pantheon-agents` was compromised in the "Hades"
+> supply-chain attack, and the PyPI releases **`pantheon-agents` 0.6.1 and 0.6.2 are
+> trojanized** (a `*-setup.pth` hook downloads the Bun runtime and runs a credential
+> stealer). **Do not `pip install pantheon-agents` from PyPI.** Install from the GitHub
+> source as shown below — the source repository is clean. If you previously installed
+> 0.6.1 or 0.6.2, uninstall it immediately and rotate any credentials that were present
+> on that machine. PyPI distribution will resume once the account is restored.
+
 ### Desktop App
 
 Download the latest Pantheon Desktop app:
@@ -89,15 +99,17 @@ uv sync --extra claw       # PantheonClaw mobile gateway channels
 uv sync --extra r          # R language support (requires R installed)
 ```
 
-### Using pip
+### Using pip (from GitHub source)
+
+> PyPI installs are temporarily disabled (see the security notice above). Install
+> directly from the clean GitHub source instead:
 
 ```bash
-# Basic installation
-pip install pantheon-agents
+# Basic installation (from source)
+pip install "git+https://github.com/aristoteleo/PantheonOS.git"
 
-# With optional dependencies
-pip install "pantheon-agents[knowledge]"  # RAG/vector search support
-pip install "pantheon-agents[claw]"       # PantheonClaw mobile gateway channels
+# With optional dependencies (e.g. RAG / vector search)
+pip install "pantheon-agents[knowledge] @ git+https://github.com/aristoteleo/PantheonOS.git"
 ```
 
 ### Development Installation

--- a/cmd2func/__init__.py
+++ b/cmd2func/__init__.py
@@ -1,0 +1,9 @@
+__author__ = """Weize Xu"""
+__email__ = 'vet.xwz@gmail.com'
+__version__ = '0.2.1'
+
+
+from .core import cmd2func
+
+
+__all__ = ["cmd2func"]

--- a/cmd2func/cmd.py
+++ b/cmd2func/cmd.py
@@ -1,0 +1,62 @@
+import typing as T
+import re
+
+from .config import CLIConfig, ArgDef
+
+
+class Command(object):
+    def __init__(self, template: str):
+        self.template = template
+        self.placeholders: T.List[str] = [
+            p.strip("{}") for p in
+            re.findall(r"\{.*?\}", self.template)
+        ]
+
+    @property
+    def main_command(self) -> str:
+        return self.template.split()[0]
+
+    def check_placeholder(self, arg_names: T.List[str]):
+        for arg in arg_names:
+            if arg not in self.placeholders:
+                raise ValueError(
+                    f"The argument {arg} is not in command templates.")
+
+    def format(self, vals: dict):
+        for ph in self.placeholders:
+            if ph not in vals:
+                raise ValueError(
+                    f"The value of placeholder {ph} is not provided.")
+        cmd = self.template.format(**vals)
+        return cmd
+
+    def infer_config(self) -> CLIConfig:
+        """Infer the config from the command template."""
+        args = {}
+        for ph in self.placeholders:
+            arg: ArgDef = {
+                "type": "str",
+                "default": None,
+            }
+            args[ph] = arg
+        config: CLIConfig = {
+            "name": self.main_command,
+            "inputs": args,
+            "inputs_order": self.placeholders,
+        }
+        return config
+
+    def complete_config(self, config: CLIConfig) -> CLIConfig:
+        """Complete the config from the command template."""
+        if 'name' not in config:
+            config["name"] = self.main_command
+        if 'inputs_order' not in config:
+            config["inputs_order"] = self.placeholders
+        args = config['inputs']
+        for ph in self.placeholders:
+            if ph not in args:
+                arg: ArgDef = {
+                    "type": "str",
+                }
+                args[ph] = arg
+        return config

--- a/cmd2func/config.py
+++ b/cmd2func/config.py
@@ -1,0 +1,50 @@
+import typing as T
+import sys
+if sys.version_info < (3, 11):  # pragma: no cover
+    from typing_extensions import TypedDict, NotRequired
+else:  # pragma: no cover
+    from typing import TypedDict, NotRequired
+
+
+from funcdesc.desc import Description, Value, NotDef
+
+
+class ArgDef(TypedDict):
+    type: str
+    default: NotRequired[T.Any]
+    true_insert: NotRequired[T.Any]
+    false_insert: NotRequired[T.Any]
+
+
+class CLIConfig(TypedDict):
+    name: NotRequired[str]
+    inputs: T.Dict[str, ArgDef]
+    inputs_order: NotRequired[T.List[str]]
+
+
+def extrace_key(d: dict, key, default) -> T.Any:
+    if key in d:
+        return d.pop(key)
+    else:
+        return default
+
+
+def config_to_desc(config: CLIConfig) -> Description:
+    """Convert a config to a funcdesc's Description object."""
+    args_conf = config['inputs'].copy()
+    order = config.get('inputs_order', list(args_conf.keys()))
+    args = [args_conf.pop(n) for n in order]
+    inputs = []
+    for n, p_conf in zip(order, args):
+        pc: dict = {**p_conf}
+        _tp = extrace_key(pc, 'type', None)
+        _default = extrace_key(pc, 'default', NotDef)
+        val = Value(
+            type_=eval(_tp),
+            default=_default,
+            name=n,
+            **pc
+        )
+        inputs.append(val)
+    desc = Description(inputs)
+    return desc

--- a/cmd2func/core.py
+++ b/cmd2func/core.py
@@ -1,0 +1,176 @@
+import inspect
+import sys
+import typing as T
+import functools
+
+from funcdesc import Description
+
+from .config import CLIConfig, config_to_desc
+from .runner import ProcessRunner
+from .cmd import Command
+
+
+def compose_signature(desc: Description) -> inspect.Signature:
+    parameters = []
+    for arg in desc.inputs:
+        param = inspect.Parameter(
+            arg.name, inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            default=arg.default, annotation=arg)
+        parameters.append(param)
+    sig = inspect.Signature(parameters)
+    return sig
+
+
+def replace_vals(vals: dict, desc: Description) -> dict:
+    vals = vals.copy()
+    name_to_arg = {v.name: v for v in desc.inputs}
+    for key, val in vals.items():
+        arg_obj = name_to_arg[key]
+        if (val is True) and ('true_insert' in arg_obj.kwargs):
+            vals[key] = arg_obj.kwargs['true_insert']
+        if (val is False) and ('false_insert' in arg_obj.kwargs):
+            vals[key] = arg_obj.kwargs['false_insert']
+    return vals
+
+
+class CommandFormater(object):
+    def __init__(
+            self, command: str,
+            config: T.Optional[CLIConfig] = None,
+            ) -> None:
+        self.command = Command(command)
+        if config is None:
+            config = self.command.infer_config()
+        else:
+            config = self.command.complete_config(config)
+        self.config = config
+        self.desc = config_to_desc(config)
+        self.command.check_placeholder([v.name for v in self.desc.inputs])
+        self.signature = compose_signature(self.desc)
+
+    def get_cmd_str(self, *args, **kwargs) -> str:
+        """Get the command string from the arguments."""
+        vals = self.desc.parse_pass_in(args, kwargs)
+        vals = replace_vals(vals, self.desc)
+        cmd_str = self.command.format(vals)
+        return cmd_str
+
+
+StrFunc = T.Callable[..., str]
+CmdGen = T.Generator[str, int, T.Any]
+StrGenFunc = T.Callable[..., CmdGen]
+
+
+class Cmd2Func(object):
+    def __init__(
+            self, cmd_or_func: T.Union[str, StrFunc, StrGenFunc],
+            config: T.Optional[CLIConfig] = None,
+            print_cmd=True,
+            out_stream=sys.stdout,
+            err_stream=sys.stderr,
+            conda_env: T.Optional[str] = None,
+            flush_streams_each_time=False,
+            popen_kwargs: T.Optional[dict] = None,):
+        """Convert a command to a function.
+
+        Args:
+            cmd_or_func: The command string or a function that returns the
+                command string or a generator that yields the command string.
+            config: The config of the command. If not provided, it will be
+                inferred from the command string. This is only used when
+                cmd_or_func is a command string. default: None.
+            print_cmd: Whether to print the command string before running it.
+                default: True.
+            out_stream: The stream to print the output of the command.
+                default: sys.stdout.
+            err_stream: The stream to print the error of the command.
+                default: sys.stderr.
+            conda_env: The conda environment to run the command.
+                default: None.
+            flush_streams_each_time: Whether to flush the streams each time
+                after writing to them. default: False.
+            popen_kwargs: The keyword arguments for subprocess.Popen.
+                default: None.
+
+        Attributes:
+            lastest_cmd_str: The lastest command string that is run.
+        """
+        self.get_cmd_str: T.Union[StrFunc, StrGenFunc]
+        if isinstance(cmd_or_func, str):
+            self.formater = CommandFormater(cmd_or_func, config)
+            self.get_cmd_str = self.formater.get_cmd_str
+            self.__signature__ = self.formater.signature
+        else:
+            self.get_cmd_str = cmd_or_func
+            functools.update_wrapper(self, cmd_or_func)
+
+        self.is_print_cmd = print_cmd
+        self.out_stream = out_stream
+        self.err_stream = err_stream
+        self.conda_env = conda_env
+        self.flush_streams_each_time = flush_streams_each_time
+        self.kwargs_popen = popen_kwargs or dict()
+        self.lastest_cmd_str: T.Optional[str] = None
+
+    def process_cmd_str(self, cmd_str: str) -> str:
+        if self.conda_env is not None:
+            cmd_str = "conda run --no-capture-output " + \
+                f"-n {self.conda_env} {cmd_str}"
+        return cmd_str
+
+    def run_cmd(self, cmd_str: str) -> int:
+        """Run the command and return the return code."""
+        cmd_str = self.process_cmd_str(cmd_str)
+        self.lastest_cmd_str = cmd_str
+        if self.is_print_cmd:
+            print(f"Run command: {cmd_str}")
+        runner = ProcessRunner(cmd_str)
+        runner.run(**self.kwargs_popen)
+        ret_code = runner.write_stream_until_stop(
+            self.out_stream, self.err_stream,
+            self.flush_streams_each_time)
+        return ret_code
+
+    def iter_and_run(self, generator: CmdGen) -> T.Any:
+        cmd = next(generator)
+        while True:
+            ret_code = self.run_cmd(cmd)
+            try:
+                cmd = generator.send(ret_code)
+            except StopIteration as e:
+                return e.value
+
+    def __call__(self, *args, **kwargs) -> T.Union[int, T.Any]:
+        cmd_or_gen = self.get_cmd_str(*args, **kwargs)
+        if isinstance(cmd_or_gen, str):
+            cmd_str = cmd_or_gen
+            return self.run_cmd(cmd_str)
+        else:
+            return self.iter_and_run(cmd_or_gen)
+
+
+def cmd2func(
+        cmd_or_func: T.Union[str, StrFunc, StrGenFunc, None] = None,
+        config: T.Optional[CLIConfig] = None,
+        print_cmd=True,
+        out_stream=sys.stdout,
+        err_stream=sys.stderr,
+        conda_env: T.Optional[str] = None,
+        flush_streams_each_time=False,
+        popen_kwargs: T.Optional[dict] = None,
+        ) -> Cmd2Func:
+    if cmd_or_func is None:
+        return functools.partial(  # type: ignore
+            cmd2func, config=config, print_cmd=print_cmd,
+            out_stream=out_stream, err_stream=err_stream,
+            conda_env=conda_env,
+            flush_streams_each_time=flush_streams_each_time,
+            popen_kwargs=popen_kwargs)
+    else:
+        return Cmd2Func(
+            cmd_or_func, config, print_cmd, out_stream, err_stream,
+            conda_env, flush_streams_each_time, popen_kwargs
+        )
+
+
+cmd2func.__doc__ = Cmd2Func.__init__.__doc__

--- a/cmd2func/runner.py
+++ b/cmd2func/runner.py
@@ -1,0 +1,96 @@
+import shlex
+import typing as T
+import subprocess as subp
+from threading import Thread
+from queue import Queue
+
+
+class ProcessRunner(object):
+    """Subprocess runner, allow stream stdout and stderr."""
+    def __init__(self, command: str) -> None:
+        self.command = command
+        self.queue: Queue[T.Tuple[T.IO[bytes], bytes]] = Queue(0)
+        self.proc: T.Optional[subp.Popen] = None
+        self.t_stdout: T.Optional[Thread] = None
+        self.t_stderr: T.Optional[Thread] = None
+
+    def run(
+            self,
+            capture_stdout: bool = True,
+            capture_stderr: bool = True,
+            shell: bool = False,
+            **kwargs: T.Any):
+        """Run the command using subprocess.Popen.
+
+        Args:
+            capture_stdout: If True, capture stdout.
+            capture_stderr: If True, capture stderr.
+            shell: If True, run the command using the shell.
+            **kwargs: other keyword arguments for subprocess.Popen
+        """
+        exe: T.Union[str, T.List[str]]
+        if shell:
+            exe = self.command
+        else:
+            exe = shlex.split(self.command)
+        sout = subp.PIPE if capture_stdout else None
+        serr = subp.PIPE if capture_stderr else None
+        self.proc = subp.Popen(
+            exe, stdout=sout, stderr=serr, shell=shell, **kwargs)
+        if capture_stdout:
+            self.t_stdout = Thread(
+                target=self.reader_func,
+                args=(self.proc.stdout, "stdout", self.queue))
+            self.t_stdout.start()
+        if capture_stderr:
+            self.t_stderr = Thread(
+                target=self.reader_func,
+                args=(self.proc.stderr, "stderr", self.queue))
+            self.t_stderr.start()
+
+    @staticmethod
+    def reader_func(pipe: T.IO[bytes], label: str, queue: "Queue"):
+        """https://stackoverflow.com/a/31867499/8500469"""
+        try:
+            with pipe:
+                for line in iter(pipe.readline, b''):
+                    queue.put((label, line))
+        finally:
+            queue.put(None)
+
+    def stream(self):
+        """https://stackoverflow.com/a/31867499/8500469"""
+        num_end_signals = 0
+        if self.t_stdout is not None:
+            num_end_signals += 1
+        if self.t_stderr is not None:
+            num_end_signals += 1
+        for _ in range(num_end_signals):
+            for src, line in iter(self.queue.get, None):
+                line_decoded = line.decode()
+                yield src, line_decoded
+        return self.proc.wait()
+
+    def write_stream_until_stop(
+            self,
+            out_file: T.TextIO,
+            err_file: T.TextIO,
+            flush_streams_each_time: bool = False,
+            ) -> int:
+        g = self.stream()
+        retcode = None
+        while True:
+            try:
+                src, line = next(g)
+                if src == 'stdout':
+                    ofile = out_file
+                else:
+                    assert src == 'stderr'
+                    ofile = err_file
+                ofile.write(line)
+                if flush_streams_each_time:
+                    ofile.flush()
+            except StopIteration as e:
+                retcode = e.value
+                break
+        return retcode

--- a/cmd2func/utils.py
+++ b/cmd2func/utils.py
@@ -1,0 +1,13 @@
+import typing as T
+from io import TextIOBase
+
+
+class Tee(TextIOBase):
+    def __init__(self, file1: T.TextIO, file2: T.TextIO):
+        self.file1 = file1
+        self.file2 = file2
+
+    def write(self, s: str) -> int:
+        ret1 = self.file1.write(s)
+        self.file2.write(s)
+        return ret1

--- a/executor/engine/__init__.py
+++ b/executor/engine/__init__.py
@@ -1,0 +1,9 @@
+from .core import Engine, EngineSetting
+from .job import LocalJob, ThreadJob, ProcessJob
+
+__version__ = '0.3.3'
+
+__all__ = [
+    'Engine', 'EngineSetting',
+    'LocalJob', 'ThreadJob', 'ProcessJob'
+]

--- a/executor/engine/base.py
+++ b/executor/engine/base.py
@@ -1,0 +1,6 @@
+import uuid
+
+
+class ExecutorObj(object):
+    def __init__(self):
+        self.id = str(uuid.uuid4())

--- a/executor/engine/core.py
+++ b/executor/engine/core.py
@@ -1,0 +1,358 @@
+import typing as T
+from dataclasses import dataclass
+from pathlib import Path
+import asyncio
+from threading import Thread
+import time
+import concurrent.futures
+
+from .base import ExecutorObj
+from .job.base import Job
+from .manager import Jobs
+from .log import logger
+
+if T.TYPE_CHECKING:
+    from dask.distributed import Client
+
+
+@dataclass
+class EngineSetting:
+    """Engine setting.
+
+    Args:
+        max_thread_jobs: Maximum number of thread jobs,
+            if not set, no limit.
+        max_process_jobs: Maximum number of process jobs,
+            if not set, no limit.
+        max_dask_jobs: Maximum number of dask jobs,
+            if not set, no limit.
+        max_jobs: Maximum number of jobs,
+            if not set, no limit.
+        cache_type: Cache type, "diskcache" or "none".
+            If set to "diskcache", will use diskcache package
+            to cache job status and result.
+            If set to "none", the status and result of job
+            will only be stored in memory.
+        cache_path: Cache path,
+            if not set, will create a cache directory in
+            .executor/{engine.id}.
+        print_traceback: Whether to print traceback when job failed.
+        kwargs_inject_key: Key to inject engine to job kwargs.
+            If set, the engine will be injected to job kwargs
+            with the key.
+            default is "__engine__".
+    """
+    max_thread_jobs: T.Optional[int] = None
+    max_process_jobs: T.Optional[int] = None
+    max_dask_jobs: T.Optional[int] = None
+    max_jobs: T.Optional[int] = 20
+    cache_type: T.Literal["diskcache", "none"] = "none"
+    cache_path: T.Optional[str] = None
+    print_traceback: bool = True
+    kwargs_inject_key: str = "__engine__"
+
+
+@dataclass
+class Resource:
+    """Resource of engine.
+
+    Args:
+        n_thread: Number of thread jobs.
+        n_process: Number of process jobs.
+        n_dask: Number of dask jobs.
+        n_job: Number of jobs.
+    """
+    n_thread: T.Union[int, float]
+    n_process: T.Union[int, float]
+    n_dask: T.Union[int, float]
+    n_job: T.Union[int, float]
+
+
+class Engine(ExecutorObj):
+    def __init__(
+            self,
+            setting: T.Optional[EngineSetting] = None,
+            jobs: T.Optional[Jobs] = None,
+            loop: T.Optional[asyncio.AbstractEventLoop] = None,
+            ) -> None:
+        """
+        Args:
+            setting: Engine setting. Defaults to None.
+            jobs: Jobs manager. Defaults to None.
+            loop: Event loop. Defaults to None.
+
+        Attributes:
+            setting: Engine setting.
+            resource: Resource of engine.
+            jobs: Jobs manager.
+        """
+        super().__init__()
+        if setting is None:
+            setting = EngineSetting()
+        self.setting = setting
+        self.print_traceback = False
+        self.setup_by_setting()
+        if jobs is None:
+            if self.setting.cache_type == "diskcache":
+                jobs = Jobs(self.cache_dir / "jobs")
+            else:
+                jobs = Jobs()
+        self.jobs: Jobs = jobs
+        self._dask_client: T.Optional["Client"] = None
+        self._loop = loop
+        self._loop_thread: T.Optional[Thread] = None
+
+    def __repr__(self) -> str:
+        return f"<Engine id={self.id}>"
+
+    def __str__(self) -> str:
+        return repr(self)
+
+    @property
+    def loop(self):
+        """Event loop of engine."""
+        if self._loop is None:
+            loop = asyncio.new_event_loop()
+            logger.info(f"{self} created new event loop.")
+            self._loop = loop
+        return self._loop
+
+    @loop.setter
+    def loop(self, loop: asyncio.AbstractEventLoop):
+        self._loop = loop
+
+    def start(self):
+        """Start event loop thread."""
+        def run_in_thread(loop: asyncio.AbstractEventLoop):
+            logger.info(f"{self} start event loop.")
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        if self._loop_thread is None:
+            self._loop_thread = Thread(
+                target=run_in_thread,
+                args=(self.loop,), daemon=True
+            )
+
+        if not self._loop_thread.is_alive():
+            logger.info(f"{self} start event loop thread.")
+            self._loop_thread.start()
+        else:
+            logger.warning(f"Event loop thread of {self} is already running.")
+
+    def stop(self):
+        """Stop event loop thread."""
+        loop = self._loop
+        if (loop is None) or (self._loop_thread is None):
+            logger.warning(f"Event loop thread of {self} is not running.")
+            return
+
+        if not self._loop_thread.is_alive():
+            logger.warning(f"Event loop thread of {self} is already closed.")
+        else:
+            logger.info(f"{self} stop event loop.")
+            loop.call_soon_threadsafe(loop.stop)
+            self._loop_thread.join()
+            if self._dask_client is not None:
+                asyncio.run_coroutine_threadsafe(
+                    self._dask_client.close(), loop)
+
+    def __enter__(self):
+        self.start()
+        from . launcher.core import set_default_engine
+        set_default_engine(self)
+        return self
+
+    def __exit__(self, *args):
+        self.stop()
+        from . launcher.core import set_default_engine
+        set_default_engine(None)
+
+    def setup_by_setting(self):
+        setting = self.setting
+        logger.info(f"Load setting: {setting}")
+        self.resource = Resource(
+            n_thread=setting.max_thread_jobs or float('inf'),
+            n_process=setting.max_process_jobs or float('inf'),
+            n_dask=setting.max_dask_jobs or float('inf'),
+            n_job=setting.max_jobs or float('inf'),
+        )
+        self.cache_dir = self.get_cache_dir()
+        self.print_traceback = setting.print_traceback
+
+    def submit(self, *jobs: Job):
+        """Submit job to engine"""
+        if (self._loop_thread is None) or\
+           (not self._loop_thread.is_alive()):
+            raise RuntimeError(
+                f"Event loop thread of {self} is not running."
+                " Please use engine as context manager or call engine.start()."
+            )
+        fut = asyncio.run_coroutine_threadsafe(
+            self.submit_async(*jobs), self.loop)
+        fut.result()
+
+    async def submit_async(self, *jobs: Job):
+        """Asynchronous interface for submit jobs to engine."""
+        for job in jobs:
+            if job.status == "created":
+                job.engine = self
+                job._status = "pending"
+                func_var_names = job.func.__code__.co_varnames
+                if self.setting.kwargs_inject_key in func_var_names:
+                    job.kwargs[self.setting.kwargs_inject_key] = self
+                self.jobs.add(job)
+            else:
+                job.status = "pending"
+            assert job.engine is self, "Job engine is not this engine."
+            await job.emit()
+
+    def remove(self, job: Job):
+        """Remove job from engine."""
+        if job.status in ('running', 'pending'):
+            fut = asyncio.run_coroutine_threadsafe(
+                job.cancel(), self.loop)
+            fut.result()
+        logger.info(f"Remove job from engine: {job}")
+        self.jobs.remove(job)
+
+    def cancel(self, *jobs: Job):
+        """Cancel a job."""
+        futures = []
+        for job in jobs:
+            fut = asyncio.run_coroutine_threadsafe(
+                job.cancel(), self.loop)
+            futures.append(fut)
+        concurrent.futures.wait(futures)
+
+    async def cancel_all_async(self):
+        """Cancel all pending and running jobs."""
+        running = self.jobs.running.values()
+        pending = self.jobs.pending.values()
+        tasks = []
+        for job in (pending + running):
+            tasks.append(job.cancel())
+        await asyncio.gather(*tasks)
+
+    def cancel_all(self):
+        """Cancel all pending and running jobs."""
+        fut = asyncio.run_coroutine_threadsafe(
+            self.cancel_all_async(), self.loop)
+        fut.result()
+
+    def wait_job(
+            self, job: Job,
+            timeout: T.Optional[float] = None,
+            ) -> T.Optional[T.Any]:
+        """Block until job is finished or timeout.
+        Return job result if job is done.
+
+        Args:
+            job: Job to wait.
+            timeout: Timeout in seconds.
+        """
+        fut = asyncio.run_coroutine_threadsafe(
+            job.join(timeout=timeout), self.loop)
+        fut.result()
+        if job.status == "done":
+            return job.result()
+        else:
+            return None
+
+    def wait(
+            self,
+            timeout: T.Optional[float] = None,
+            time_delta: float = 0.2,
+            select_jobs: T.Optional[T.Callable[[Jobs], T.List[Job]]] = None,
+            ):
+        """Block until all jobs are finished or timeout.
+
+        Args:
+            timeout: Timeout in seconds.
+            time_delta: Time interval to check job status.
+            select_jobs: Function to select jobs to wait.
+        """
+        if select_jobs is None:
+            select_jobs = (
+                lambda jobs: jobs.running.values() + jobs.pending.values()
+            )
+        total_time = timeout if timeout is not None else float('inf')
+        while True:
+            n_wait_jobs = len(select_jobs(self.jobs))
+            if n_wait_jobs == 0:
+                break
+            if total_time <= 0:
+                break
+            time.sleep(time_delta)
+            total_time -= time_delta
+
+    async def wait_async(
+            self,
+            timeout: T.Optional[float] = None,
+            time_delta: float = 0.2,
+            select_jobs: T.Optional[T.Callable[[Jobs], T.List[Job]]] = None,
+            ):
+        """Asynchronous interface for wait.
+        Block until all jobs are finished or timeout.
+
+        Args:
+            timeout: Timeout in seconds.
+            time_delta: Time interval to check job status.
+            select_jobs: Function to select jobs to wait.
+        """
+        if select_jobs is None:
+            select_jobs = (
+                lambda jobs: jobs.running.values() + jobs.pending.values()
+            )
+        total_time = timeout if timeout is not None else float('inf')
+        while True:
+            n_wait_jobs = len(select_jobs(self.jobs))
+            if n_wait_jobs == 0:
+                break
+            if total_time <= 0:
+                break
+            await asyncio.sleep(time_delta)
+            total_time -= time_delta
+
+    async def join(
+            self,
+            jobs: T.Optional[T.List[Job]] = None,
+            timeout: T.Optional[float] = None):
+        """Join all running and pending jobs."""
+        if jobs is None:
+            jobs_for_join = (
+                self.jobs.running.values() +
+                self.jobs.pending.values()
+            )
+        else:
+            jobs_for_join = jobs
+        tasks = [
+            asyncio.create_task(job.join())
+            for job in jobs_for_join
+        ]
+        if len(tasks) > 0:
+            await asyncio.wait(tasks, timeout=timeout)
+
+    def get_cache_dir(self) -> Path:
+        """Get cache directory for engine."""
+        cache_path = self.setting.cache_path
+        if cache_path is not None:
+            path = cache_path
+        else:
+            path = f".executor/{self.id}"
+        path_obj = Path(path)
+        path_obj.mkdir(parents=True, exist_ok=True)
+        return path_obj
+
+    @property
+    def dask_client(self):
+        from .job.dask import get_default_client
+        if self._dask_client is None:
+            self._dask_client = get_default_client()
+        return self._dask_client
+
+    @dask_client.setter
+    def dask_client(self, client: "Client"):
+        if not client.asynchronous:
+            raise ValueError("Dask client must be asynchronous.")
+        self._dask_client = client

--- a/executor/engine/job/__init__.py
+++ b/executor/engine/job/__init__.py
@@ -1,0 +1,9 @@
+from .base import Job
+from .local import LocalJob
+from .thread import ThreadJob
+from .process import ProcessJob
+
+
+__all__ = [
+    "Job", "LocalJob", "ThreadJob", "ProcessJob",
+]

--- a/executor/engine/job/base.py
+++ b/executor/engine/job/base.py
@@ -1,0 +1,435 @@
+import asyncio
+import inspect
+import typing as T
+from datetime import datetime
+from pathlib import Path
+from copy import copy
+import itertools
+
+import cloudpickle
+
+from .utils import (
+    JobStatusAttr, InvalidStateError, JobStatusType,
+    ExecutorError, valid_job_statuses, GeneratorWrapper
+)
+from .condition import Condition, AfterOthers, AllSatisfied
+from ..middle.capture import CaptureOut
+from ..middle.dir import ChDir
+from ..log import logger
+from ..base import ExecutorObj
+from ..utils import get_callable_name
+
+
+if T.TYPE_CHECKING:
+    from ..core import Engine
+
+
+class StopResolve(Exception):
+    pass
+
+
+class JobFuture():
+    def __init__(self, job_id: str) -> None:
+        """A future object for job."""
+        self.job_id = job_id
+        self._result: T.Optional[T.Any] = None
+        self._exception: T.Optional[Exception] = None
+        self.done_callbacks: T.List[T.Callable] = []
+        self.error_callbacks: T.List[T.Callable] = []
+
+    def result(self) -> T.Any:
+        return self._result
+
+    def set_result(self, result: T.Any) -> None:
+        self._result = result
+
+    def exception(self) -> T.Optional[Exception]:
+        return self._exception
+
+    def set_exception(self, exception: Exception) -> None:
+        self._exception = exception
+
+    def add_done_callback(self, callback: T.Callable) -> None:
+        self.done_callbacks.append(callback)
+
+    def add_error_callback(self, callback: T.Callable) -> None:
+        self.error_callbacks.append(callback)
+
+
+class Job(ExecutorObj):
+
+    status = JobStatusAttr()
+    repr_attrs: T.List[T.Tuple[str, T.Callable[["Job"], T.Any]]] = [
+        ("status", lambda self: self.status),
+        ("id", lambda self: self.id),
+        ("func", lambda self: get_callable_name(self.func)),
+        ("condition", lambda self: self.condition),
+        ("retry_remain", lambda self: self.retry_remain),
+    ]
+
+    func: T.Callable
+    condition: T.Optional[Condition]
+    retry_remain: int
+
+    def __init__(
+            self,
+            func: T.Callable,
+            args: T.Optional[tuple] = None,
+            kwargs: T.Optional[dict] = None,
+            callback: T.Optional[T.Callable[[T.Any], None]] = None,
+            error_callback: T.Optional[T.Callable[[Exception], None]] = None,
+            retries: int = 0,
+            retry_time_delta: float = 0.0,
+            name: T.Optional[str] = None,
+            condition: T.Optional[Condition] = None,
+            wait_time_delta: float = 0.01,
+            redirect_out_err: T.Union[bool, str] = False,
+            change_dir: bool = False,
+            **attrs
+            ) -> None:
+        """Base class for job.
+
+        Args:
+            func: The function to be executed.
+            args: The positional arguments to be passed to the function.
+            kwargs: The keyword arguments to be passed to the function.
+            callback: The callback function to be called when the job is done.
+            error_callback: The callback function to be called
+                when the job is failed.
+            retries: The number of retries when the job is failed.
+            retry_time_delta: The time delta between retries.
+            name: The name of the job.
+            condition: The condition of the job.
+            wait_time_delta: The time delta between each
+                check of the condition.
+            redirect_out_err: Whether to redirect the stdout
+                and stderr to the log. If is a string, it will be
+                used as the path of the log file.
+            change_dir: Whether to change the working directory
+                to the log directory.
+            **attrs: The attributes of the job.
+        """
+        super().__init__()
+        self.future = JobFuture(self.id)
+        self.func = func
+        self.args = args or tuple()
+        self.kwargs = kwargs or {}
+        if callback is not None:
+            self.future.add_done_callback(callback)
+        if error_callback is not None:
+            self.future.add_error_callback(error_callback)
+        self.retries = retries
+        self.retry_remain = retries
+        self.retry_time_delta = retry_time_delta
+        self.engine: T.Optional["Engine"] = None
+        self._status: str = "created"
+        self.name = name or func.__name__
+        self.attrs = attrs
+        self.task: T.Optional[asyncio.Task] = None
+        self.condition = condition
+        self.wait_time_delta = wait_time_delta
+        self.redirect_out_err = redirect_out_err
+        self.change_dir = change_dir
+        self.created_time: datetime = datetime.now()
+        self.submit_time: T.Optional[datetime] = None
+        self.stoped_time: T.Optional[datetime] = None
+        self._executor: T.Any = None
+        self.dep_job_ids: T.List[str] = []
+
+    def __repr__(self) -> str:
+        attrs = []
+        for attr_name, attr_func in self.repr_attrs:
+            attr_value = attr_func(self)
+            if bool(attr_value) is False:
+                continue
+            attrs.append(f"{attr_name}={attr_value}")
+        attr_str = " ".join(attrs)
+        return f"<{self.__class__.__name__} {attr_str}>"
+
+    def __str__(self) -> str:
+        return repr(self)
+
+    def has_resource(self) -> bool:
+        """Check if the job has resource to run."""
+        if self.engine is None:
+            return False
+        else:
+            return self.engine.resource.n_job > 0
+
+    def consume_resource(self) -> bool:
+        """Consume the resource of the job."""
+        if self.engine is None:
+            return False
+        else:
+            self.engine.resource.n_job -= 1
+            return True
+
+    def release_resource(self) -> bool:
+        """Release the resource of the job."""
+        if self.engine is None:
+            return False
+        else:
+            self.engine.resource.n_job += 1
+            return True
+
+    def resolve_dependencies(self) -> None:
+        """Resolve args and kwargs
+        and auto specify the condition."""
+        dep_jobs_ids: T.List[str] = []
+        args = itertools.chain(self.args, self.kwargs.values())
+        for arg in args:
+            if isinstance(arg, JobFuture):
+                dep_jobs_ids.append(arg.job_id)
+        if len(dep_jobs_ids) > 0:
+            after_others = AfterOthers(dep_jobs_ids)
+            if self.condition is None:
+                self.condition = after_others
+            else:
+                self.condition = AllSatisfied([self.condition, after_others])
+        self.dep_job_ids = dep_jobs_ids
+
+    async def _resolve_arg(self, arg: T.Union[JobFuture, T.Any]) -> T.Any:
+        if isinstance(arg, JobFuture):
+            assert self.engine is not None
+            job = self.engine.jobs.get_job_by_id(arg.job_id)
+            if job.status == "done":
+                return job.result()
+            elif job.status == "failed":
+                msg = f"Job {self} cancelled because " \
+                      f"of upstream job {job} failed."
+                logger.warning(msg)
+                await self.cancel()
+                raise StopResolve(msg)
+            elif job.status == "cancelled":
+                msg = f"Job {self} cancelled because " \
+                      f"of upstream job {job} cancelled."
+                logger.warning(msg)
+                await self.cancel()
+                raise StopResolve(msg)
+            else:  # pragma: no cover
+                raise ExecutorError("Unreachable code.")
+        else:
+            return arg
+
+    async def resolve_args(self):
+        """Resolve args and kwargs."""
+        if len(self.dep_job_ids) > 0:
+            args = []
+            kwargs = {}
+            for arg in self.args:
+                resolved = await self._resolve_arg(arg)
+                args.append(resolved)
+            for key, value in self.kwargs.items():
+                resolved = await self._resolve_arg(value)
+                kwargs[key] = resolved
+            self.args = tuple(args)
+            self.kwargs = kwargs
+
+    def runnable(self) -> bool:
+        """Check if the job is runnable.
+        Job is runnable if:
+        1. engine is not None.
+        2. condition is None and condition is satisfied.
+        3. has resource."""
+        if self.engine is None:
+            return False
+        if self.condition is not None:
+            return self.condition.satisfy(self.engine) and self.has_resource()
+        else:
+            return self.has_resource()
+
+    async def emit(self) -> asyncio.Task:
+        """Emit the job to the engine."""
+        logger.info(f"Emit job {self}, watting for run.")
+        if self.status != 'pending':
+            raise InvalidStateError(self, ['pending'])
+        self.resolve_dependencies()
+        self.submit_time = datetime.now()
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(self.wait_and_run())
+        self.task = task
+        return task
+
+    def process_func(self):
+        """Process(decorate) the target func, before run.
+        For example, let the func
+        change the dir, redirect the stdout and stderr
+        before the actual run."""
+        cache_dir = self.cache_dir.resolve()
+        is_redirect = (self.redirect_out_err is not False)
+        if is_redirect and (not isinstance(self.func, CaptureOut)):
+            if isinstance(self.redirect_out_err, str):
+                path_stdout = Path(self.redirect_out_err)
+                path_stderr = Path(self.redirect_out_err)
+            else:
+                path_stdout = cache_dir / 'stdout.txt'
+                path_stderr = cache_dir / 'stderr.txt'
+            self.func = CaptureOut(self.func, path_stdout, path_stderr)
+        if self.change_dir:
+            self.func = ChDir(self.func, cache_dir)
+
+    async def wait_and_run(self):
+        """Wait for the condition satisfied and run the job."""
+        while True:
+            if self.runnable() and self.consume_resource():
+                logger.info(f"Start run job {self}")
+                self.process_func()
+                try:
+                    await self.resolve_args()
+                except StopResolve:
+                    break
+                self.status = "running"
+                try:
+                    res = await self.run()
+                    if not isinstance(res, GeneratorWrapper):
+                        await self.on_done(res)
+                    else:
+                        self.future.set_result(res)
+                    return res
+                except Exception as e:
+                    await self.on_failed(e)
+                    break
+            else:
+                await asyncio.sleep(self.wait_time_delta)
+
+    async def run(self):
+        """Run the job."""
+        if inspect.isgeneratorfunction(self.func) or inspect.isasyncgenfunction(self.func):  # noqa: E501
+            return await self.run_generator()
+        else:
+            return await self.run_function()
+
+    async def run_function(self):  # pragma: no cover
+        """Run the job as a function."""
+        msg = f"{type(self).__name__} does not implement " \
+              "run_function method."
+        raise NotImplementedError(msg)
+
+    async def run_generator(self):  # pragma: no cover
+        """Run the job as a generator."""
+        msg = f"{type(self).__name__} does not implement " \
+              "run_generator method."
+        raise NotImplementedError(msg)
+
+    async def rerun(self, check_status: bool = True):
+        """Rerun the job."""
+        _valid_status: T.List[JobStatusType] = ["cancelled", "done", "failed"]
+        if check_status and (self.status not in _valid_status):
+            raise InvalidStateError(self, _valid_status)
+        logger.info(f"Rerun job {self}")
+        self.status = "pending"
+        await self.emit()
+
+    def _on_finish(self, new_status: JobStatusType = "done"):
+        self.status = new_status
+        self.release_resource()
+
+    async def on_done(self, res):
+        """Callback when the job is done."""
+        logger.info(f"Job {self} done.")
+        self.future.set_result(res)
+        for callback in self.future.done_callbacks:
+            if inspect.iscoroutinefunction(callback):
+                await callback(res)
+            else:
+                callback(res)
+        self._on_finish("done")
+
+    async def on_failed(self, e: Exception):
+        """Callback when the job is failed."""
+        logger.error(f"Job {self} failed: {repr(e)}")
+        assert self.engine is not None
+        if self.engine.print_traceback:
+            logger.exception(e)
+        self.future.set_exception(e)
+        for err_callback in self.future.error_callbacks:
+            if inspect.iscoroutinefunction(err_callback):
+                await err_callback(e)
+            else:
+                err_callback(e)
+        if self.retry_remain > 0:
+            self._on_finish("pending")
+            self.retry_remain -= 1
+            await asyncio.sleep(self.retry_time_delta)
+            await self.rerun(check_status=False)
+        else:
+            self._on_finish("failed")
+
+    async def cancel(self):
+        """Cancel the job."""
+        logger.info(f"Cancel job {self}.")
+        self.task.cancel()
+        if self.status == "running":
+            try:
+                self.clear_context()
+            except Exception as e:  # pragma: no cover
+                print(str(e))
+            finally:
+                self._on_finish("cancelled")
+        elif self.status == "pending":
+            self.status = "cancelled"
+
+    def clear_context(self):
+        """Clear the context of the job."""
+        pass
+
+    def result(self) -> T.Any:
+        """Get the result of the job."""
+        res = self.future.result()
+        if not isinstance(res, GeneratorWrapper):
+            if self.status != "done":
+                raise InvalidStateError(self, ['done'])
+        return res
+
+    def exception(self):
+        """Get the exception of the job."""
+        return self.future.exception()
+
+    def serialization(self) -> bytes:
+        """Serialize the job to bytes."""
+        job = copy(self)
+        job.task = None
+        job.engine = None
+        job._executor = None
+        bytes_ = cloudpickle.dumps(job)
+        return bytes_
+
+    @staticmethod
+    def deserialization(bytes_: bytes) -> "Job":
+        """Deserialize the job from bytes."""
+        job: "Job" = cloudpickle.loads(bytes_)
+        return job
+
+    async def join(self, timeout: T.Optional[float] = None):
+        """Wait for the job done."""
+        if self.task is None:
+            raise InvalidStateError(self, valid_job_statuses)
+        await asyncio.wait([self.task], timeout=timeout)
+
+    async def wait_until(
+        self, check_func: T.Callable[["Job"], bool],
+        timeout: T.Optional[float] = None
+    ):
+        """Wait until the check_func return True."""
+        total_time = 0.0
+        while not check_func(self):
+            await asyncio.sleep(self.wait_time_delta)
+            total_time += self.wait_time_delta
+            if (timeout is not None) and total_time > timeout:
+                raise asyncio.TimeoutError
+
+    async def wait_until_status(
+            self, status: JobStatusType,
+            timeout: T.Optional[float] = None):
+        """Wait until the job is in the target status."""
+        await self.wait_until(lambda job: job.status == status, timeout)
+
+    @property
+    def cache_dir(self) -> T.Optional[Path]:
+        """Get the cache dir of the job."""
+        if self.engine is None:
+            return None
+        parent = self.engine.cache_dir
+        path = parent / self.id
+        path.mkdir(parents=True, exist_ok=True)
+        return path

--- a/executor/engine/job/condition.py
+++ b/executor/engine/job/condition.py
@@ -1,0 +1,312 @@
+import typing as T
+from datetime import datetime, timedelta
+from dataclasses import dataclass
+
+from .utils import JobStatusType
+
+if T.TYPE_CHECKING:
+    from ..core import Engine
+
+
+@dataclass
+class Condition():
+    """Base class for condition"""
+
+    def satisfy(self, engine: "Engine") -> bool:  # pragma: no cover
+        """Check if the condition is satisfied."""
+        return True
+
+    def __or__(self, other: "Condition") -> "AnySatisfied":
+        return AnySatisfied(conditions=[self, other])
+
+    def __and__(self, other: "Condition") -> "AllSatisfied":
+        return AllSatisfied(conditions=[self, other])
+
+
+@dataclass
+class AfterAnother(Condition):
+    """Condition that the job is executed after
+    another job is done/failed/cancelled.
+
+    Attributes:
+        job_id: The id of the job.
+        statuses: The statuses of the job that satisfy the condition.
+    """
+
+    job_id: str
+    statuses: T.Iterable[JobStatusType] = ("done", "failed", "cancelled")
+
+    def satisfy(self, engine) -> bool:
+        try:
+            another = engine.jobs.get_job_by_id(self.job_id)
+        except Exception:
+            return False
+        if another.status in self.statuses:
+            return True
+        else:
+            return False
+
+
+@dataclass
+class AfterOthers(Condition):
+    """Condition that the job is executed after
+    other jobs are done/failed/cancelled.
+
+    Attributes:
+        job_ids: The ids of the jobs.
+        statuses: The statuses of the jobs that satisfy the condition.
+        mode: The mode of the condition. If it is 'all', the job is executed
+            after all other jobs are done/failed/cancelled. If it is 'any',
+            the job is executed after any other job is done/failed/cancelled.
+    """
+
+    job_ids: T.List[str]
+    statuses: T.Iterable[JobStatusType] = ("done", "failed", "cancelled")
+    mode: T.Literal['all', 'any'] = "all"
+
+    def satisfy(self, engine) -> bool:
+        other_job_satisfy = []
+        for id_ in self.job_ids:
+            try:
+                job = engine.jobs.get_job_by_id(id_)
+            except Exception:
+                other_job_satisfy.append(False)
+                continue
+            s_ = job.status in self.statuses
+            other_job_satisfy.append(s_)
+        if self.mode == 'all':
+            return all(other_job_satisfy)
+        else:
+            return any(other_job_satisfy)
+
+
+@dataclass
+class Combination(Condition):
+    """Base class for combination of conditions.
+
+    Attributes:
+        conditions: The sub-conditions.
+    """
+    conditions: T.List[Condition]
+
+
+@dataclass
+class AllSatisfied(Combination):
+    """Condition that the job is executed after all
+    sub-conditions are satisfied.
+
+    Attributes:
+        conditions: The sub-conditions.
+    """
+
+    conditions: T.List[Condition]
+
+    def satisfy(self, engine):
+        """Check if the condition is satisfied."""
+        return all([c.satisfy(engine) for c in self.conditions])
+
+
+@dataclass
+class AnySatisfied(Combination):
+    """Condition that the job is executed after any
+    sub-condition is satisfied.
+
+    Attributes:
+        conditions: The sub-conditions.
+    """
+
+    conditions: T.List[Condition]
+
+    def satisfy(self, engine):
+        """Check if the condition is satisfied."""
+        return any([c.satisfy(engine) for c in self.conditions])
+
+
+def _parse_clock_str(time_str: str) -> T.Tuple[int, int, int]:
+    hour: int
+    minute: int
+    second: int
+    if time_str.count(":") == 1:
+        _hour, _minute = time_str.split(":")
+        hour, minute = int(_hour), int(_minute)
+        second = 0
+    elif time_str.count(":") == 2:
+        _hour, _minute, _second = time_str.split(":")
+        hour, minute, second = int(_hour), int(_minute), int(_second)
+    else:
+        hour = int(time_str)
+        minute = 0
+        second = 0
+    return hour, minute, second
+
+
+def _parse_weekday_str(weekday_str: str) -> int:
+    if weekday_str.lower() in ("monday", "mon"):
+        return 0
+    elif weekday_str.lower() in ("tuesday", "tue"):
+        return 1
+    elif weekday_str.lower() in ("wednesday", "wed"):
+        return 2
+    elif weekday_str.lower() in ("thursday", "thu"):
+        return 3
+    elif weekday_str.lower() in ("friday", "fri"):
+        return 4
+    elif weekday_str.lower() in ("saturday", "sat"):
+        return 5
+    elif weekday_str.lower() in ("sunday", "sun"):
+        return 6
+    raise ValueError(f"Invalid weekday string: {weekday_str}")
+
+
+def _parse_period_str(period_str: str) -> timedelta:
+    if period_str.endswith("d"):
+        return timedelta(days=float(period_str[:-1]))
+    elif period_str.endswith("h"):
+        return timedelta(hours=float(period_str[:-1]))
+    elif period_str.endswith("m"):
+        return timedelta(minutes=float(period_str[:-1]))
+    elif period_str.endswith("s"):
+        return timedelta(seconds=float(period_str[:-1]))
+    raise ValueError(f"Invalid period string: {period_str}")
+
+
+@dataclass
+class TimeCondition(Condition):
+    pass
+
+
+@dataclass
+class EveryPeriod(TimeCondition):
+    """Every period.
+
+    Attributes:
+        period_str: The period string.
+            format: "1d", "1h", "1m", "1s"
+        last_submitted_at: The last submitted time.
+        immediate: Whether to submit the job immediately.
+    """
+    period_str: str
+    last_submitted_at: T.Optional[datetime] = None
+    immediate: bool = False
+
+    def satisfy(self, _) -> bool:
+        period = _parse_period_str(self.period_str)
+        res: bool
+        if self.last_submitted_at is None:
+            self.last_submitted_at = datetime.now()
+            res = self.immediate
+        else:
+            res = (datetime.now() - self.last_submitted_at >= period)
+        if res:
+            self.last_submitted_at = datetime.now()
+        return res
+
+
+@dataclass
+class AfterClock(TimeCondition):
+    """After a specific clock.
+
+    Attributes:
+        time_str: The time string.
+            format: "12:00", "12:00:00"
+    """
+    time_str: str
+
+    def satisfy(self, _) -> bool:
+        hour, minute, second = _parse_clock_str(self.time_str)
+        now = datetime.now()
+        res = (
+            (now.hour >= hour) &
+            (now.minute >= minute) &
+            (now.second >= second)
+        )
+        return res
+
+
+@dataclass
+class BeforeClock(TimeCondition):
+    """Before a specific clock.
+
+    Attributes:
+        time_str: The time string.
+            format: "12:00", "12:00:00"
+    """
+    time_str: str
+
+    def satisfy(self, _) -> bool:
+        hour, minute, second = _parse_clock_str(self.time_str)
+        now = datetime.now()
+        res = (
+            (now.hour <= hour) &
+            (now.minute <= minute) &
+            (now.second <= second)
+        )
+        return res
+
+
+@dataclass
+class AfterWeekday(TimeCondition):
+    """After a specific weekday.
+
+    Attributes:
+        weekday_str: The weekday string.
+            format: "monday", "mon", "tuesday", "tue", "wednesday", "wed",
+                "thursday", "thu", "friday", "fri", "saturday", "sat",
+                "sunday", "sun"
+    """
+    weekday_str: str
+
+    def satisfy(self, _) -> bool:
+        weekday = _parse_weekday_str(self.weekday_str)
+        now = datetime.now()
+        res = (now.weekday() >= weekday)
+        return res
+
+
+@dataclass
+class BeforeWeekday(TimeCondition):
+    """Before a specific weekday.
+
+    Attributes:
+        weekday_str: The weekday string.
+            format: "monday", "mon", "tuesday", "tue", "wednesday", "wed",
+                "thursday", "thu", "friday", "fri", "saturday", "sat",
+                "sunday", "sun"
+    """
+    weekday_str: str
+
+    def satisfy(self, _) -> bool:
+        weekday = _parse_weekday_str(self.weekday_str)
+        now = datetime.now()
+        res = (now.weekday() <= weekday)
+        return res
+
+
+_valid_timepoint_fields = ("year", "month", "day", "hour", "minute", "second")
+
+
+@dataclass
+class AfterTimepoint(TimeCondition):
+    """After a timepoint.
+
+    Attributes:
+        timepoint: The timepoint.
+    """
+
+    timepoint: datetime
+
+    def satisfy(self, _) -> bool:
+        return datetime.now() > self.timepoint
+
+
+@dataclass
+class BeforeTimepoint(TimeCondition):
+    """Before a timepoint.
+
+    Attributes:
+        timepoint: The timepoint.
+    """
+    timepoint: datetime
+
+    def satisfy(self, _) -> bool:
+        return datetime.now() < self.timepoint

--- a/executor/engine/job/dask.py
+++ b/executor/engine/job/dask.py
@@ -1,0 +1,86 @@
+import functools
+from inspect import iscoroutinefunction
+
+from dask.distributed import Client, LocalCluster
+
+from .base import Job
+from .utils import create_generator_wrapper, run_async_func
+from ..utils import PortManager
+
+
+def get_default_client() -> Client:
+    free_port = PortManager.find_free_port()
+    cluster = LocalCluster(
+        dashboard_address=f":{free_port}",
+        asynchronous=True,
+    )
+    return Client(
+        cluster,
+        asynchronous=True,
+    )
+
+
+class DaskJob(Job):
+    """Job that runs with Dask."""
+
+    def has_resource(self) -> bool:
+        """Check if the job has enough resource to run."""
+        if self.engine is None:
+            return False
+        else:
+            return (
+                super().has_resource() and
+                (self.engine.resource.n_dask > 0)
+            )
+
+    def consume_resource(self) -> bool:
+        """Consume resource for the job."""
+        if self.engine is None:
+            return False
+        else:
+            self.engine.resource.n_dask -= 1
+            return (
+                super().consume_resource() and
+                True
+            )
+
+    def release_resource(self) -> bool:
+        """Release resource for the job."""
+        if self.engine is None:
+            return False
+        else:
+            self.engine.resource.n_dask += 1
+            return (
+                super().release_resource() and
+                True
+            )
+
+    async def run_function(self):
+        """Run job with Dask."""
+        client = self.engine.dask_client
+        func = functools.partial(self.func, *self.args, **self.kwargs)
+        if iscoroutinefunction(func):
+            func = functools.partial(run_async_func, func)
+        fut = client.submit(func)
+        self._executor = fut
+        result = await fut
+        return result
+
+    async def run_generator(self):
+        """Run job as a generator."""
+        client = self.engine.dask_client
+        func = functools.partial(self.func, *self.args, **self.kwargs)
+        fut = client.submit(func)
+        self._executor = client.get_executor(pure=False)
+        result = create_generator_wrapper(self, fut)
+        return result
+
+    async def cancel(self):
+        """Cancel job."""""
+        if self.status == "running":
+            await self._executor.cancel()
+        await super().cancel()
+
+    def clear_context(self):
+        """Clear context."""
+        self._executor = None

--- a/executor/engine/job/extend/__init__.py
+++ b/executor/engine/job/extend/__init__.py
@@ -1,0 +1,7 @@
+from .subprocess import SubprocessJob
+from .webapp import WebappJob
+from .sentinel import SentinelJob
+from .cron import CronJob
+
+
+__all__ = ["SubprocessJob", "WebappJob", "SentinelJob", "CronJob"]

--- a/executor/engine/job/extend/cron.py
+++ b/executor/engine/job/extend/cron.py
@@ -1,0 +1,71 @@
+import typing as T
+from datetime import datetime
+
+from .. import Job
+from ..condition import (
+    TimeCondition,
+    AllSatisfied, AfterTimepoint, BeforeTimepoint,
+    EveryPeriod, BeforeClock, AfterClock,
+    AfterWeekday, BeforeWeekday
+)
+from .sentinel import SentinelJob
+
+
+every = EveryPeriod
+daily = EveryPeriod("1d")
+weekly = EveryPeriod("7d")
+hourly = EveryPeriod("1h")
+
+before_clock = BeforeClock
+after_clock = AfterClock
+
+after_weekday = AfterWeekday
+before_weekday = BeforeWeekday
+
+after_timepoint = AfterTimepoint
+before_timepoint = BeforeTimepoint
+
+
+def between_clock(start: str, end: str) -> AllSatisfied:
+    return AllSatisfied([BeforeClock(end), AfterClock(start)])
+
+
+def between_weekday(start: str, end: str) -> AllSatisfied:
+    return AllSatisfied([BeforeWeekday(end), AfterWeekday(start)])
+
+
+def between_timepoint(start: datetime, end: datetime) -> AllSatisfied:
+    return AllSatisfied([BeforeTimepoint(end), AfterTimepoint(start)])
+
+
+def CronJob(
+        func: T.Callable,
+        time_condition: TimeCondition,
+        job_type: T.Union[str, T.Type[Job]] = "process",
+        time_delta: float = 0.01,
+        sentinel_attrs: T.Optional[dict] = None,
+        **attrs
+        ):
+    """Submit a job periodically.
+
+    Args:
+        func: The function to be executed.
+        time_period: The time period.
+        job_type: The type of the job.
+        time_delta: The time delta between each
+            check of the sentinel condition.
+        sentinel_attrs: The attributes of the sentinel job.
+        **attrs: The attributes of the job.
+    """
+    sentinel_attrs = sentinel_attrs or {}
+    if "name" not in sentinel_attrs:
+        sentinel_attrs["name"] = f"cron-sentinel-{func.__name__}"
+    sentinel_job = SentinelJob(
+        func,
+        time_condition,
+        job_type,
+        time_delta,
+        sentinel_attrs,
+        **attrs
+    )
+    return sentinel_job

--- a/executor/engine/job/extend/sentinel.py
+++ b/executor/engine/job/extend/sentinel.py
@@ -1,0 +1,57 @@
+import typing as T
+import asyncio
+
+from .. import Job, ProcessJob, LocalJob, ThreadJob
+from ..condition import Condition
+
+
+if T.TYPE_CHECKING:
+    from ...core import Engine
+
+
+def SentinelJob(
+        func: T.Callable,
+        sentinel_condition: Condition,
+        job_type: T.Union[str, T.Type[Job]] = "process",
+        time_delta: float = 0.01,
+        sentinel_attrs: T.Optional[dict] = None,
+        **attrs
+        ):
+    """Submit a job when the sentinel condition is met.
+
+    Args:
+        func: The function to be executed.
+        sentinel_condition: The sentinel condition.
+        job_type: The type of the job.
+        time_delta: The time delta between each check
+            of the sentinel condition.
+        sentinel_attrs: The attributes of the sentinel job.
+        **attrs: The attributes of the job.
+    """
+    sentinel_attrs = sentinel_attrs or {}
+    if "name" not in sentinel_attrs:
+        sentinel_attrs["name"] = f"sentinel-{func.__name__}"
+
+    base_class: T.Type[Job]
+    if isinstance(job_type, str):
+        if job_type == "process":
+            base_class = ProcessJob
+        elif job_type == "thread":
+            base_class = ThreadJob
+        else:
+            base_class = LocalJob
+    else:
+        base_class = job_type
+
+    async def sentinel(__engine__: "Engine"):
+        while True:
+            if sentinel_condition.satisfy(__engine__):
+                job = base_class(func, **attrs)
+                await __engine__.submit_async(job)
+            await asyncio.sleep(time_delta)
+
+    sentinel_job = LocalJob(
+        sentinel,
+        **sentinel_attrs
+    )
+    return sentinel_job

--- a/executor/engine/job/extend/subprocess.py
+++ b/executor/engine/job/extend/subprocess.py
@@ -1,0 +1,176 @@
+import copy
+import typing as T
+import subprocess as subp
+from pathlib import Path
+
+from ..condition import Condition
+from ..thread import ThreadJob
+from ..base import Job
+
+from cmd2func.runner import ProcessRunner
+
+
+def SubprocessJob(
+    cmd: str, record_cmd: bool = True,
+    base_class: T.Type[Job] = ThreadJob,
+    callback: T.Optional[T.Callable[[T.Any], None]] = None,
+    error_callback: T.Optional[T.Callable[[Exception], None]] = None,
+    retries: int = 0,
+    retry_time_delta: float = 0.0,
+    name: T.Optional[str] = None,
+    condition: T.Optional[Condition] = None,
+    wait_time_delta: float = 0.01,
+    redirect_out_err: bool = False,
+    target_dir: str = "$current_dir",
+    popen_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
+    **attrs
+):
+    """Create a job that runs a subprocess.
+
+    Args:
+        cmd: The command to run.
+        record_cmd: Whether to record the command to a file.
+        base_class: The base class of the job.
+        callback: The callback function.
+        error_callback: The error callback function.
+        retries: The number of retries.
+        retry_time_delta: The time delta between retries.
+        name: The name of the job.
+        condition: The condition of the job.
+        wait_time_delta: The time delta between each check.
+        redirect_out_err: Whether to redirect stdout and stderr to files.
+        target_dir: The target directory path for run the command.
+            Use '$cache_dir' to represent the cache directory of the job.
+            Use '$current_dir' to represent the current directory of the job.
+            Default is '$current_dir'.
+        popen_kwargs: The keyword arguments for subprocess.Popen.
+        **attrs: Other attributes of the job.
+    """
+    class _SubprocessJob(base_class):  # type: ignore
+        cmd: str
+        target_dir: str
+
+        repr_attrs = [
+            ('status', lambda self: self.status),
+            ('id', lambda self: self.id),
+            ('cmd', lambda self: self.cmd),
+            ('target_dir', lambda self: self.target_dir),
+            ('base_class', lambda _: base_class.__name__),
+            ("condition", lambda self: self.condition),
+            ("retry_remain", lambda self: self.retry_remain),
+        ]
+
+        def __init__(self) -> None:
+            self.cmd = cmd
+            self.record_cmd = record_cmd
+            nonlocal name
+            if name is None:
+                name = cmd.split()[0]
+            self.target_dir = target_dir
+            attrs.update({
+                'cmd': cmd,
+                'target_dir': target_dir,
+            })
+            super().__init__(
+                lambda x: x,
+                callback=callback,
+                error_callback=error_callback,
+                retries=retries,
+                retry_time_delta=retry_time_delta,
+                name=name,
+                condition=condition,
+                wait_time_delta=wait_time_delta,
+                redirect_out_err=redirect_out_err,
+                **attrs
+            )
+            self.runner: T.Optional[ProcessRunner] = None
+
+        def resolve_target_dir(self, target_dir: str) -> str:
+            if target_dir == "$cache_dir":
+                return self.cache_dir.resolve().as_posix()
+            elif target_dir == "$current_dir":
+                return Path.cwd().resolve().as_posix()
+            else:
+                return Path(target_dir).resolve().as_posix()
+
+        def process_func(self):
+            cmd = copy.copy(self.cmd)
+            record_cmd = copy.copy(self.record_cmd)
+            target_dir = self.resolve_target_dir(self.target_dir)
+            self.attrs.update({
+                'target_dir': target_dir,
+            })
+            self.target_dir = target_dir
+
+            cache_dir = self.cache_dir.resolve()
+            path_sh = cache_dir / 'command.sh'
+
+            def record_command():
+                with open(path_sh, 'w') as f:
+                    f.write(cmd + "\n")
+
+            pkwargs = popen_kwargs or {}
+            pkwargs['cwd'] = target_dir
+
+            if self.redirect_out_err is not False:
+                if isinstance(self.redirect_out_err, str):
+                    path_stdout = Path(self.redirect_out_err)
+                    if not path_stdout.parent.exists():
+                        path_stdout.parent.mkdir(parents=True, exist_ok=True)
+                    path_stdout = self.redirect_out_err
+                    path_stderr = self.redirect_out_err
+                else:
+                    path_stdout = cache_dir / 'stdout.txt'
+                    path_stderr = cache_dir / 'stderr.txt'
+
+                def _run_cmd(runner: ProcessRunner):  # pragma: no cover
+                    runner.run(**pkwargs)
+                    if path_stdout == path_stderr:
+                        fo = open(path_stdout, 'a')
+                        fe = fo
+                    else:
+                        fo = open(path_stdout, 'a')
+                        fe = open(path_stderr, 'a')
+                    retcode = runner.write_stream_until_stop(
+                        fo, fe, flush_streams_each_time=True)
+                    fo.close()
+                    if path_stdout != path_stderr:
+                        fe.close()
+                    return retcode
+            else:
+                def _run_cmd(runner: ProcessRunner):
+                    runner.run(
+                        capture_stdout=False,
+                        capture_stderr=False,
+                        **pkwargs
+                    )
+                    retcode = runner.proc.wait()
+                    return retcode
+
+            if base_class is ThreadJob:
+                runner = ProcessRunner(cmd)
+                self.runner = runner
+
+                def run_cmd():
+                    return _run_cmd(runner)
+            else:
+                def run_cmd():
+                    runner = ProcessRunner(cmd)
+                    return _run_cmd(runner)
+
+            def func():
+                if record_cmd:
+                    record_command()
+                retcode = run_cmd()
+                if retcode > 0:
+                    raise subp.SubprocessError(
+                        f"Command '{cmd}' run failed, return code: {retcode}")
+                return retcode
+            self.func = func
+
+        async def cancel(self):
+            if self.runner is not None:
+                self.runner.proc.terminate()
+            await super().cancel()
+
+    return _SubprocessJob()

--- a/executor/engine/job/extend/webapp.py
+++ b/executor/engine/job/extend/webapp.py
@@ -1,0 +1,165 @@
+import time
+import typing as T
+import copy
+import sys
+
+from loky.backend.process import LokyProcess
+from cmd2func.runner import ProcessRunner
+
+from ..process import ProcessJob
+from ..base import Job
+from ..condition import Condition
+from ...utils import PortManager, ExecutorError
+
+
+LauncherFunc = T.Callable[[str, int], None]
+
+
+def WebappJob(
+    web_launcher: T.Union[LauncherFunc, str],
+    ip: str = "127.0.0.1", port: T.Optional[int] = None,
+    base_class: T.Type[Job] = ProcessJob,
+    check_times: int = 6,
+    check_delta: float = 1.0,
+    callback: T.Optional[T.Callable[[T.Any], None]] = None,
+    error_callback: T.Optional[T.Callable[[Exception], None]] = None,
+    retries: int = 0,
+    retry_time_delta: float = 0.0,
+    name: T.Optional[str] = None,
+    condition: T.Optional[Condition] = None,
+    wait_time_delta: float = 0.01,
+    redirect_out_err: bool = False,
+    **attrs
+):
+    """Create a job that runs a web app.
+
+    Args:
+        web_launcher: The function to launch the web app.
+            The function should accept two arguments: ip and port.
+        ip: The ip address of the web app.
+        port: The port of the web app. If None, will find a free port.
+        base_class: The base class of the job.
+        check_times: The number of times to check the web app.
+        check_delta: The time delta between each check.
+        callback: The callback function.
+        error_callback: The error callback function.
+        retries: The number of retries.
+        retry_time_delta: The time delta between retries.
+        name: The name of the job.
+        condition: The condition of the job.
+        wait_time_delta: The time delta between each check.
+        redirect_out_err: Whether to redirect stdout and stderr to files.
+        **attrs: Other attributes of the job.
+    """
+    class _WebappJob(base_class):  # type: ignore
+        ip: str
+        port: T.Optional[int]
+
+        repr_attrs = [
+            ('status', lambda self: self.status),
+            ('id', lambda self: self.id),
+            ('addr', lambda self: f'{self.ip}:{self.port}'),
+            ('base_class', lambda _: base_class.__name__),
+            ("condition", lambda self: self.condition),
+            ("retry_remain", lambda self: self.retry_remain),
+        ]
+
+        def __init__(self) -> None:
+            self.ip = ip
+            if ip not in ("127.0.0.1", "localhost", "0.0.0.0"):
+                raise NotImplementedError(
+                    "WebappJob now only support launch in local mechine.")
+            self.port = port
+            self.check_web_launcher(web_launcher)
+            self.web_launcher = web_launcher
+            self.check_times = check_times
+            self.check_delta = check_delta
+            if isinstance(web_launcher, str):
+                attrs.update({"cmd": web_launcher})
+            super().__init__(
+                lambda x: x, callback=callback,
+                error_callback=error_callback,
+                retries=retries,
+                retry_time_delta=retry_time_delta,
+                name=name,
+                condition=condition,
+                wait_time_delta=wait_time_delta,
+                redirect_out_err=redirect_out_err,
+                **attrs
+            )
+
+        @staticmethod
+        def check_web_launcher(web_launcher: T.Union[LauncherFunc, str]):
+            if isinstance(web_launcher, str):
+                cmd_temp = web_launcher
+                if ('{ip}' not in cmd_temp) or ('{port}' not in cmd_temp):
+                    raise ValueError(
+                        "web_launcher should has ip and port placeholder.")
+            else:
+                if not callable(web_launcher):
+                    raise TypeError(
+                        "web_launcher should be a callable object or str.")
+
+        def consume_resource(self) -> bool:
+            if super().consume_resource():
+                if self.port is None:
+                    self.port = PortManager.get_port()
+                else:
+                    PortManager.consume_port(self.port)
+                self.attrs.update({"address": f"{self.ip}:{self.port}"})
+                return True
+            else:  # pragma: no cover
+                return False
+
+        def release_resource(self) -> bool:
+            if self.port is None:  # pragma: no cover
+                return False
+            if super().release_resource():
+                PortManager.release_port(self.port)
+                return True
+            else:  # pragma: no cover
+                return False
+
+        def process_func(self):
+            web_launcher = copy.copy(self.web_launcher)
+            if self.port is None:  # pragma: no cover
+                raise ExecutorError("Unreachable code.")
+            ip, port = copy.copy(self.ip), copy.copy(self.port)
+            check_times = copy.copy(self.check_times)
+            check_delta = copy.copy(self.check_delta)
+
+            def check_port(pid: int) -> bool:  # pragma: no cover
+                for _ in range(check_times):
+                    time.sleep(check_delta)
+                    if PortManager.process_has_port(pid, ip, port):
+                        return True
+                    print(f"Process is not listen on {ip}:{port}. Try again.")
+                return False
+
+            if isinstance(web_launcher, str):
+                cmd = web_launcher.format(ip=ip, port=port)
+
+                def func():  # pragma: no cover
+                    runner = ProcessRunner(cmd)
+                    runner.run()
+                    if check_port(runner.proc.pid):
+                        retcode = runner.write_stream_until_stop(
+                            sys.stdout, sys.stderr)
+                        sys.exit(retcode)
+                    else:
+                        runner.proc.terminate()
+                        raise IOError(f"Process is not listen on {ip}:{port}.")
+            else:
+                def func():  # pragma: no cover
+                    proc = LokyProcess(target=web_launcher, args=(ip, port))
+                    proc.start()
+                    pid = proc.pid
+                    if check_port(pid):
+                        proc.join()
+                    else:
+                        proc.terminate()
+                        raise IOError(f"Process is not listen on {ip}:{port}.")
+
+            self.func = func
+            super().process_func()
+    return _WebappJob()

--- a/executor/engine/job/local.py
+++ b/executor/engine/job/local.py
@@ -1,0 +1,18 @@
+from inspect import iscoroutinefunction
+
+from .base import Job
+from .utils import create_generator_wrapper
+
+
+class LocalJob(Job):
+    async def run_function(self):
+        """Run job in local thread."""
+        if iscoroutinefunction(self.func):
+            res = await self.func(*self.args, **self.kwargs)
+        else:
+            res = self.func(*self.args, **self.kwargs)
+        return res
+
+    async def run_generator(self):
+        """Run job as a generator."""
+        return create_generator_wrapper(self)

--- a/executor/engine/job/process.py
+++ b/executor/engine/job/process.py
@@ -1,0 +1,79 @@
+import asyncio
+import functools
+from inspect import iscoroutinefunction
+
+import loky.process_executor
+if hasattr(loky.process_executor, "_MAX_MEMORY_LEAK_SIZE"):
+    loky.process_executor._MAX_MEMORY_LEAK_SIZE = int(1e13)
+from loky.process_executor import ProcessPoolExecutor
+
+from .base import Job
+from .utils import (
+    _gen_initializer, create_generator_wrapper, run_async_func
+)
+
+
+class ProcessJob(Job):
+    """Job that runs in a process."""""
+
+    def has_resource(self) -> bool:
+        """Check if the job has enough resource to run."""
+        if self.engine is None:
+            return False
+        else:
+            return (
+                super().has_resource() and
+                (self.engine.resource.n_process > 0)
+            )
+
+    def consume_resource(self) -> bool:
+        """Consume resource for the job."""
+        if self.engine is None:
+            return False
+        else:
+            self.engine.resource.n_process -= 1
+            return (
+                super().consume_resource() and
+                True
+            )
+
+    def release_resource(self) -> bool:
+        """Release resource for the job."""
+        if self.engine is None:
+            return False
+        else:
+            self.engine.resource.n_process += 1
+            return (
+                super().release_resource() and
+                True
+            )
+
+    async def run_function(self):
+        """Run job in process pool."""
+        func = functools.partial(self.func, *self.args, **self.kwargs)
+        if iscoroutinefunction(func):
+            func = functools.partial(run_async_func, func)
+        self._executor = ProcessPoolExecutor(1)
+        loop = asyncio.get_running_loop()
+        fut = loop.run_in_executor(self._executor, func)
+        result = await fut
+        return result
+
+    async def run_generator(self):
+        """Run job as a generator."""
+        func = functools.partial(self.func, *self.args, **self.kwargs)
+        self._executor = ProcessPoolExecutor(
+            1, initializer=_gen_initializer, initargs=(func,))
+        result = create_generator_wrapper(self)
+        return result
+
+    async def cancel(self):
+        """Cancel job."""
+        if self.status == "running":
+            self._executor.shutdown(wait=True, kill_workers=True)
+        await super().cancel()
+
+    def clear_context(self):
+        """Clear context."""
+        self._executor.shutdown(wait=True, kill_workers=True)
+        self._executor = None

--- a/executor/engine/job/thread.py
+++ b/executor/engine/job/thread.py
@@ -1,0 +1,75 @@
+import asyncio
+import functools
+from inspect import iscoroutinefunction
+from concurrent.futures import ThreadPoolExecutor
+
+from .base import Job
+from .utils import (
+    _gen_initializer, create_generator_wrapper, run_async_func
+)
+
+
+class ThreadJob(Job):
+    """Job that runs in a thread."""
+
+    def has_resource(self) -> bool:
+        """Check if the job has enough resource to run."""
+        if self.engine is None:
+            return False
+        else:
+            return (
+                super().has_resource() and
+                (self.engine.resource.n_thread > 0)
+            )
+
+    def consume_resource(self) -> bool:
+        """Consume resource for the job."""
+        if self.engine is None:
+            return False
+        else:
+            self.engine.resource.n_thread -= 1
+            return (
+                super().consume_resource() and
+                True
+            )
+
+    def release_resource(self) -> bool:
+        """Release resource for the job."""
+        if self.engine is None:
+            return False
+        else:
+            self.engine.resource.n_thread += 1
+            return (
+                super().release_resource() and
+                True
+            )
+
+    async def run_function(self):
+        """Run job in thread pool."""
+        func = functools.partial(self.func, *self.args, **self.kwargs)
+        if iscoroutinefunction(func):
+            func = functools.partial(run_async_func, func)
+        self._executor = ThreadPoolExecutor(1)
+        loop = asyncio.get_running_loop()
+        fut = loop.run_in_executor(self._executor, func)
+        result = await fut
+        return result
+
+    async def run_generator(self):
+        """Run job as a generator."""
+        func = functools.partial(self.func, *self.args, **self.kwargs)
+        self._executor = ThreadPoolExecutor(
+            1, initializer=_gen_initializer, initargs=(func,))
+        result = create_generator_wrapper(self)
+        return result
+
+    async def cancel(self):
+        """Cancel job."""
+        if self.status == "running":
+            self._executor.shutdown()
+        await super().cancel()
+
+    def clear_context(self):
+        """Clear context."""
+        self._executor.shutdown()
+        self._executor = None

--- a/executor/engine/job/utils.py
+++ b/executor/engine/job/utils.py
@@ -1,0 +1,173 @@
+import typing as T
+import asyncio
+import inspect
+from datetime import datetime
+from concurrent.futures import Future
+import threading
+
+from ..utils import CheckAttrRange, ExecutorError
+
+
+if T.TYPE_CHECKING:
+    from .base import Job
+
+JobStatusType = T.Literal['pending', 'running', 'failed', 'done', 'cancelled']
+valid_job_statuses: T.List[JobStatusType] = [
+    'pending', 'running', 'failed', 'done', 'cancelled']
+
+
+class JobStatusAttr(CheckAttrRange):
+    valid_range: T.Iterable[JobStatusType] = valid_job_statuses
+    attr = "_status"
+
+    def __set__(self, obj: "Job", value: JobStatusType):
+        self.check(obj, value)
+        old_status = getattr(obj, self.attr)
+        setattr(obj, self.attr, value)
+        if obj.engine is not None:
+            obj.engine.jobs.move_job_store(
+                obj, value, old_status)
+        if value in ('done', 'failed', 'cancelled'):
+            obj.stoped_time = datetime.now()
+
+
+class InvalidStateError(ExecutorError):
+    def __init__(self, job: "Job", valid_status: T.List[JobStatusType]):
+        self.valid_status = valid_status
+        super().__init__(
+            f"Invalid state: {job} is in {job.status} state, "
+            f"but should be in {valid_status} state.")
+
+
+_thread_locals = threading.local()
+
+
+def _gen_initializer(gen_func, args=tuple(), kwargs={}):  # pragma: no cover
+    global _thread_locals
+    if "_thread_locals" not in globals():
+        # avoid conflict for ThreadJob
+        _thread_locals = threading.local()
+    _thread_locals._generator = gen_func(*args, **kwargs)
+
+
+def _gen_next(send_value=None, fut=None):  # pragma: no cover
+    if fut is None:
+        g = _thread_locals._generator
+    else:
+        g = fut
+    if send_value is None:
+        return next(g)
+    else:
+        return g.send(send_value)
+
+
+def _gen_anext(send_value=None, fut=None):  # pragma: no cover
+    if fut is None:
+        g = _thread_locals._generator
+    else:
+        g = fut
+    if send_value is None:
+        return asyncio.run(g.__anext__())
+    else:
+        return asyncio.run(g.asend(send_value))
+
+
+class GeneratorWrapper():
+    """
+    wrap a generator in executor pool
+    """
+
+    def __init__(self, job: "Job", fut: T.Optional[Future] = None):
+        self._job = job
+        self._fut = fut
+        self._local_res = None
+
+
+class SyncGeneratorWrapper(GeneratorWrapper):
+    """
+    wrap a generator in executor pool
+    """
+    def __iter__(self):
+        return self
+
+    def _next(self, send_value=None):
+        try:
+            if self._job._executor is not None:
+                return self._job._executor.submit(
+                    _gen_next, send_value, self._fut).result()
+            else:
+                # create local generator
+                if self._local_res is None:
+                    self._local_res = self._job.func(
+                        *self._job.args, **self._job.kwargs)
+                if send_value is not None:
+                    return self._local_res.send(send_value)
+                else:
+                    return next(self._local_res)
+        except Exception as e:
+            engine = self._job.engine
+            if engine is None:
+                loop = asyncio.get_event_loop()  # pragma: no cover
+            else:
+                loop = engine.loop
+            if isinstance(e, StopIteration):
+                cor = self._job.on_done(self)
+            else:
+                cor = self._job.on_failed(e)
+            fut = asyncio.run_coroutine_threadsafe(cor, loop)
+            fut.result()
+            raise e
+
+    def __next__(self):
+        return self._next()
+
+    def send(self, value):
+        return self._next(value)
+
+
+class AsyncGeneratorWrapper(GeneratorWrapper):
+    """
+    wrap a generator in executor pool
+    """
+    def __aiter__(self):
+        return self
+
+    async def _anext(self, send_value=None):
+        try:
+            if self._job._executor is not None:
+                fut = self._job._executor.submit(
+                    _gen_anext, send_value, self._fut)
+                res = await asyncio.wrap_future(fut)
+                return res
+            else:
+                if self._local_res is None:
+                    self._local_res = self._job.func(
+                        *self._job.args, **self._job.kwargs)
+                if send_value is not None:
+                    return await self._local_res.asend(send_value)
+                else:
+                    return await self._local_res.__anext__()
+        except Exception as e:
+            if isinstance(e, StopAsyncIteration):
+                await self._job.on_done(self)
+            else:
+                await self._job.on_failed(e)
+            raise e
+
+    async def __anext__(self):
+        return await self._anext()
+
+    async def asend(self, value):
+        return await self._anext(value)
+
+
+def create_generator_wrapper(
+        job: "Job", fut: T.Optional[Future] = None) -> GeneratorWrapper:
+    if inspect.isasyncgenfunction(job.func):
+        return AsyncGeneratorWrapper(job, fut)
+    else:
+        return SyncGeneratorWrapper(job, fut)
+
+
+def run_async_func(func, *args, **kwargs):
+    return asyncio.run(func(*args, **kwargs))

--- a/executor/engine/launcher/__init__.py
+++ b/executor/engine/launcher/__init__.py
@@ -1,0 +1,12 @@
+from .core import (
+    launcher, SyncLauncher,
+    AsyncLauncher, LauncherBase,
+    set_default_engine, get_default_engine
+)
+
+
+__all__ = [
+    'launcher', 'SyncLauncher',
+    'AsyncLauncher', 'LauncherBase',
+    'set_default_engine', 'get_default_engine'
+]

--- a/executor/engine/launcher/core.py
+++ b/executor/engine/launcher/core.py
@@ -1,0 +1,232 @@
+import typing as T
+import inspect
+import functools
+from copy import copy
+
+from funcdesc import parse_func
+from cmd2func.core import Cmd2Func
+
+from ..core import Engine
+from ..job import Job, LocalJob, ThreadJob, ProcessJob
+from ..job.extend import SubprocessJob, WebappJob
+from ..utils import get_callable_name
+
+
+Job_or_ExtJob = T.Union[T.Type[Job], T.Callable[..., Job]]
+
+
+job_type_classes: T.Dict[str, Job_or_ExtJob] = {
+    'local': LocalJob,
+    'thread': ThreadJob,
+    'process': ProcessJob,
+    'subprocess': SubprocessJob,
+    'webapp': WebappJob,
+}
+
+
+try:
+    from ..job.dask import DaskJob
+    job_type_classes['dask'] = DaskJob
+except ImportError:  # pragma: no cover
+    pass
+
+
+JOB_TYPES = T.Literal[
+    'local', 'thread', 'process', 'dask',
+    'subprocess', 'webapp'
+]
+
+
+_engine: T.Optional[Engine] = None
+
+
+def get_default_engine() -> Engine:
+    """Get the default engine."""
+    global _engine
+    if _engine is None:
+        _engine = Engine()
+    return _engine
+
+
+def set_default_engine(engine: Engine):
+    """Set the default engine."""
+    global _engine
+    _engine = engine
+
+
+class LauncherBase(object):
+    def __init__(
+            self, target_func: T.Union[T.Callable, Cmd2Func],
+            engine: T.Optional['Engine'] = None,
+            job_type: JOB_TYPES = 'process',
+            name: T.Optional[str] = None,
+            description: T.Optional[str] = None,
+            tags: T.Optional[T.List[str]] = None,
+            job_attrs: T.Optional[dict] = None,):
+        self._engine = engine
+        self.target_func = target_func
+        self.__signature__ = inspect.signature(target_func)
+        self.job_type = job_type
+        if isinstance(target_func, Cmd2Func):
+            if self.job_type != 'webapp':
+                self.job_type = 'subprocess'
+        self.desc = parse_func(target_func)
+        self.name = name or get_callable_name(target_func)
+        self.description = description or self.target_func.__doc__
+        functools.update_wrapper(self, target_func)
+        self.tags = tags or []
+        job_attrs = job_attrs or {}
+        self.job_attrs = job_attrs
+        self.job_attrs.update({
+            'name': self.name,
+        })
+
+    @property
+    def engine(self) -> Engine:
+        """Get the engine of the launcher."""
+        if self._engine is None:
+            self._engine = get_default_engine()
+        return self._engine
+
+    @engine.setter
+    def engine(self, engine: Engine):
+        """Set the engine of the launcher."""
+        self._engine = engine
+
+    def create_job(self, args: tuple, kwargs: dict, **attrs) -> 'Job':
+        """Create a job from the launcher."""
+        job_attrs = copy(self.job_attrs)
+        job_attrs.update(attrs)
+        job_class = job_type_classes[self.job_type]
+        if isinstance(self.target_func, Cmd2Func):
+            assert job_class in (SubprocessJob, WebappJob)
+            cmd_or_gen = self.target_func.get_cmd_str(*args, **kwargs)
+            if isinstance(cmd_or_gen, str):
+                cmd = cmd_or_gen
+            else:
+                cmd = next(cmd_or_gen)
+            job = job_class(cmd, **job_attrs)  # type: ignore
+        else:
+            if job_class is WebappJob:
+                kwargs = copy(kwargs)
+                kwargs.update(job_attrs)
+                job = job_class(self.target_func, *args, **kwargs)
+            else:
+                job = job_class(
+                    self.target_func, args, kwargs,
+                    **job_attrs
+                )
+        return job
+
+    @staticmethod
+    def _fetch_result(job: 'Job') -> T.Any:
+        if job.status == "failed":
+            raise job.exception()
+        elif job.status == "cancelled":
+            raise RuntimeError("Job cancelled")
+        else:
+            return job.result()
+
+    def __call__(
+            self, *args: T.Any, **kwargs: T.Any) -> T.Any:  # pragma: no cover
+        raise NotImplementedError("Subclasses must implement __call__")
+
+
+class SyncLauncher(LauncherBase):
+
+    @property
+    def async_mode(self):
+        """Check if the launcher is in async mode."""
+        return False
+
+    def submit(self, *args, **kwargs) -> Job:
+        """Submit a job to the engine."""
+        job = self.create_job(args, kwargs)
+        self.engine.submit(job)
+        return job
+
+    def __call__(self, *args, **kwargs) -> T.Any:
+        """Submit a job to the engine and wait for the result."""
+        job = self.submit(*args, **kwargs)
+        self.engine.wait_job(job)
+        return self._fetch_result(job)
+
+    def to_async(self) -> "AsyncLauncher":
+        """Convert the launcher to async mode."""
+        return AsyncLauncher(
+            self.target_func, self._engine, self.job_type,
+            self.name, self.description, self.tags,
+            job_attrs=self.job_attrs,
+        )
+
+
+class AsyncLauncher(LauncherBase):
+    @property
+    def async_mode(self):
+        """Check if the launcher is in async mode."""
+        return True
+
+    async def submit(self, *args, **kwargs):
+        """Submit a job to the engine."""
+        job = self.create_job(args, kwargs)
+        await self.engine.submit_async(job)
+        return job
+
+    async def __call__(self, *args, **kwargs) -> T.Any:
+        """Submit a job to the engine and wait for the result."""
+        job = await self.submit(*args, **kwargs)
+        await job.join()
+        return self._fetch_result(job)
+
+    def to_sync(self) -> "SyncLauncher":
+        """Convert the launcher to sync mode."""
+        return SyncLauncher(
+            self.target_func, self._engine, self.job_type,
+            self.name, self.description, self.tags,
+            job_attrs=self.job_attrs,
+        )
+
+
+def launcher(
+        func: T.Optional[T.Union[T.Callable, Cmd2Func]] = None,
+        engine: T.Optional['Engine'] = None,
+        async_mode: bool = False,
+        job_type: JOB_TYPES = 'process',
+        name: T.Optional[str] = None,
+        description: T.Optional[str] = None,
+        tags: T.Optional[T.List[str]] = None,
+        job_attrs: T.Optional[dict] = None):
+    """Create a launcher for a function.
+
+    Args:
+        func: The function to be launched. If the function is instance of
+            [Cmd2Func](https://github.com/Nanguage/cmd2func),
+            the launcher will be in subprocess mode,
+            will launch `SubprocessJob` on each submit.
+        engine: The engine to use. If not specified, the default engine
+            will be used.
+        async_mode: If True, the launcher will be AsyncLauncher.
+        job_type: The job type to use. Default is 'process'.
+        name: The name of the launcher.
+        description: The description of the launcher.
+        tags: The tags of the launcher.
+        job_attrs: The attributes for creating the job.
+    """
+    if func is None:
+        return functools.partial(
+            launcher, engine=engine, async_mode=async_mode,
+            job_type=job_type, name=name,
+            description=description, tags=tags,
+            job_attrs=job_attrs
+        )
+
+    launcher_cls: T.Union[T.Type[AsyncLauncher], T.Type[SyncLauncher]]
+    if async_mode:
+        launcher_cls = AsyncLauncher
+    else:
+        launcher_cls = SyncLauncher
+
+    return launcher_cls(
+        func, engine, job_type,
+        name, description, tags, job_attrs,
+    )

--- a/executor/engine/log.py
+++ b/executor/engine/log.py
@@ -1,0 +1,4 @@
+from loguru import logger
+
+
+__all__ = ["logger"]

--- a/executor/engine/manager.py
+++ b/executor/engine/manager.py
@@ -1,0 +1,242 @@
+import typing as T
+from pathlib import Path
+
+from diskcache import Cache
+
+from .job.base import Job
+from .job.utils import (
+    valid_job_statuses, JobStatusType, ExecutorError
+)
+
+if T.TYPE_CHECKING:
+    from .core import Engine
+
+
+class JobNotFoundError(ExecutorError):
+    """Job not found error."""
+    def __init__(self, job_id: str):
+        self.job_id = job_id
+        super().__init__(f"Job {job_id} not found.")
+
+
+class JobStore():
+    """Store jobs.
+
+    Attributes:
+        cache: The cache on disk(Use diskcache package).
+            See:
+            [disk-cache's doc](https://github.com/grantjenks/python-diskcache)
+            for more details.
+        mem: In memory store.
+    """
+
+    cache: T.Optional[Cache]
+    mem: T.Dict[str, Job]
+
+    def __init__(self, cache_path: T.Optional[Path] = None):
+        """Init.
+
+        Args:
+            cache_path: Cache path.
+        """
+        if cache_path is not None:
+            self.cache = Cache(str(cache_path))
+        else:
+            self.cache = None
+        self.mem: T.Dict[str, Job] = dict()
+
+    @classmethod
+    def load_from_cache(cls, path: Path):
+        """Load from cache."""
+        store = cls(path)
+        store.update_from_cache()
+        return store
+
+    def update_from_cache(self, clear_old=False):
+        """Update from cache."""
+        if clear_old:
+            self.mem.clear()
+        if self.cache is not None:
+            for key in self.cache:
+                job = self.get_from_cache(key)
+                self.mem[key] = job
+
+    def get_from_cache(self, key: str) -> Job:
+        """Get from cache."""
+        if self.cache is None:
+            raise RuntimeError("No cache")
+        bytes_ = self.cache[key]
+        job = Job.deserialization(bytes_)
+        return job
+
+    def set_to_cache(self, key: str, val: Job):
+        """Set job to cache."""
+        bytes_ = val.serialization()
+        if self.cache is not None:
+            self.cache[key] = bytes_
+
+    def __setitem__(self, key: str, val: Job):
+        self.mem[key] = val
+        if self.cache is not None:
+            self.set_to_cache(key, val)
+
+    def __getitem__(self, key: str) -> Job:
+        return self.mem[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.mem
+
+    def clear(self):
+        """Clear all jobs."""
+        self.mem.clear()
+        if self.cache is not None:
+            self.cache.clear()
+
+    def pop(self, key: str) -> Job:
+        """Pop a job from store."""
+        job = self.mem.pop(key)
+        if self.cache is not None:
+            self.cache.pop(key)
+        return job
+
+    def values(self) -> T.List[Job]:
+        """Get all values(Job)."""
+        vals = list(self.mem.values())
+        return vals
+
+    def keys(self) -> T.List[str]:
+        """Get all keys(Job's id)."""
+        return list(self.mem.keys())
+
+    def items(self) -> T.List[T.Tuple[str, Job]]:
+        """Get all key-value pairs."""
+        return list(self.mem.items())
+
+    def __del__(self):
+        if self.cache is not None:
+            self.cache.close()
+
+    def __len__(self):
+        return len(self.mem)
+
+
+class Jobs:
+    """Jobs manager.
+
+    Attributes:
+        pending: Pending jobs.
+        running: Running jobs.
+        done: Done jobs.
+        failed: Failed jobs.
+        cancelled: Cancelled jobs.
+    """
+    valid_statuses = valid_job_statuses
+    pending: JobStore
+    running: JobStore
+    done: JobStore
+    failed: JobStore
+    cancelled: JobStore
+
+    def __init__(self, cache_path: T.Optional[Path] = None):
+        self.cache_path = cache_path
+        self._stores: T.Dict[str, JobStore] = {}
+        s: str
+        for s in self.valid_statuses:
+            if cache_path is None:
+                store = JobStore(None)
+            else:
+                path = cache_path / s
+                if path.exists():
+                    store = JobStore.load_from_cache(path)
+                else:
+                    store = JobStore(path)
+            self._stores[s] = store
+        self.set_attrs_for_read()
+
+    def update_from_cache(self, clear_old=True):
+        """Update jobs from cache."""
+        for store in self._stores.values():
+            store.update_from_cache(clear_old=clear_old)
+
+    def set_attrs_for_read(self):
+        self.pending = self._stores['pending']
+        self.running = self._stores['running']
+        self.done = self._stores['done']
+        self.failed = self._stores['failed']
+        self.cancelled = self._stores['cancelled']
+
+    def set_engine(self, engine: "Engine"):
+        """Set engine for all jobs."""
+        for job in self.all_jobs():
+            job.engine = engine
+
+    def clear(self, statuses: T.List[JobStatusType]):
+        """Clear jobs by status."""
+        for s in statuses:
+            self._stores[s].clear()
+
+    def clear_non_active(self):
+        """Clear non-active jobs."""
+        self.clear(["done", "failed", "cancelled"])
+
+    def clear_all(self):
+        """Clear all jobs."""
+        self.clear(self.valid_statuses)
+
+    def add(self, job: Job):
+        """Add job to store."""
+        store = self._stores[job.status]
+        store[job.id] = job
+
+    def remove(self, job: Job):
+        """Remove job from store."""
+        for tp in self.valid_statuses:
+            store = self._stores[tp]
+            if job.id in store:
+                store.pop(job.id)
+
+    def move_job_store(
+            self, job: Job,
+            new_status: JobStatusType,
+            old_status: T.Optional[JobStatusType] = None):
+        """Move job to another store."""
+        if old_status is None:
+            old_status = job.status
+        if old_status == new_status:
+            return
+        old_store = self._stores[old_status]
+        new_store = self._stores[new_status]
+        new_store[job.id] = old_store.pop(job.id)
+
+    def get_job_by_id(self, job_id: str) -> Job:
+        """Get job by id."""
+        for status in self.valid_statuses:
+            store = self._stores[status]
+            if job_id in store:
+                return store[job_id]
+        raise JobNotFoundError(job_id)
+
+    def __contains__(self, job: T.Union[str, Job]):
+        if isinstance(job, Job):
+            job_id = job.id
+        else:
+            job_id = job
+        try:
+            self.get_job_by_id(job_id)
+            return True
+        except JobNotFoundError:
+            return False
+
+    def all_jobs(self) -> T.List[Job]:
+        """Get all jobs."""
+        return list(iter(self))
+
+    def __iter__(self):
+        """Iterate all jobs."""
+        for status in self.valid_statuses:
+            store = self._stores[status]
+            for job in store.values():
+                yield job
+
+    def __len__(self):
+        return sum(len(store) for store in self._stores.values())

--- a/executor/engine/middle/capture.py
+++ b/executor/engine/middle/capture.py
@@ -1,0 +1,80 @@
+import sys
+import typing as T
+from functools import update_wrapper
+from pathlib import Path
+import traceback
+import loguru
+
+
+LOGURU_HANDLERS = {}
+
+
+class Tee(object):
+    def __init__(
+            self, out_file: T.TextIO,
+            stream: T.Literal['stdout', 'stderr'] = 'stdout'):
+        self.stream_type = stream
+        self.file = out_file
+        self.stream: T.TextIO = getattr(sys, stream)
+
+    def write(self, data):
+        self.stream.write(data)
+        self.file.write(data)
+
+    def flush(self):
+        self.stream.flush()
+        self.file.flush()
+
+    def __enter__(self):
+        setattr(sys, self.stream_type, self)
+        fname = repr(self.file)
+        if fname not in LOGURU_HANDLERS:
+            loguru_handler = loguru.logger.add(self.file)
+            LOGURU_HANDLERS[fname] = loguru_handler
+        return self
+
+    def __exit__(self, _type, _value, _traceback):
+        setattr(sys, self.stream_type, self.stream)
+        fname = repr(self.file)
+        if fname in LOGURU_HANDLERS:
+            loguru.logger.remove(LOGURU_HANDLERS[fname])
+            del LOGURU_HANDLERS[fname]
+
+
+class CaptureOut(object):
+    def __init__(
+            self, func: T.Callable,
+            stdout_file: Path, stderr_file: Path,
+            capture_traceback: bool = True):
+        update_wrapper(func, self)
+        self.func = func
+        self.stdout_file = stdout_file
+        self.stderr_file = stderr_file
+        self.capture_traceback = capture_traceback
+
+    def __call__(self, *args, **kwargs) -> T.Any:
+        if not self.stdout_file.parent.exists():
+            self.stdout_file.parent.mkdir(
+                parents=True, exist_ok=True)  # pragma: no cover
+        if not self.stderr_file.parent.exists():
+            self.stderr_file.parent.mkdir(
+                parents=True, exist_ok=True)  # pragma: no cover
+
+        if self.stdout_file == self.stderr_file:
+            outf = open(self.stdout_file, 'a')
+            errf = outf
+        else:
+            outf = open(self.stdout_file, 'a')
+            errf = open(self.stderr_file, 'a')
+        with Tee(outf, 'stdout'), Tee(errf, 'stderr'):
+            try:
+                res = self.func(*args, **kwargs)
+            except Exception as e:
+                if self.capture_traceback:
+                    traceback.print_exc()
+                raise e
+            finally:
+                outf.close()
+                if self.stdout_file != self.stderr_file:
+                    errf.close()
+        return res

--- a/executor/engine/middle/dir.py
+++ b/executor/engine/middle/dir.py
@@ -1,0 +1,18 @@
+import os
+import typing as T
+from pathlib import Path
+from functools import update_wrapper
+
+
+class ChDir(object):
+    def __init__(self, func: T.Callable, target_dir: Path):
+        update_wrapper(func, self)
+        self.func = func
+        self.target_dir = target_dir
+
+    def __call__(self, *args, **kwargs) -> T.Any:
+        old = os.getcwd()
+        os.chdir(self.target_dir)
+        res = self.func(*args, **kwargs)
+        os.chdir(old)
+        return res

--- a/executor/engine/utils.py
+++ b/executor/engine/utils.py
@@ -1,0 +1,141 @@
+import typing as T
+import asyncio
+import contextlib
+import psutil
+import socket
+
+
+class ExecutorError(Exception):
+    pass
+
+
+class CheckError(ExecutorError):
+    pass
+
+
+class TypeCheckError(CheckError):
+    pass
+
+
+class RangeCheckError(CheckError):
+    pass
+
+
+class CheckAttrRange(object):
+    valid_range: T.Iterable[T.Any] = []
+    attr = "__"
+
+    def __get__(self, obj, objtype=None):
+        return getattr(obj, self.attr)
+
+    def check(self, obj, value):
+        if value not in self.valid_range:
+            raise RangeCheckError(
+                f"{obj}'s {type(self)} attr should be "
+                f"one of: {self.valid_range}"
+            )
+
+    def __set__(self, obj, value):
+        self.check(obj, value)
+        setattr(obj, self.attr, value)
+
+
+Checker = T.Callable[[T.Any], bool]
+
+
+class CheckAttrType(object):
+    valid_type: T.List[T.Union[Checker, type]] = []
+    attr = "__"
+
+    def __get__(self, obj, objtype=None):
+        return getattr(obj, self.attr)
+
+    def __set__(self, obj, value):
+        check_passed = []
+        for tp in self.valid_type:
+            if isinstance(tp, type):
+                passed = isinstance(value, tp)
+            else:
+                assert isinstance(tp, T.Callable)
+                passed = tp(value)
+            check_passed.append(passed)
+        is_valid_type = any(check_passed)
+        if not is_valid_type:
+            raise TypeCheckError(
+                f"{obj}'s {type(self)} attr should in type: "
+                f"{self.valid_type}"
+            )
+        setattr(obj, self.attr, value)
+
+
+@contextlib.contextmanager
+def event_loop():
+    loop, is_new_loop = get_event_loop()
+    try:
+        yield loop
+    finally:
+        if is_new_loop:
+            loop.close()
+
+
+def get_event_loop() -> T.Tuple[asyncio.AbstractEventLoop, bool]:
+    is_new_loop = False
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        is_new_loop = True
+    return loop, is_new_loop
+
+
+class PortManager():
+
+    used_port: T.Set[int] = set()
+
+    @classmethod
+    def get_port(cls) -> int:
+        while True:
+            port = cls.find_free_port()
+            if port in cls.used_port:  # pragma: no cover
+                continue
+            else:
+                cls.consume_port(port)
+                return port
+
+    @classmethod
+    def consume_port(cls, port: int):
+        cls.used_port.add(port)
+
+    @classmethod
+    def release_port(cls, port: int):
+        cls.used_port.remove(port)
+
+    @staticmethod
+    def find_free_port() -> int:
+        """https://stackoverflow.com/a/45690594/8500469"""
+        with contextlib.closing(
+                socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            s.bind(('', 0))
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            port = s.getsockname()[1]
+        return port
+
+    @staticmethod
+    def process_has_port(target_pid: int, ip: str, port: int) -> bool:
+        p = psutil.Process(target_pid)
+        addrs = [
+            (c.laddr.ip, c.laddr.port) for c in p.connections()
+        ]
+        return (ip, port) in addrs
+
+
+def get_callable_name(callable) -> str:
+    if hasattr(callable, "func"):
+        inner_func = getattr(callable, "func")
+        return get_callable_name(inner_func)
+    elif hasattr(callable, "__name__"):
+        return getattr(callable, "__name__")
+    elif hasattr(callable, "__class__"):
+        return getattr(callable, "__class__").__name__
+    else:  # pragma: no cover
+        return str(callable)

--- a/funcdesc/__init__.py
+++ b/funcdesc/__init__.py
@@ -1,0 +1,17 @@
+from .desc import Description, Value, SideEffect
+from .guard import make_guard, Guard
+from .parse import parse_func
+from .mark import (
+    mark_input, mark_output, mark_side_effect,
+    Val, Outputs,
+)
+
+__all__ = [
+    "Description", "Value", "SideEffect",
+    "make_guard", "Guard",
+    "parse_func",
+    "mark_input", "mark_output", "mark_side_effect",
+    "Val", "Outputs"
+]
+
+__version__ = '0.2.1'

--- a/funcdesc/desc.py
+++ b/funcdesc/desc.py
@@ -1,0 +1,242 @@
+import typing as T
+from copy import copy
+import inspect
+
+from .utils.json import DescriptionJSONEncoder, DescriptionJSONDecoder
+from .utils.misc import CreateByGetItem
+
+
+class _NotDef:
+    def __str__(self):
+        return "NotDef"
+
+
+NotDef = _NotDef()
+
+
+T1 = T.TypeVar("T1")
+
+
+TypeChecker = T.Callable[[T.Any, type], bool]
+RangeChecker = T.Callable[[T.Any, T.Any], bool]
+
+
+class Value(metaclass=CreateByGetItem):
+    """The description of a value."""
+    type_to_range_checker: T.Dict[type, TypeChecker] = {}
+    type_to_type_checker: T.Dict[type, RangeChecker] = {}
+
+    def __init__(
+            self,
+            type_: T.Optional[T.Type[T1]] = None,
+            range_: T.Optional[T.Any] = None,
+            default: T.Union[_NotDef, T1] = NotDef,
+            name: T.Optional[str] = None,
+            doc: T.Optional[str] = None,
+            **kwargs,
+            ):
+        self.name = name
+        self.type = type_
+        self.range = range_
+        self.default = default
+        self.kwargs = kwargs
+        self.doc = doc
+
+    @property
+    def type_checker(self):
+        if self.type is None:
+            return None
+        else:
+            return self.type_to_type_checker.get(self.type.__name__, None)
+
+    @property
+    def range_checker(self):
+        if self.type is None:
+            return None
+        else:
+            return self.type_to_range_checker.get(self.type.__name__, None)
+
+    @classmethod
+    def register_range_check(cls, type, checker):
+        cls.type_to_range_checker[type.__name__] = checker
+
+    @classmethod
+    def register_type_check(cls, type, checker=None):
+        checker = checker or (lambda v, t: isinstance(v, t))
+        cls.type_to_type_checker[type.__name__] = checker
+
+    def check_type(self, val):
+        if self.type_checker is not None:
+            if not self.type_checker(val, self.type):
+                raise TypeError(
+                    f"Value {val} is not in valid type({self.type})")
+
+    def check_range(self, val):
+        if (self.range_checker is not None):
+            if (not self.range_checker(val, self.range)):
+                raise ValueError(
+                    f"Value {val} is not in a valid range({self.range}).")
+
+    def __repr__(self):
+        return (
+            f"<Value name={self.name} type={self.type} range={self.range} "
+            f"default={self.default}>"
+        )
+
+    def __eq__(self, other):
+        return (
+            self.name == other.name and
+            self.doc == other.doc and
+            self.type == other.type and
+            self.range == other.range and
+            self.default == other.default
+        )
+
+
+# register basic types
+def _check_number_in_range(v, range):
+    return (range is None) or (range[0] <= v <= range[1])
+
+
+Value.register_type_check(str)
+Value.register_range_check(int, _check_number_in_range)
+Value.register_type_check(int)
+Value.register_range_check(float, _check_number_in_range)
+Value.register_type_check(float)
+Value.register_type_check(bool)
+
+
+class SideEffect():
+    def __init__(self, description: str):
+        self._description = description
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    def check_before_run(self, inputs: dict) -> bool:
+        return True
+
+    def check_after_run(self, inputs: dict, outputs: dict) -> bool:
+        return True
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} description={self.description}>"
+
+    def __eq__(self, other):
+        return self.description == other.description
+
+
+class Description():
+    """The description of a function."""
+    def __init__(
+            self,
+            inputs: T.Optional[T.List[Value]] = None,
+            outputs: T.Optional[T.List[Value]] = None,
+            side_effects: T.Optional[T.List[SideEffect]] = None,
+            name: T.Optional[str] = None,
+            doc: T.Optional[str] = None,
+            ):
+        self.inputs = [] if inputs is None else inputs
+        self.outputs = [] if outputs is None else outputs
+        self.side_effects = [] if side_effects is None else side_effects
+        self.name = name
+        self.doc = doc
+
+    def parse_pass_in(self, args: tuple, kwargs: dict) -> T.Dict[str, T.Any]:
+        """Get the pass in value of the func
+        arguments according to the inputs description."""
+
+        args_ = list(args)
+        kwargs = copy(kwargs)
+        res = {}
+        for val in self.inputs:
+            has_default = val.default is not NotDef
+            name = "?" if val.name is None else val.name
+            if len(args_) > 0:
+                res[name] = args_.pop(0)
+            elif (len(kwargs) > 0) and (name in kwargs):
+                res[name] = kwargs.pop(name)
+            else:
+                if has_default:
+                    res[name] = val.default
+                else:
+                    raise TypeError(
+                        f"{name} is not provided and has no default value."
+                    )
+        return res
+
+    def to_dict(self) -> T.Dict[str, T.Any]:
+        return DescriptionJSONEncoder().default(self)
+
+    @classmethod
+    def from_dict(
+            cls,
+            d: T.Dict[str, T.Any], env: T.Optional[T.Dict[str, T.Any]] = None
+            ) -> "Description":
+        return DescriptionJSONDecoder().decode_description(d, env=env)
+
+    def to_json(self) -> str:
+        json_str = DescriptionJSONEncoder().encode(self)
+        return json_str
+
+    @classmethod
+    def from_json(
+            cls,
+            json_str: str,
+            env: T.Optional[T.Dict[str, T.Any]] = None
+            ) -> "Description":
+        return DescriptionJSONDecoder().decode(json_str, env=env)
+
+    def __repr__(self) -> str:
+        return (
+            "<Description\n"
+            f"\tinputs={self.inputs}\n"
+            f"\toutputs={self.outputs}\n"
+            f"\tside_effects={self.side_effects}\n"
+            f"\tname={self.name}\n"
+            f"\tdoc={self.doc}\n"
+            ">"
+        )
+
+    def __eq__(self, other):
+        return (
+            self.inputs == other.inputs and
+            self.outputs == other.outputs and
+            self.side_effects == other.side_effects and
+            self.name == other.name and
+            self.doc == other.doc
+        )
+
+    def compose_signature(self) -> inspect.Signature:
+        """Compose the signature of the function
+        according to the description."""
+        params = []
+        for val in self.inputs:
+            default: T.Any
+            if val.default is NotDef:
+                default = inspect._empty
+            else:
+                default = val.default
+            params.append(
+                inspect.Parameter(
+                    val.name or "?",
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=default,
+                    annotation=val.type,
+                )
+            )
+        rtn_type: T.Union[None, type, list]
+        if len(self.outputs) == 0:  # pragma: no cover
+            rtn_type = inspect._empty
+        elif len(self.outputs) == 1:
+            rtn_type = self.outputs[0].type
+            if rtn_type is type(None):  # noqa: E721
+                rtn_type = inspect._empty
+        else:
+            rtn_type = [val.type for val in self.outputs]
+        sig = inspect.Signature(
+            params,
+            return_annotation=rtn_type
+        )
+        return sig

--- a/funcdesc/guard.py
+++ b/funcdesc/guard.py
@@ -1,0 +1,182 @@
+import typing as T
+import functools
+import types
+
+from .desc import Value, Description
+from .parse import parse_func
+
+
+class CheckError(Exception):
+    pass
+
+
+class SideEffectError(Exception):
+    pass
+
+
+TF2 = T.TypeVar("TF2", bound=T.Callable)
+
+
+class Guard(T.Generic[TF2]):
+    def __init__(
+            self,
+            func: TF2,
+            desc: T.Optional[Description] = None,
+            check_inputs: bool = True,
+            check_outputs: bool = True,
+            check_side_effect: bool = False,
+            check_type: bool = True,
+            check_range: bool = True,
+            ) -> None:
+        self.func = func
+        functools.update_wrapper(self, func)
+        if desc is None:
+            desc = parse_func(func)
+        self.desc = desc
+        self.is_check_type = check_type
+        self.is_check_range = check_range
+        self.is_check_side_effect = check_side_effect
+        self.is_check_inputs = check_inputs
+        self.is_check_outputs = check_outputs
+
+    def __call__(self, *args, **kwargs):
+        pass_in = self.desc.parse_pass_in(args, kwargs)
+        errors = []
+        if self.is_check_inputs:
+            self.check_inputs(pass_in, errors)
+        if self.is_check_side_effect:
+            self.check_side_effects_before_run(
+                pass_in, errors)
+        res = self.func(*args, **kwargs)
+        if self.is_check_outputs:
+            self.check_outputs(res, errors)
+        if self.is_check_side_effect:
+            self.check_side_effects_after_run(
+                pass_in, res, errors)
+        return res
+
+    def check_inputs(self, pass_in: dict, errors: list):
+        for val in self.desc.inputs:
+            self.check_value(val, pass_in[val.name], errors)
+        if len(errors) > 0:
+            raise CheckError(errors)
+
+    def check_outputs(self, res: T.Union[T.Any, T.Tuple], errors: list):
+        if isinstance(res, tuple):
+            if len(res) != len(self.desc.outputs):
+                raise CheckError(
+                    f"Output num({len(res)}) not match the"
+                    f" description outputs num({len(self.desc.outputs)})"
+                )
+            for idx, val in enumerate(self.desc.outputs):
+                self.check_value(val, res[idx], errors)
+        else:
+            if len(self.desc.outputs) != 1:
+                raise CheckError(
+                    "Output num(1) not match the"
+                    f" description outputs num({len(self.desc.outputs)})"
+                )
+            val = self.desc.outputs[0]
+            self.check_value(val, res, errors)
+        if len(errors) > 0:
+            raise CheckError(errors)
+
+    def check_value(
+            self,
+            arg: Value,
+            val: T.Any,
+            errors: T.List[Exception]):
+        try:
+            if self.is_check_type:
+                arg.check_type(val)
+            if self.is_check_range:
+                arg.check_range(val)
+        except Exception as e:
+            errors.append(e)
+
+    def get_input_dict(self, pass_in: dict) -> dict:
+        in_dict: T.Dict[T.Union[int, str], T.Any] = {}
+        for i, v in enumerate(self.desc.inputs):
+            in_dict[i] = pass_in[v.name]
+            in_dict[v.name or "?"] = pass_in[v.name]
+        return in_dict
+
+    def get_output_dict(self, res: T.Union[tuple, T.Any]) -> dict:
+        rtn_dict: T.Dict[T.Union[int, str], T.Any]
+        if self.is_check_outputs:
+            if isinstance(res, tuple):
+                rtn_dict = {}
+                for i, v in enumerate(self.desc.outputs):
+                    rtn_dict[i] = res[i]
+                    rtn_dict[v.name or "?"] = res[i]
+            else:
+                rtn_dict = {
+                    self.desc.outputs[0].name or "?": res,
+                    0: res,
+                }
+        else:
+            rtn_dict = {}
+        return rtn_dict
+
+    def check_side_effects_before_run(
+            self, pass_in: dict, errors: list):
+        if len(self.desc.side_effects) == 0:
+            return
+        in_dict = self.get_input_dict(pass_in)
+        for e in self.desc.side_effects:
+            if not e.check_before_run(in_dict):
+                err = SideEffectError(
+                    "Error occured when check "
+                    f"side effect(before run): {self.func}"
+                )
+                errors.append(err)
+        if len(errors) > 0:
+            raise CheckError(errors)
+
+    def check_side_effects_after_run(
+            self, pass_in: dict,
+            res: T.Union[tuple, T.Any], errors: list):
+        if len(self.desc.side_effects) == 0:
+            return
+        in_dict = self.get_input_dict(pass_in)
+        rtn_dict = self.get_output_dict(res)
+        for e in self.desc.side_effects:
+            if not e.check_after_run(in_dict, rtn_dict):
+                err = SideEffectError(
+                    "Error occured when check "
+                    f"side effect(after run): {self.func}"
+                )
+                errors.append(err)
+        if len(errors) > 0:
+            raise CheckError(errors)
+
+    def __get__(self, obj, objtype):
+        """Allow use on instance method."""
+        if not hasattr(self, "_bounded"):  # bound only once
+            target_func = self.func
+            bound_mth = types.MethodType(target_func, obj)
+            self.func = bound_mth
+            self.desc.inputs.pop(0)
+            self._bounded = True
+        return self
+
+
+def make_guard(
+        func: T.Optional[TF2] = None,
+        *,
+        check_inputs: bool = True,
+        check_outputs: bool = True,
+        check_side_effect: bool = False,
+        check_type: bool = True,
+        check_range: bool = True,
+        ) -> TF2:
+    kwargs = {
+        "check_inputs": check_inputs,
+        "check_outputs": check_outputs,
+        "check_side_effect": check_side_effect,
+        "check_type": check_type,
+        "check_range": check_range,
+    }
+    if func is None:
+        return functools.partial(make_guard, **kwargs)  # type: ignore
+    return Guard(func, **kwargs)  # type: ignore

--- a/funcdesc/mark.py
+++ b/funcdesc/mark.py
@@ -1,0 +1,148 @@
+import typing as T
+import inspect
+
+from .desc import Value, _NotDef, NotDef, T1, SideEffect
+from .utils.misc import CreateByGetItem
+
+
+Val = Value
+
+
+class Outputs(metaclass=CreateByGetItem):
+    def __new__(
+            cls,
+            *outputs,
+            ):
+        return list(outputs)
+
+
+FUNC_MARK_STORE_KEY = "_funcdesc_marks"
+
+
+class FuncMarks():
+    def __init__(self) -> None:
+        self.input_marks: T.Dict[T.Union[str, int], T.Dict] = dict()
+        self.output_marks: T.Dict[T.Union[str, int], T.Dict] = dict()
+        self.side_effect_marks: T.List[SideEffect] = []
+
+
+TF1 = T.TypeVar("TF1")
+
+
+def _mark_val_factory(store_key: T.Literal["input", "output"]):
+    def add_when_not_default(dict_, key, val, default):
+        if val != default:
+            dict_[key] = val
+
+    def mark_val(
+            pos_or_name: T.Union[int, str],
+            *,
+            type: T.Optional[T.Type[T1]] = None,
+            range: T.Optional[T.Any] = None,
+            default: T.Union[_NotDef, T1] = NotDef,
+            name: T.Optional[str] = None,
+            doc: T.Optional[str] = None,
+            **attrs) -> T.Callable[[TF1], TF1]:
+
+        store = {}
+        store['attrs'] = attrs
+        add_when_not_default(store, "type", type, None)
+        add_when_not_default(store, "range", range, None)
+        add_when_not_default(store, "default", default, NotDef)
+        add_when_not_default(store, "name", name, None)
+        add_when_not_default(store, "doc", doc, None)
+
+        def wrap(func: TF1) -> TF1:
+            func.__dict__.setdefault(FUNC_MARK_STORE_KEY, FuncMarks())
+            marks: FuncMarks = func.__dict__[FUNC_MARK_STORE_KEY]
+            if store_key == "input":
+                marks.input_marks[pos_or_name] = store
+            else:
+                marks.output_marks[pos_or_name] = store
+            return func
+        return wrap
+
+    return mark_val
+
+
+mark_input = _mark_val_factory("input")
+mark_output = _mark_val_factory("output")
+
+
+def mark_side_effect(side_effect: SideEffect):
+
+    def wrap(func: T.Callable) -> T.Callable:
+        func.__dict__.setdefault(FUNC_MARK_STORE_KEY, FuncMarks())
+        marks: FuncMarks = func.__dict__[FUNC_MARK_STORE_KEY]
+        marks.side_effect_marks.append(side_effect)
+        return func
+
+    return wrap
+
+
+PARAM_TYPE = T.Union[
+    str,
+    T.Tuple[str, T.Type],
+    T.Tuple[str, T.Type, T.Any]
+]
+
+
+def sign_parameters(
+        *params: PARAM_TYPE,
+        ) -> T.Callable[[T.Callable], T.Callable]:
+    """Change the parameters signature of a function."""
+    def wrap(func: T.Callable) -> T.Callable:
+        sig = inspect.signature(func)
+        new_params = []
+        for param in params:
+            if isinstance(param, str):
+                new_params.append(
+                    inspect.Parameter(
+                        param,
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    )
+                )
+            elif len(param) == 2:
+                name, type_ = param  # type: ignore
+                new_params.append(
+                    inspect.Parameter(
+                        name,
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=type_,
+                    )
+                )
+            else:
+                name, type_, default = param  # type: ignore
+                new_params.append(
+                    inspect.Parameter(
+                        name,
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=type_,
+                        default=default,
+                    )
+                )
+        func.__signature__ = sig.replace(parameters=new_params)  # type: ignore
+        return func
+    return wrap
+
+
+def sign_return(
+        type_: T.Optional[T.Type] = None,
+        ) -> T.Callable[[T.Callable], T.Callable]:
+    """Change the return type signature of a function."""
+    def wrap(func: T.Callable) -> T.Callable:
+        sig = inspect.signature(func)
+        func.__signature__ = sig.replace(   # type: ignore
+            return_annotation=type_)
+        return func
+    return wrap
+
+
+def copy_signature(
+        from_func: T.Callable,
+        ) -> T.Callable[[T.Callable], T.Callable]:
+    """Copy the signature of a function to another function."""
+    def wrap(func: T.Callable) -> T.Callable:
+        func.__signature__ = inspect.signature(from_func)  # type: ignore
+        return func
+    return wrap

--- a/funcdesc/parse.py
+++ b/funcdesc/parse.py
@@ -1,0 +1,153 @@
+import types
+import typing as T
+import inspect
+
+from .desc import Description, Value
+from .mark import FUNC_MARK_STORE_KEY, FuncMarks
+
+
+def _update_val_by_marks(
+        mark_idx: int, name: str,
+        marks: T.Dict, val: Value
+        ):
+    if mark_idx in marks:
+        store = marks[mark_idx].copy()
+    elif name in marks:
+        store = marks[name].copy()
+    else:
+        store = None
+
+    if store is not None:
+        val.kwargs.update(store.pop("attrs"))
+        val.__dict__.update(store)
+
+
+def parse_func_inputs(
+        sig: inspect.Signature,
+        is_method: bool,
+        marks: T.Dict[T.Union[int, str], dict],
+        ) -> T.List[Value]:
+    inputs = []
+    for idx, (name, param) in enumerate(sig.parameters.items()):
+        ann = param.annotation
+        if isinstance(ann, Value):
+            val = ann
+        elif ann is inspect._empty:
+            val = Value(None)
+        else:
+            val = Value(ann)
+
+        val.name = name
+
+        # set default value
+        if param.default is not inspect._empty:
+            val.default = param.default
+
+        # update by marks
+        mark_idx = idx + 1 if is_method else idx
+        _update_val_by_marks(mark_idx, name, marks, val)
+
+        inputs.append(val)
+    return inputs
+
+
+def marks_to_outputs(marks):
+    outputs = []
+    if len(marks) == 0:
+        val = Value(type(None))
+        outputs.append(val)
+    else:
+        marks_keys = list(marks.keys())
+        if all([isinstance(k, int) for k in marks_keys]):
+            for _ in range(max(marks_keys) + 1):  # type: ignore
+                val = Value(type(None))
+                outputs.append(val)
+        elif (len(marks) == 1) and isinstance(marks_keys[0], str):
+            val = Value(type(None), name=marks_keys[0])
+            outputs.append(val)
+        else:
+            raise ValueError(
+                f"Invalid marks keys: {marks_keys},"
+                " the keys should be all int or single str."
+            )
+    return outputs
+
+
+def parse_func_outputs(
+        sig: inspect.Signature,
+        marks: T.Dict[T.Union[int, str], dict]
+        ) -> T.List[Value]:
+    outputs = []
+    ret = sig.return_annotation
+
+    def to_val(o):
+        return o if isinstance(o, Value) else Value(o)
+
+    val: Value
+    if ret is inspect._empty:
+        outputs.extend(marks_to_outputs(marks))
+    elif isinstance(ret, Value):
+        outputs.append(ret)
+    elif isinstance(ret, list):
+        outputs.extend([to_val(o) for o in ret])
+    elif T.get_origin(ret) is tuple:
+        outputs.extend([to_val(o) for o in ret.__args__])
+    else:
+        val = Value(ret)
+        outputs.append(val)
+
+    # update by marks
+    for idx, val in enumerate(outputs):
+        if val.name is None:
+            val.name = f"output_{idx}"
+        _update_val_by_marks(idx, val.name, marks, val)
+    return outputs
+
+
+def update_using_docstring(desc: Description, docstring: str):
+    import docstring_parser
+    doc = docstring_parser.parse(docstring)
+    for i, val in enumerate(desc.inputs):
+        if val.doc is None:
+            val.doc = doc.params[i].description
+        if val.type is None:
+            val.type = eval(doc.params[i].type_name or "None")
+    if doc.returns is not None:
+        for i, val in enumerate(desc.outputs):
+            if val.doc is None:
+                val.doc = doc.returns.description
+            if val.type is type(None):
+                val.type = eval(doc.returns.type_name or "None")
+
+
+def parse_func(
+        func: T.Callable,
+        update_by_docstring: bool = False
+        ) -> Description:
+    """Parse the function and return a Description object."""
+    sig = inspect.signature(func)
+    is_method = isinstance(func, types.MethodType)
+    func_marks: T.Optional[FuncMarks] = func.__dict__.get(FUNC_MARK_STORE_KEY)
+    desc = parse_signature(sig, is_method, func_marks)
+    if update_by_docstring:
+        update_using_docstring(desc, func.__doc__ or "")
+    desc.name = func.__name__
+    desc.doc = func.__doc__
+    return desc
+
+
+def parse_signature(
+        sig: inspect.Signature,
+        is_method: bool = False,
+        func_marks: T.Optional[FuncMarks] = None
+        ) -> Description:
+    """Parse the function signature and return a Description object."""
+    if func_marks is None:
+        func_marks = FuncMarks()
+    desc = Description()
+    inputs = parse_func_inputs(sig, is_method, func_marks.input_marks)
+    desc.inputs = inputs
+    outputs = parse_func_outputs(sig, func_marks.output_marks)
+    desc.outputs = outputs
+    desc.side_effects = func_marks.side_effect_marks
+    return desc

--- a/funcdesc/pydantic.py
+++ b/funcdesc/pydantic.py
@@ -1,0 +1,35 @@
+import typing as T
+
+from .desc import Description, Value, NotDef
+from .parse import parse_func
+
+from pydantic import create_model, Field
+
+
+def value_to_field(value: Value):
+    kwargs = {
+        "description": value.doc,
+    }
+    if value.default is not NotDef:
+        kwargs["default"] = value.default  # type: ignore
+    field = Field(**kwargs)  # type: ignore
+    return field
+
+
+def desc_to_pydantic(description: Description) -> dict:
+    res = {}
+    for _tp in ("inputs", "outputs"):
+        fields = {}
+        for val in getattr(description, _tp):
+            field = value_to_field(val)
+            fields[val.name] = (val.type, field)
+        res[_tp] = create_model(  # type: ignore
+            description.name or _tp,
+            **fields
+        )
+    return res
+
+
+def parse_func_pydantic(func: T.Callable) -> dict:
+    desc = parse_func(func)
+    return desc_to_pydantic(desc)

--- a/funcdesc/types/__init__.py
+++ b/funcdesc/types/__init__.py
@@ -1,0 +1,11 @@
+from .value import (
+    OneOf, SubSet, InputPath, OutputPath,
+)
+from .side_effects import (
+    WriteFile,
+)
+
+__all__ = [
+    "OneOf", "SubSet", "InputPath", "OutputPath",
+    "WriteFile",
+]

--- a/funcdesc/types/side_effects.py
+++ b/funcdesc/types/side_effects.py
@@ -1,0 +1,26 @@
+import re
+from pathlib import Path
+
+from ..desc import SideEffect
+
+
+class WriteFile(SideEffect):
+    def __init__(self, path_template: str):
+        self.path_template = path_template
+
+    @property
+    def description(self) -> str:
+        return f"Write file to {self.path_template}"
+
+    def check_before_run(self, inputs: dict) -> bool:
+        if re.match(r"\{outputs.*?\}", self.path_template):
+            return True
+        path = self.path_template.format(inputs=inputs)
+        path_obj = Path(path)
+        return not path_obj.exists()
+
+    def check_after_run(self, inputs: dict, outputs: dict) -> bool:
+        path = self.path_template.format(
+            inputs=inputs, outputs=outputs)
+        path_obj = Path(path)
+        return path_obj.exists()

--- a/funcdesc/types/value.py
+++ b/funcdesc/types/value.py
@@ -1,0 +1,61 @@
+import typing as T
+from pathlib import Path
+
+from ..desc import Value
+
+
+class ValueType(object):
+    """The base custom value type, for
+    custom type and range checking.
+
+    Sub-class should override the `check_type` or
+    `check_range` method.
+    """
+    @staticmethod
+    def check_type(val: T.Any, type_: T.Type) -> bool:
+        return True
+
+    @staticmethod
+    def check_range(val: T.Any, range_: T.Any) -> bool:
+        return True
+
+
+class OneOf(ValueType):
+    """Input value should be equal to at least one elements in `range`"""
+    @staticmethod
+    def check_range(val, range_):
+        return val in range_
+
+
+class SubSet(ValueType):
+    """Input value should be a subset of `range`"""
+    @staticmethod
+    def check_range(val, range_):
+        return all([v in range_ for v in val])
+
+
+class InputPath(ValueType):
+    """Input value should be a file path,
+    and the file should be exist."""
+    @staticmethod
+    def check_type(val, type_):
+        return isinstance(val, str) or isinstance(val, Path)
+
+    @staticmethod
+    def check_range(val, range_):
+        path = Path(val) if isinstance(val, str) else val
+        return path.exists()
+
+
+class OutputPath(ValueType):
+    """Input value should be a file path. """
+    @staticmethod
+    def check_type(val, type_):
+        return isinstance(val, str) or isinstance(val, Path)
+
+
+Value.register_range_check(OneOf, OneOf.check_range)
+Value.register_range_check(SubSet, SubSet.check_range)
+Value.register_type_check(InputPath, InputPath.check_type)
+Value.register_range_check(InputPath, InputPath.check_range)
+Value.register_type_check(OutputPath, OutputPath.check_type)

--- a/funcdesc/utils/json.py
+++ b/funcdesc/utils/json.py
@@ -1,0 +1,130 @@
+import types
+import typing as T
+import warnings
+import json
+
+if T.TYPE_CHECKING:  # pragma: no cover
+    from ..desc import Value, SideEffect, Description
+
+
+NoneType = type(None)
+
+
+class DescriptionJSONEncoder(json.JSONEncoder):
+    def default(self, o: T.Any) -> T.Any:
+        from ..desc import Description, Value, SideEffect, _NotDef
+        if isinstance(o, Description):
+            return {
+                "inputs": [self.default(v) for v in o.inputs],
+                "outputs": [self.default(v) for v in o.outputs],
+                "side_effects": [self.default(v) for v in o.side_effects],
+                "name": o.name,
+                "doc": o.doc,
+            }
+        elif isinstance(o, Value):
+            if o.type is None:
+                t = None
+            elif isinstance(o.type, str):
+                t = o.type
+            elif o.type.__module__ == "typing":
+                t = str(o.type)
+            elif isinstance(
+                    o.type, (T.GenericAlias, types.UnionType)):  # type: ignore
+                t = str(o.type)
+            else:
+                t = o.type.__name__
+            d: str | object
+            if isinstance(o.default, _NotDef):
+                d = "not_defined"
+            else:
+                d = o.default
+            return {
+                "type": t,
+                "range": o.range,
+                "default": d,
+                "name": o.name,
+                "doc": o.doc,
+            }
+        elif isinstance(o, SideEffect):
+            return {
+                "description": o.description,
+            }
+        else:
+            return super().default(o)
+
+
+class DescriptionJSONDecoder(json.JSONDecoder):
+    def decode_value(
+            self,
+            v: T.Dict[str, T.Any],
+            env: T.Optional[T.Dict[str, T.Any]] = None
+            ) -> "Value":
+        from ..desc import Value, NotDef
+        import typing
+
+        # fill the missing values with default values
+        v['type'] = v.get('type', None)
+        v['range'] = v.get('range', None)
+        v['default'] = v.get('default', NotDef)
+        v['name'] = v.get('name', None)
+        v['doc'] = v.get('doc', None)
+
+        if env is not None:
+            env["typing"] = typing
+
+        if isinstance(v["type"], str):
+            try:
+                t = eval(v["type"], env)
+            except NameError:
+                warnings.warn(
+                    f"Failed to eval type {v['type']}, "
+                    "using the original string as type."
+                )
+                t = v["type"]
+        else:
+            t = v["type"]
+
+        r = v["range"]
+
+        if v["default"] == "not_defined":
+            d = NotDef
+        else:
+            d = v["default"]
+        value = Value(
+            type_=t,
+            range_=r,
+            default=d,
+            name=v["name"],
+            doc=v["doc"],
+        )
+        return value
+
+    def decode_side_effect(
+            self, v: T.Dict[str, T.Any]) -> "SideEffect":
+        from ..desc import SideEffect
+        return SideEffect(**v)
+
+    def decode_description(
+            self,
+            jdict: T.Dict[str, T.Any],
+            env: T.Optional[T.Dict[str, T.Any]] = None
+            ) -> "Description":
+        from ..desc import Description
+        desc = Description()
+        desc.name = jdict["name"]
+        desc.doc = jdict.get("doc", "")
+        desc.inputs = [
+            self.decode_value(v, env) for v in jdict.get("inputs", [])
+        ]
+        desc.outputs = [
+            self.decode_value(v, env) for v in jdict.get("outputs", [])
+        ]
+        desc.side_effects = [
+            self.decode_side_effect(v) for v in jdict.get("side_effects", [])
+        ]
+        return desc
+
+    def decode(self, *args, **kwargs) -> T.Any:
+        s = args[0]
+        jdict = super().decode(s)
+        return self.decode_description(jdict, **kwargs)

--- a/funcdesc/utils/misc.py
+++ b/funcdesc/utils/misc.py
@@ -1,0 +1,7 @@
+
+class CreateByGetItem(type):
+    def __getitem__(self, args):
+        if isinstance(args, tuple):
+            return self(*args)
+        else:
+            return self(args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,17 @@ dependencies = [
     # Core
     "tomli>=2.0.1; python_version < '3.11'",
     "diff-match-patch>=20241021",
-    "executor-engine>=0.3.3",
     "fire>=0.7.0",
-    "funcdesc>=0.1.8",
+    # executor-engine, funcdesc and cmd2func are VENDORED in-tree at the repo root
+    # (./executor, ./funcdesc, ./cmd2func) instead of being pulled from PyPI: their
+    # PyPI releases were removed after the maintainer's account was compromised in the
+    # June 2026 "Hades" supply-chain attack (the GitHub sources are clean). The four
+    # deps below are their runtime requirements, listed explicitly because vendoring
+    # bypasses these packages' own dependency resolution.
+    "loky",
+    "fastavro",
+    "tokenizers",
+    "pyyaml",
     "anthropic>=0.40.0",
     "google-genai>=1.0.0",
     "loguru>=0.7.3",


### PR DESCRIPTION
## Why
The maintainer's PyPI account was compromised in the June 2026 "Hades" supply-chain attack. PyPI releases **pantheon-agents 0.6.1 / 0.6.2 are trojanized**, and three helper deps (`executor-engine`, `funcdesc`, `cmd2func`) were removed from PyPI — which breaks `pip install pantheon-agents` for everyone.

## What
- Vendor `executor/`, `funcdesc/`, `cmd2func/` in-tree at the repo root (GitHub sources are clean; setuptools `find` auto-includes them).
- Drop `executor-engine` + `funcdesc` from PyPI dependencies; add their runtime deps (`loky`, `fastavro`, `tokenizers`, `pyyaml`).
- README: add a security warning and switch install instructions to the GitHub source.

## Verification
A wheel built from a clean checkout includes `pantheon/`, `executor/engine/`, `cmd2func/`, `funcdesc/`, and they import with only the declared deps. `pip install git+https://github.com/aristoteleo/PantheonOS.git` now works without the removed PyPI packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)