### PR TITLE
store: bioSkills/SciAgent sources + references, auto-versioning, dep-install, dedup

### DIFF
--- a/pantheon/store/seed.py
+++ b/pantheon/store/seed.py
@@ -93,6 +93,25 @@ EXTERNAL_REPOS = {
         "source_url": "https://github.com/Starlitnightly/omicclaw",
         "has_categories": False,
     },
+    "bioskills": {
+        # GPTomics/bioSkills — 540+ SKILL.md across 60+ bioinformatics categories (MIT).
+        # Category folders live at the REPO ROOT (e.g. differential-expression/, chip-seq/),
+        # so skills_dir is "." : <category>/<skill-name>/SKILL.md.
+        "url": "https://github.com/GPTomics/bioSkills.git",
+        "skills_dir": ".",
+        "display_name": "bioSkills",
+        "source_url": "https://github.com/GPTomics/bioSkills",
+        "has_categories": True,
+    },
+    "sciagent": {
+        # jaechang-hits/SciAgent-Skills — ~197 skills (CC-BY-4.0); 92% on BixBench-Verified-50.
+        # Curated skills under skills/<category>/<skill-name>/SKILL.md (legacy/ is excluded).
+        "url": "https://github.com/jaechang-hits/SciAgent-Skills.git",
+        "skills_dir": "skills",
+        "display_name": "SciAgent-Skills",
+        "source_url": "https://github.com/jaechang-hits/SciAgent-Skills",
+        "has_categories": True,
+    },
 }
 
 


### PR DESCRIPTION
Store-side enhancements to the seed + CLI (`pantheon/store/{seed,cli,client}.py`).

## What
| Area | Change |
|---|---|
| **External sources** | Add **bioSkills** (GPTomics, MIT, ~537 skills) and **SciAgent-Skills** (jaechang-hits, CC-BY, ~197) to `EXTERNAL_REPOS` |
| **Skill references** | Extract cross-references at ingest (relative `[x](./a/SKILL.md)` links + `## Related Skills` name lists), resolve to exact store names, thread through publish |
| **Dependency install** | `pantheon store install <pkg>` now installs the reference closure (root + referenced skills); `--deps=False` / `--nodeps` to opt out |
| **Auto-versioning** | Re-seeding an existing package publishes a **new patch version when content changed** (was a no-op skip) → real content sync + version history |
| **Collision handling** | Two different skills with the same `name:` frontmatter (e.g. OpenClaw `pptx` + `pptx-official`): exact dups dropped, same-name-different skills disambiguated (`..._pptx`, `..._pptx-2`) so each keeps a distinct id |

## Verification (local hub)
- Seed: bioSkills 537 + SciAgent 197 ingested; 398 packages carry references (1416 edges).
- Re-seed unchanged → 0 published / 0 updated / all skipped. Changed → new `1.0.x` version.
- `install omics_group` → root + 44 referenced skills. Collisions → 0 remaining duplicate names; `pptx-official` preserved as a distinct id.

Companion PRs: pantheon-hub (references/graph/version API), pantheon-ui (store UI + relationship graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)