### PR TITLE
Per-task output folders + decision-point gating, reliability fixes (v0.6.3)

### DIFF
--- a/pantheon/__init__.py
+++ b/pantheon/__init__.py
@@ -28,4 +28,4 @@ logging.getLogger("mcp").setLevel(logging.WARNING)
 logging.getLogger("mcp.server").setLevel(logging.WARNING)
 logging.getLogger("mcp.server.lowlevel.server").setLevel(logging.WARNING)
 
-__version__ = "0.6.0"
+__version__ = "0.6.3"

--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -2985,7 +2985,10 @@ class ChatRoom(ToolSet):
             context_variables = context_variables or {}
             context_variables["image_output_dir"] = image_output_path
 
-        # Pre-snapshot: only scan the designated image output directory
+        # Pre-snapshot: only scan the dedicated quick-preview dir (.pantheon/images).
+        # Deliverable figures are surfaced via the Output panel — register_output plus
+        # the live preview of the task's declared output_dir — NOT this inline channel,
+        # which exists mainly for claw channels that have no Output panel.
         pre_image_snapshot = snapshot_images(image_output_path) if image_output_path else {}
 
         # Expose the chat id to tools. `client_id` in the tool context is the
@@ -3058,8 +3061,8 @@ class ChatRoom(ToolSet):
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
 
-            # Post-execution image detection: scan the designated image
-            # output directory for any newly created images.
+            # Post-execution image detection: scan the quick-preview dir for images
+            # created during this run and push them inline (mainly for claw channels).
             if image_output_path and pre_image_snapshot is not None:
                 post_image_snapshot = snapshot_images(image_output_path)
                 new_image_paths = diff_snapshots(pre_image_snapshot, post_image_snapshot)

--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -373,6 +373,48 @@ class ChatRoom(ToolSet):
             logger.debug(f"[multi-project] resolve endpoint for active project: {e}")
         return None
 
+    async def _project_dir_for_chat(self, session_id: str | None) -> str | None:
+        """Resolve a chat's PROJECT ROOT directory (workspace root) — the dir its
+        files, task brain, and image outputs should all live under.
+
+        Mirrors _resolve_endpoint_for_chat's routing but returns the directory
+        (no endpoint spawn), and — unlike that method — resolves home chats to the
+        home dir too, so the brain/prompt are ALWAYS anchored to a concrete project
+        instead of silently falling back to the global default brain dir.
+
+        Priority: (1) the chat's explicit workspace_path, else (2) the project that
+        owns the chat's memory, else (3) the active project, else (4) home."""
+        if session_id:
+            try:
+                memory = await run_func(self.memory_manager.get_memory, session_id)
+                project = memory.extra_data.get("project", {})
+                if isinstance(project, dict):
+                    wpath = project.get("workspace_path")
+                    if wpath and Path(wpath).is_dir():
+                        return str(Path(wpath).resolve())
+            except Exception as e:
+                logger.debug(f"[multi-project] project dir (workspace_path) for {session_id}: {e}")
+            try:
+                mdir = self.memory_manager.mgr_for_chat(session_id).path
+                pdir = Path(mdir).parent.parent
+                if pdir.is_dir():
+                    return str(pdir.resolve())
+            except Exception as e:
+                logger.debug(f"[multi-project] project dir (memory) for {session_id}: {e}")
+        try:
+            active = self.project_manager.active_project
+            if active and active.path and Path(active.path).is_dir():
+                return str(Path(active.path).resolve())
+        except Exception:
+            pass
+        try:
+            home = self.project_manager.default_project
+            if home and home.path and Path(home.path).is_dir():
+                return str(Path(home.path).resolve())
+        except Exception:
+            pass
+        return None
+
     async def _shutdown_project_endpoints(self):
         """Terminate all per-project endpoint subprocesses (cleanup)."""
         for _path, entry in list(self._project_endpoints.items()):
@@ -937,6 +979,12 @@ class ChatRoom(ToolSet):
             agents=all_agents,
             plugins=plugins,
         )
+        # Anchor the task/brain prompt to this chat's project root (TaskSystemPlugin
+        # reads team._project_dir in on_team_created, which runs inside async_setup).
+        try:
+            team._project_dir = await self._project_dir_for_chat(chat_id)
+        except Exception as e:
+            logger.debug(f"[multi-project] team project dir for {chat_id}: {e}")
         setup_t0 = time.perf_counter()
         await team.async_setup()
         log_startup_profile(
@@ -1269,7 +1317,12 @@ class ChatRoom(ToolSet):
             if self._endpoint_embed and not self._embedded_endpoint_ready():
                 return self._endpoint_not_ready_response()
 
-            # Inject workdir from project metadata if session is in isolated mode
+            # Steer the ENDPOINT toolset's cwd via `workdir` (isolated → workspace_path;
+            # project → clear so the endpoint falls back to its own project path). This
+            # mutates the SHARED per-task context, so it ONLY governs endpoint-side cwd.
+            # The LOCAL task toolset's brain/output anchor is `project_root` (set once in
+            # chat()), which we deliberately never touch here — popping workdir below must
+            # not relocate the brain.
             session_id = (args or {}).get("session_id") or getattr(self, '_current_chat_id', None)
             # Special '__global__' session_id: explicitly use project root (clear any workdir)
             if session_id == '__global__':
@@ -1696,16 +1749,20 @@ class ChatRoom(ToolSet):
                 team_template = extra_data.get("team_template", None)
 
                 # UI busy flag = main agent loop active OR an in-flight background
-                # task (which outlives the loop). Response-only OR — does not touch
-                # the persisted "running" flag; chat()'s busy-guard keys off
-                # self.threads, not this. Lets the sidebar / project-switcher keep
-                # showing background work after the agent turn returns.
+                # task (which outlives the loop). The persisted "running" flag is
+                # only trusted when the chat actually has a LIVE thread — otherwise a
+                # run that was killed mid-flight (e.g. a backend restart, which never
+                # runs the completion reset) leaves "running": true on disk and the
+                # sidebar shows a phantom spinner on a cold start. self.threads is
+                # empty right after startup, so a stale flag resolves to not-running
+                # immediately instead of waiting for the list_running_chats poll.
                 bg_running = self._chat_has_running_bg_tasks(id)
+                main_running = bool(extra_data.get("running", False)) and id in self.threads
                 chats.append(
                     {
                         "id": id,
                         "name": item["name"],
-                        "running": bool(extra_data.get("running", False)) or bg_running,
+                        "running": main_running or bg_running,
                         "has_background_tasks": bg_running,
                         "last_activity_date": extra_data.get(
                             "last_activity_date", None
@@ -2895,16 +2952,24 @@ class ChatRoom(ToolSet):
         team = await self.get_team_for_chat(chat_id)
         self._setup_bg_auto_notify(chat_id, team)
 
-        # Inject workdir from project metadata if in isolated mode
+        # Anchor the run to THIS chat's project root (workspace root) so the task
+        # brain, image output, and file tools all live under it — never the global
+        # home. Previously workdir was set ONLY for "isolated" chats with an
+        # explicit workspace_path; a "project"-mode chat (no workspace_path) left
+        # workdir empty, so the task brain fell back to the global brain dir and the
+        # agent saw home paths and wrote files into the wrong project.
         project = memory.extra_data.get("project", {})
-        workspace_path = None
-        if isinstance(project, dict):
-            workspace_mode = project.get("workspace_mode",
-                "isolated" if project.get("workspace_path") else "project")
-            workspace_path = project.get("workspace_path")
-            if workspace_mode == "isolated" and workspace_path:
-                context_variables = context_variables or {}
-                context_variables["workdir"] = workspace_path
+        workspace_path = project.get("workspace_path") if isinstance(project, dict) else None
+        project_dir = await self._project_dir_for_chat(chat_id)
+        if project_dir:
+            context_variables = context_variables or {}
+            context_variables["workdir"] = project_dir
+            # `project_root` is the IMMUTABLE anchor for this chat's project. Unlike
+            # `workdir` — which proxy_toolset pops/overwrites per endpoint-toolset
+            # call to steer the endpoint's cwd — `project_root` is never mutated, so
+            # LOCAL toolsets (task brain, register_output) always resolve to the
+            # right project instead of silently falling back to the global home.
+            context_variables["project_root"] = project_dir
 
         # Set up a designated image output directory so agents save images
         # to a known location and claw channels can detect them cheaply.
@@ -2912,9 +2977,10 @@ class ChatRoom(ToolSet):
             IMAGE_OUTPUT_DIR, snapshot_images, diff_snapshots, encode_images_to_uris,
         )
         image_output_path: str | None = None
-        if workspace_path:
+        img_root = project_dir or workspace_path
+        if img_root:
             import os
-            image_output_path = os.path.join(workspace_path, IMAGE_OUTPUT_DIR)
+            image_output_path = os.path.join(img_root, IMAGE_OUTPUT_DIR)
             os.makedirs(image_output_path, exist_ok=True)
             context_variables = context_variables or {}
             context_variables["image_output_dir"] = image_output_path

--- a/pantheon/endpoint/toolset_proxy.py
+++ b/pantheon/endpoint/toolset_proxy.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Any, Union
 from enum import Enum
 
 from pantheon.utils.log import logger
+from pantheon.utils.misc import wire_safe_tool_args
 
 if TYPE_CHECKING:
     from pantheon.remote import RemoteService
@@ -254,22 +255,25 @@ class ToolsetProxy:
                 method_name=method_name, args=args, toolset_name=self.toolset_name
             )
         elif self.mode == ProxyMode.ENDPOINT_ID:
-            # Remote invoke through endpoint service
+            # Remote invoke through endpoint service. The payload is cloudpickled
+            # over the wire, so strip agent-internal live closures (see
+            # wire_safe_tool_args) that would otherwise raise
+            # "cannot pickle '_asyncio.Future'/'_asyncio.Task' object".
             if not self.service:
                 raise ValueError("service is None for ENDPOINT_ID mode")
             return await self.service.invoke(
                 "proxy_toolset",
                 {
                     "method_name": method_name,
-                    "args": args,
+                    "args": wire_safe_tool_args(args),
                     "toolset_name": self.toolset_name,
                 },
             )
         else:  # TOOLSET_ID
-            # Direct invoke to toolset (bypass endpoint)
+            # Direct invoke to toolset (bypass endpoint) — also cloudpickled.
             if not self.service:
                 raise ValueError("service is None for TOOLSET_ID mode")
-            return await self.service.invoke(method_name, args)
+            return await self.service.invoke(method_name, wire_safe_tool_args(args))
 
     async def invoke(self, method_name: str, args: Optional[Dict] = None) -> Dict:
         """Invoke toolset method (simple passthrough, returns result or raises)."""

--- a/pantheon/endpoint/toolsets.py
+++ b/pantheon/endpoint/toolsets.py
@@ -198,12 +198,16 @@ class ToolSetManager:
                     )
                     return await self._execute_local_method(method, args)
             else:
-                # REMOTE mode: call via remote service
+                # REMOTE mode: call via remote service. Args are cloudpickled over
+                # the wire to the toolset subprocess, so strip agent-internal live
+                # closures (wire_safe_tool_args) that capture the in-process Agent's
+                # asyncio Future/Task and would raise "cannot pickle ... object".
                 logger.debug(f"Using REMOTE mode for {toolset_name}")
                 from pantheon.remote import connect_remote
+                from pantheon.utils.misc import wire_safe_tool_args
 
                 toolset_service = await connect_remote(service_info["id"])
-                return await toolset_service.invoke(method_name, args)
+                return await toolset_service.invoke(method_name, wire_safe_tool_args(args))
 
         except Exception as e:
             logger.error(f"Error calling {method_name} on {toolset_name}: {e}")

--- a/pantheon/factory/templates/prompts/agentic_general.md
+++ b/pantheon/factory/templates/prompts/agentic_general.md
@@ -83,7 +83,7 @@ You are in AGENTIC mode.
 **Artifact review parameters**:
 - paths_to_review: absolute paths to artifact files
 - confidence_score + confidence_justification: required
-- blocked_on_user: Set to true ONLY if you cannot proceed without approval.
+- blocked_on_user: Set to true when you genuinely need the user's input before going further — either you truly cannot proceed, OR you are at a consequential, under-specified choice that is theirs to make (see <decision_points>). Do NOT block for choices that are trivial, easily reversible, or already implied by the request.
 </notify_user_tool>
 </agentic_mode_overview>
 ```
@@ -116,8 +116,8 @@ Set mode when calling task_boundary: PLANNING, EXECUTION, or REVIEW.
 
 
 **PLANNING**: Analyze the request, gather context, and design your approach.
-- Always create `plan.md` to document your proposed strategy and steps.
-- If the task is complex or critical, request user review via `notify_user` before proceeding.
+- Create `plan.md` for multi-step or non-trivial tasks (strategy + success criteria); for a simple one-shot task a brief `task.md` is enough — don't over-document.
+- If the request leaves a REAL, consequential choice that is yours to guess (which dataset/method/scope, an expensive or irreversible step), STOP and ask the user via `notify_user` before proceeding. If the path is clear, just proceed — don't ask for pointless confirmation.
 - If user requests changes, stay in PLANNING mode, update `plan.md`, and review again.
 Start with PLANNING mode when beginning a new complex task.
 

--- a/pantheon/factory/templates/skills/live_view/gosling/gosling.md
+++ b/pantheon/factory/templates/skills/live_view/gosling/gosling.md
@@ -104,6 +104,11 @@ traps make this fail (both observed in practice):
   spec below.
 - ❌ giving up and rendering the matrix as a full-resolution Plotly / matplotlib
   heatmap → **not scalable**, the UI lags badly. Don't.
+- ❌ abandoning gosling to hand-roll a raw HiGlass viewer (a custom LiveView app
+  that loads `hglib.min.js` from a CDN). gosling already IS HiGlass + PIXI,
+  correctly wired and bundled; a raw build almost always forgets HiGlass's **PIXI**
+  peer dependency and dies with `hglib is not defined` / `Cannot read properties of
+  undefined (reading 'rgb2hex')`. Use the matrix spec below — not a custom app.
 
 **Default = a genome browser: matrix + gene track.** Don't open a bare matrix.
 Build a **two-track linked view** — the contact **matrix** on top, a **gene

--- a/pantheon/factory/templates/skills/live_view/live-view-app.md
+++ b/pantheon/factory/templates/skills/live_view/live-view-app.md
@@ -15,8 +15,20 @@ When no existing viewer fits, write your own interactive component. With the
 **LiveView SDK** the component is controllable-by-construction: the agent
 drives it and reads it back, with no extra wiring.
 
-Use this for bespoke dashboards, custom plots, tailored data views. For
-heavy domain viewers (spatial omics) prefer the Vitessce skill instead.
+Use this for bespoke dashboards, custom plots, tailored data views. **First
+check the existing viewer skills — a custom build is the last resort, not the
+first move.** In particular:
+
+- **Genomics / genome browser / Hi-C contact matrices → use the `gosling` skill.**
+  Gosling already IS HiGlass + PIXI, correctly wired and bundled. Do NOT hand-roll
+  a raw HiGlass viewer here (a custom app loading `hglib.min.js` from a CDN) — you
+  will forget HiGlass's **PIXI** peer dependency and it dies with `hglib is not
+  defined` / `Cannot read properties of undefined (reading 'rgb2hex')`.
+- **Spatial omics / single-cell / imaging → Vitessce or Viv.**
+- **Structures, MSAs, networks, molecules, classic locus browser → Mol\*, MSA,
+  Cytoscape, RDKit, IGV.**
+
+If one of those fits even roughly, load its skill and use it — don't rebuild it.
 
 ## The golden rule: ONE state path
 

--- a/pantheon/factory/templates/skills/omics/general_data_analysis/SKILL.md
+++ b/pantheon/factory/templates/skills/omics/general_data_analysis/SKILL.md
@@ -2,16 +2,25 @@
 id: general_data_analysis_index
 name: General Data Analysis Skills Index
 description: |
-  General-purpose skills for data analysis infrastructure: environment management,
-  parallel computing, and performance optimization.
-tags: [environment, parallel, performance, conda, gpu]
+  General-purpose skills for data analysis infrastructure: workspace file
+  organization, environment management, parallel computing, and performance.
+tags: [organization, workspace, environment, parallel, performance, conda, gpu]
 ---
 
 # General Data Analysis Skills
 
-Cross-cutting skills for environment setup and computational performance.
+Cross-cutting skills for workspace hygiene, environment setup, and computational
+performance.
 
 ## Available Skills
+
+### Workspace File Organization
+
+Give every analysis task its own descriptively-named folder (notebook, figures,
+data, reports inside it) — never scatter files at the workspace root or dump
+figures into internal dirs.
+
+**Skill file**: [file_organization.md](./file_organization.md)
 
 ### Environment Management
 

--- a/pantheon/factory/templates/skills/omics/general_data_analysis/file_organization.md
+++ b/pantheon/factory/templates/skills/omics/general_data_analysis/file_organization.md
@@ -1,0 +1,103 @@
+---
+id: file_organization
+name: Workspace File Organization
+description: |
+  Keep the workspace tidy: give every analysis task its own descriptively-named
+  folder, with figures / data / reports organized inside it — never scatter
+  files at the workspace root or dump figures into internal dirs.
+tags: [organization, workspace, folders, figures, outputs, hygiene]
+---
+
+# Workspace File Organization
+
+A clean workspace makes results reproducible and browsable. The workspace root
+is shared across many analyses — treat it like a projects directory, not a
+dumping ground. **One analysis task → one self-contained folder.**
+
+> The hard rule is always in your prompt (`<task_brain_dir>`). This skill is the
+> detailed reference: naming, layout, figures, and reuse.
+
+---
+
+## The rule
+
+For each distinct analysis, **first create a dedicated, descriptively-named
+folder** directly under the workspace root, then keep everything that task
+produces inside it.
+
+- ✅ `scatac_pbmc5k/`, `visium_brain_qc/`, `xenium_breast_dea/`
+- ❌ loose files at the root: `analysis.ipynb`, `01_qc.png`, `result.h5ad` …
+- ❌ figures in `.pantheon/images/` (that's an internal preview dir, not a deliverable home)
+- ❌ a generic `outputs/` shared across unrelated analyses
+
+Name the folder for the **analysis + dataset**, lowercase, `snake_case`, no
+spaces. Add a short suffix if you run variants (`..._v2`, `..._macs3`).
+
+**Declare this folder at PLANNING time** via `task_boundary`'s `output_dir`
+(e.g. `output_dir="scatac_pbmc5k"`) — even before it exists. The Output panel
+live-previews it, so the user watches results land as you produce them, before
+you register anything.
+
+---
+
+## Standard layout
+
+```
+<workspace_root>/
+  scatac_pbmc5k/                  ← one folder per analysis task
+    scatac_pbmc5k.ipynb           ← the analysis notebook
+    figures/                      ← all plots/figures for THIS task
+      01_qc_metrics.png
+      02_umap_celltypes.png
+      06_summary_figure.png
+    data/                         ← intermediate + result data
+      pbmc5k_processed.h5ad
+    report.md                     ← optional written summary
+```
+
+Set this up at the start, e.g.:
+
+```python
+import os
+TASK_DIR = "scatac_pbmc5k"
+FIG_DIR  = os.path.join(TASK_DIR, "figures")
+DATA_DIR = os.path.join(TASK_DIR, "data")
+os.makedirs(FIG_DIR, exist_ok=True)
+os.makedirs(DATA_DIR, exist_ok=True)
+
+fig.savefig(os.path.join(FIG_DIR, "01_qc_metrics.png"), dpi=150, bbox_inches="tight")
+adata.write(os.path.join(DATA_DIR, "pbmc5k_processed.h5ad"))
+```
+
+Use **relative paths** rooted at the task folder — not absolute
+`/Users/.../.pantheon/images` paths.
+
+---
+
+## Figures
+
+Save deliverable figures into `<task_folder>/figures/`. The Output panel
+live-previews your declared task folder, so figures appear to the user as you
+create them; then register the real ones with `register_output`.
+
+- Do NOT dump figures into `.pantheon/images/` or the workspace root.
+- `.pantheon/images/` is only for a quick throwaway plot you want pushed inline
+  into the chat right now (e.g. on a messaging channel) — never for deliverables.
+
+---
+
+## Registering outputs
+
+When the task is done, register the **task folder** (or its `figures/`
+subfolder) with `register_output` so the user can browse it in the Output panel.
+Prefer registering the folder over each individual file.
+
+---
+
+## Reuse vs. new
+
+Before creating a folder, glance at the workspace root:
+
+- **Continuing** earlier work on the same analysis? Reuse that task folder.
+- **New / unrelated** analysis? Make a new folder — don't graft it onto an
+  existing one.

--- a/pantheon/internal/system_prompt.py
+++ b/pantheon/internal/system_prompt.py
@@ -104,7 +104,11 @@ def _append_context_blocks(prompt: str, ctx: dict[str, Any]) -> str:
         prompt += USER_INFORMATION_BLOCK.format(content="\n".join(lines))
 
     # <workdir_constraint>
-    workdir = ctx.get("workdir", "")
+    # Prefer the immutable `project_root`: this prompt is re-rendered every turn,
+    # and proxy_toolset pops `workdir` off the shared context for endpoint calls —
+    # so reading `workdir` here makes the constraint (and the image-output block
+    # nested under it) vanish mid-run once the agent touches a notebook/shell tool.
+    workdir = ctx.get("project_root") or ctx.get("workdir", "")
     if workdir:
         prompt += WORKDIR_CONSTRAINT_BLOCK.format(workdir=workdir)
         img_dir = ctx.get("image_output_dir", "")

--- a/pantheon/internal/system_prompt.py
+++ b/pantheon/internal/system_prompt.py
@@ -39,8 +39,13 @@ IMPORTANT: You are operating in a restricted workspace environment.
 IMAGE_OUTPUT_CONSTRAINT_BLOCK = """\
 
 <image_output_constraint>
-When you generate or save images (plots, charts, figures, etc.), ALWAYS save them to: {img_dir}
-This directory is monitored so images saved here are automatically sent back to the user.
+Save deliverable figures INTO the current task's folder (e.g.
+`<task_folder>/figures/`) — the folder you declared via task_boundary's
+output_dir. The Output panel live-previews that folder, so figures appear to the
+user as you create them; then mark the real ones with `register_output`.
+Do NOT save figures into {img_dir} or scatter them at the workspace root.
+{img_dir} is ONLY for a quick throwaway plot you want pushed inline into the chat
+right now (e.g. on a messaging channel) — never for deliverable figures.
 </image_output_constraint>"""
 
 # ── Public API ────────────────────────────────────────────────────────────────

--- a/pantheon/internal/task_system/plugin.py
+++ b/pantheon/internal/task_system/plugin.py
@@ -22,7 +22,10 @@ if TYPE_CHECKING:
 TASK_BRAIN_DIR_BLOCK = """
 
 <task_brain_dir>
-Artifact directory: {brain_dir}/{{chat_id}}
+Your workspace root is {workspace_root}. Create ALL output files — notebooks,
+reports, figures, data — under this directory. Never write outside it (file and
+notebook tools are scoped to it and will reject paths elsewhere).
+Internal task-state directory: {brain_dir}/{{chat_id}}
   - Base path: {brain_dir}
   - {{chat_id}} is the current conversation's ID (provided per-request in
     context). It keeps each conversation's task.md isolated from other chats.
@@ -120,9 +123,20 @@ class TaskSystemPlugin(TeamPlugin):
         if not team.team_agents:
             return
 
+        from pathlib import Path
+
         settings = get_settings()
-        brain_dir = str(settings.brain_dir)
-        tag = TASK_BRAIN_DIR_BLOCK.format(brain_dir=brain_dir)
+        # Anchor the brain dir + workspace root to THIS chat's project (set on the
+        # team at creation, see ChatRoom._create_team_from_template). Falls back to
+        # the global home brain dir only when no per-project root was resolved.
+        proj_dir = getattr(team, "_project_dir", None)
+        if proj_dir:
+            brain_dir = str(Path(proj_dir) / ".pantheon" / "brain")
+            workspace_root = str(proj_dir)
+        else:
+            brain_dir = str(settings.brain_dir)
+            workspace_root = str(Path(brain_dir).parent.parent)
+        tag = TASK_BRAIN_DIR_BLOCK.format(brain_dir=brain_dir, workspace_root=workspace_root)
 
         primary = team.team_agents[0]
         if hasattr(primary, "instructions") and primary.instructions:

--- a/pantheon/internal/task_system/plugin.py
+++ b/pantheon/internal/task_system/plugin.py
@@ -22,9 +22,21 @@ if TYPE_CHECKING:
 TASK_BRAIN_DIR_BLOCK = """
 
 <task_brain_dir>
-Your workspace root is {workspace_root}. Create ALL output files — notebooks,
-reports, figures, data — under this directory. Never write outside it (file and
-notebook tools are scoped to it and will reject paths elsewhere).
+Your workspace root is {workspace_root}.
+
+ORGANIZE EVERY ANALYSIS INTO ITS OWN FOLDER. For each distinct task/analysis,
+FIRST create a dedicated, descriptively-named subfolder directly under the
+workspace root (e.g. `scatac_pbmc5k/`, `visium_brain_qc/`) and keep ALL of that
+task's files together inside it — the notebook, figures (in a `figures/`
+subfolder), intermediate + result data, and reports. Do NOT scatter task files
+loosely at the workspace root, and do NOT reuse an unrelated task's folder.
+Before starting, glance at the workspace root: reuse the matching task folder if
+this continues earlier work, otherwise make a new one. DECLARE this folder up
+front via task_boundary's `output_dir` (during PLANNING) so the user sees your
+results appear live in the Output panel as you produce them. Never write outside
+the workspace root (file and notebook tools are scoped to it and reject paths
+elsewhere).
+
 Internal task-state directory: {brain_dir}/{{chat_id}}
   - Base path: {brain_dir}
   - {{chat_id}} is the current conversation's ID (provided per-request in
@@ -40,9 +52,12 @@ When you produce a user-facing DELIVERABLE — a report, a figure, a data
 file/table, or an output folder — register it with the `register_output` tool
 so the user can find and browse it in the Output panel.
 
-  - This is the ONLY way deliverables show up for the user. In particular,
-    files produced by RUNNING CODE (e.g. a plot a script saved, a generated
-    CSV) are tracked NOWHERE else — you MUST register them.
+  - The Output panel live-previews your declared task folder as you work, so the
+    user sees raw files appear. But REGISTERING is how you mark and title the
+    FINAL, curated deliverables — and is the only way files produced by RUNNING
+    CODE (a plot a script saved, a generated CSV) are surfaced as real outputs
+    rather than scratch. Register each deliverable as soon as it's final; don't
+    wait until the very end.
   - Deliverables produced by SUB-AGENTS you delegated to are reported back to
     you in their `## Files Produced` list — treat them exactly like your own
     output and register the real deliverables among them. Sub-agents do not
@@ -56,6 +71,46 @@ so the user can find and browse it in the Output panel.
   - Do NOT register scratch/intermediate files or the task.md/plan.md
     artifacts — only things the user actually wants.
 </output_registration>"""
+
+
+DECISION_POINTS_BLOCK = """
+
+<decision_points>
+Calibrate when to ask the user vs. just proceed — neither over-confirm nor
+silently guess on choices that are theirs to make.
+
+STOP and ask (notify_user, blocked_on_user=true, with concrete options + your
+recommended default) when the request leaves a REAL, consequential choice that is
+yours to guess — for example:
+  - It is under-specified and several materially-different options exist: which
+    dataset / sample / organism / condition, which method when the choice changes
+    the result, which scope or target.
+  - A step is expensive or hard to undo (large download/compute, destructive or
+    irreversible operation) and a wrong guess wastes significant work.
+  - Proceeding needs an assumption that, if wrong, yields the wrong deliverable.
+
+CRUCIAL — do not rationalize past this: vague phrasing like "find some data", "any
+dataset", or "analyze X" does NOT make the path clear and does NOT waive a
+confirmation. Picking the SPECIFIC dataset/sample to analyze is itself a choice the
+user usually wants in on — "find some" means "propose one and let me confirm", NOT
+"pick silently and run with it".
+
+Worked example — user: "find some spatial metabolomics data and analyze it":
+  1. Research candidate datasets — do NOT download yet.
+  2. notify_user(blocked_on_user=true): "I propose <dataset A> (<1-line why>).
+     Alternatives: <B>, <C>. Go with A?"
+  3. ONLY after they confirm: download + analyze.
+
+Ask ONCE, up front, bundling the open choices — don't drip-feed questions, and
+don't ask only after you've already done the work. Set blocked_on_user=true at
+these points even though you COULD technically proceed without approval — a choice
+being the user's to make is itself a valid reason to block; "needing the user" is
+not limited to being mechanically stuck.
+
+Otherwise — when the request already pinned every consequential choice, or the
+choice is trivial / easily reversible — just DO IT. Pointless confirmations are
+noise.
+</decision_points>"""
 
 
 SUBAGENT_FILE_REPORT_BLOCK = """
@@ -140,8 +195,8 @@ class TaskSystemPlugin(TeamPlugin):
 
         primary = team.team_agents[0]
         if hasattr(primary, "instructions") and primary.instructions:
-            primary.instructions += tag + OUTPUT_REGISTRATION_BLOCK
-            logger.debug(f"TaskSystemPlugin: injected task_brain_dir + output_registration into '{primary.name}'")
+            primary.instructions += tag + DECISION_POINTS_BLOCK + OUTPUT_REGISTRATION_BLOCK
+            logger.debug(f"TaskSystemPlugin: injected task_brain_dir + decision_points + output_registration into '{primary.name}'")
 
         # Sub-agents never register outputs themselves — the leader is the single
         # point of registration (consistency). But each sub-agent MUST report the

--- a/pantheon/toolsets/notebook/integrated_notebook.py
+++ b/pantheon/toolsets/notebook/integrated_notebook.py
@@ -230,48 +230,69 @@ class IntegratedNotebookToolSet(ToolSet):
         import shutil
         import subprocess
 
+        import asyncio
+
+        # Probe each kernel's Python for version + key-package versions. Use
+        # importlib.metadata (reads dist metadata — milliseconds) instead of
+        # actually importing the packages: importing scanpy/scvi-tools/cellrank
+        # costs seconds EACH, and doing it for every registered kernelspec
+        # sequentially made list_kernels take a minute+. (Bonus: metadata uses the
+        # distribution name, so 'scvi-tools' is detected correctly — the old
+        # __import__('scvi_tools') silently failed.)
+        _probe_script = (
+            "import sys\n"
+            "print('%d.%d.%d' % sys.version_info[:3])\n"
+            "try:\n"
+            "    from importlib.metadata import version\n"
+            "except Exception:\n"
+            "    from importlib_metadata import version\n"
+            "for _p in ['scanpy','pertpy','anndata','numpy','pandas','scipy',"
+            "'matplotlib','scvi-tools','cellrank']:\n"
+            "    try:\n"
+            "        print(_p, version(_p))\n"
+            "    except Exception:\n"
+            "        pass\n"
+        )
+
+        async def _probe_kernel(name, info):
+            spec = info.get("spec", {})
+            argv = spec.get("argv", [])
+            python_path = argv[0] if argv else "unknown"
+            is_abs = os.path.isabs(python_path)
+            actual_python = python_path if is_abs else (shutil.which(python_path) or python_path)
+            python_version = None
+            key_packages: list = []
+            if os.path.isfile(actual_python):
+                try:
+                    result = await asyncio.to_thread(
+                        subprocess.run,
+                        [actual_python, "-c", _probe_script],
+                        capture_output=True, text=True, timeout=10,
+                    )
+                    lines = [ln for ln in result.stdout.strip().split("\n") if ln]
+                    if lines:
+                        python_version = lines[0]
+                        key_packages = lines[1:]
+                except Exception:
+                    pass
+            return {
+                "name": name,
+                "display_name": spec.get("display_name", name),
+                "python": actual_python,
+                "python_version": python_version,
+                "is_absolute_path": is_abs,
+                "key_packages": key_packages,
+            }
+
         kernels = []
         try:
             from jupyter_client.kernelspec import KernelSpecManager
-            ksm = KernelSpecManager()
-            specs = ksm.get_all_specs()
-            for name, info in specs.items():
-                spec = info.get("spec", {})
-                argv = spec.get("argv", [])
-                python_path = argv[0] if argv else "unknown"
-                is_abs = os.path.isabs(python_path)
-
-                # Try to get Python version and key packages
-                actual_python = python_path if is_abs else (shutil.which(python_path) or python_path)
-                python_version = None
-                key_packages = []
-                if os.path.isfile(actual_python):
-                    try:
-                        result = subprocess.run(
-                            [actual_python, "-c",
-                             "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}'); "
-                             "pkgs = ['scanpy','pertpy','anndata','numpy','pandas','scipy','matplotlib','scvi-tools','cellrank']\n"
-                             "for p in pkgs:\n"
-                             " try:\n"
-                             "  mod=__import__(p.replace('-','_')); print(f'{p} {getattr(mod,\"__version__\",\"?\")}')\n"
-                             " except: pass"],
-                            capture_output=True, text=True, timeout=10,
-                        )
-                        lines = result.stdout.strip().split("\n")
-                        if lines:
-                            python_version = lines[0]
-                            key_packages = lines[1:]
-                    except Exception:
-                        pass
-
-                kernels.append({
-                    "name": name,
-                    "display_name": spec.get("display_name", name),
-                    "python": actual_python,
-                    "python_version": python_version,
-                    "is_absolute_path": is_abs,
-                    "key_packages": key_packages,
-                })
+            specs = KernelSpecManager().get_all_specs()
+            # Probe every kernel concurrently — wall-clock ≈ the slowest single
+            # probe, not the sum.
+            kernels = list(await asyncio.gather(
+                *(_probe_kernel(name, info) for name, info in specs.items())
+            ))
         except Exception as e:
             logger.warning(f"Failed to list kernelspecs: {e}")
 
@@ -728,15 +749,34 @@ class IntegratedNotebookToolSet(ToolSet):
             # Eagerly create kernel context if kernel_spec is specified
             if session_id:
                 context = self._get_context(notebook_path, session_id)
+
+                # If a DIFFERENT kernel was explicitly requested than the one
+                # currently bound to this notebook, switch to it (tear the old
+                # kernel down + recreate below). Previously this was silently
+                # ignored, stranding the notebook on the wrong env — e.g. the agent
+                # asks for its conda env 'vizgen-liver' but the notebook stays on
+                # bare 'python3', so every cell dies with "No module named 'pandas'"
+                # and the agent can't recover (recreating the file kept the kernel).
+                if context and kernel_spec and kernel_spec != context.kernel_spec:
+                    logger.info(
+                        f"Switching kernel for {notebook_path}: "
+                        f"'{context.kernel_spec}' -> '{kernel_spec}'"
+                    )
+                    try:
+                        await self.kernel_toolset.shutdown_session(context.kernel_session_id)
+                    except Exception as e:
+                        logger.warning(f"Old-kernel shutdown during switch failed: {e}")
+                    try:
+                        self.completion_service.clear_session_context(context.kernel_session_id)
+                    except Exception:
+                        pass
+                    self.notebook_contexts.pop((notebook_path, session_id), None)
+                    await self._save_contexts()
+                    context = None  # recreate below with the requested kernel
+
                 if context:
                     result["kernel_session_id"] = context.kernel_session_id
                     result["kernel_spec"] = context.kernel_spec
-                    if kernel_spec and kernel_spec != context.kernel_spec:
-                        result["kernel_warning"] = (
-                            f"Notebook already has an active kernel '{context.kernel_spec}'. "
-                            f"Requested kernel_spec='{kernel_spec}' was ignored. "
-                            f"Use manage_kernel(action='delete') then recreate to switch kernels."
-                        )
                 elif kernel_spec:
                     # Create context now with the specified kernel
                     try:
@@ -745,6 +785,10 @@ class IntegratedNotebookToolSet(ToolSet):
                         )
                         result["kernel_session_id"] = context.kernel_session_id
                         result["kernel_spec"] = context.kernel_spec
+                        if kernel_spec and kernel_spec != "python3":
+                            result["kernel_message"] = (
+                                f"Notebook bound to kernel '{context.kernel_spec}'."
+                            )
                     except Exception as e:
                         result["kernel_warning"] = f"Notebook created but kernel '{kernel_spec}' failed to start: {e}"
 

--- a/pantheon/toolsets/notebook/jupyter_kernel.py
+++ b/pantheon/toolsets/notebook/jupyter_kernel.py
@@ -154,7 +154,7 @@ class JupyterKernelToolSet(ToolSet):
         ctx = self.get_context()
         return dict(ctx) if ctx else {}
 
-    def _build_kernel_env(self) -> dict:
+    def _build_kernel_env(self, kernel_python: str | None = None) -> dict:
         import sys
 
         env = os.environ.copy()
@@ -162,17 +162,20 @@ class JupyterKernelToolSet(ToolSet):
         for _drop_var in ("LS_COLORS", "LESSOPEN", "LESSCLOSE", "PANTHEON_CONTEXT"):
             env.pop(_drop_var, None)
 
-        # Get paths from current sys.path and existing PYTHONPATH
-        # Prepend sys.path to give it priority for the kernel subprocess
-        current_paths = [p for p in sys.path if p]
-        existing_pythonpath = env.get("PYTHONPATH", "")
-        existing_paths = [p for p in existing_pythonpath.split(os.pathsep) if p]
-
-        # Combine and deduplicate while preserving order
-        all_paths = current_paths + existing_paths
-        unique_paths = list(dict.fromkeys(all_paths))
-
-        env["PYTHONPATH"] = os.pathsep.join(unique_paths)
+        # Only share THIS process's import paths with the kernel when the kernel
+        # runs the SAME Python interpreter. For a kernel on a DIFFERENT Python
+        # (e.g. a conda env the user selected), injecting our sys.path / PYTHONPATH
+        # points it at THIS interpreter's site-packages — the kernel then loads C
+        # extensions (numpy, …) compiled for a different Python version and dies on
+        # startup ("Kernel died before replying to kernel_info"). Give a foreign
+        # kernel a clean env so it uses its own environment's packages.
+        if self._is_same_interpreter(kernel_python):
+            current_paths = [p for p in sys.path if p]
+            existing_paths = [p for p in env.get("PYTHONPATH", "").split(os.pathsep) if p]
+            env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(current_paths + existing_paths))
+        else:
+            env.pop("PYTHONPATH", None)
+            env.pop("PYTHONHOME", None)
 
         context_vars = {
             k: v for k, v in self._current_context_dict().items()
@@ -185,6 +188,23 @@ class JupyterKernelToolSet(ToolSet):
             base_env=env,
             optimize=True,
         )
+
+    def _is_same_interpreter(self, kernel_python: str | None) -> bool:
+        """Whether the kernel's Python IS this process's interpreter. Unknown or
+        unresolvable values (e.g. a relative 'python') default to True, preserving
+        the legacy sys.path-sharing behavior for the in-process default kernel."""
+        import sys
+        if not kernel_python:
+            return True
+        try:
+            from shutil import which
+            resolved = (
+                kernel_python if os.path.isabs(kernel_python)
+                else (which(kernel_python) or kernel_python)
+            )
+            return os.path.realpath(resolved) == os.path.realpath(sys.executable)
+        except Exception:
+            return True
 
     def _context_prefix_code(self) -> str:
         from pantheon.internal.package_runtime.context import build_context_payload, export_context
@@ -387,8 +407,10 @@ class JupyterKernelToolSet(ToolSet):
             kernel_python = available.get(kernel_spec, "")
             km = AsyncKernelManager(kernel_name=kernel_spec)
 
-            # Start kernel in specified working directory with Pantheon context
-            env = self._build_kernel_env()
+            # Start kernel in specified working directory with Pantheon context.
+            # Pass the kernel's Python so a foreign interpreter (conda env) doesn't
+            # inherit THIS interpreter's PYTHONPATH (which crashes it on startup).
+            env = self._build_kernel_env(kernel_python)
 
             # Diagnostic logging for environment size
             total_env_size = sum(len(str(k)) + len(str(v)) + 1 for k, v in env.items())

--- a/pantheon/toolsets/task/ephemeral.py
+++ b/pantheon/toolsets/task/ephemeral.py
@@ -80,6 +80,11 @@ PLAN_ARTIFACT_MODIFIED_REMINDER = """\
 You have modified {files} during this task in {ctx_mode} mode. Before you switch to execution/analysis mode, you should notify and request the user to review your plan changes via notify_user.
 </plan_artifact_modified_reminder>"""
 
+CONFIRM_OPEN_CHOICES_REMINDER = """\
+<confirm_open_choices>
+You are still PLANNING and have NOT yet asked the user anything. Before you commit to an approach or run anything expensive (downloading a dataset, long compute): did the request leave a CONSEQUENTIAL choice that is the user's to make — most often WHICH specific dataset/sample to analyze, but also which method/scope when it changes the outcome? Vague phrasing like "find some data" / "any dataset" does NOT waive this — it means "propose one and let me confirm", NOT "pick silently and run". If such a choice is open, use notify_user(blocked_on_user=true) to present your specific proposal + 1-2 alternatives and get a quick OK FIRST. If the request already pinned every consequential choice, just proceed — don't ask for pointless confirmation.
+</confirm_open_choices>"""
+
 ARTIFACTS_MODIFIED_REMINDER = """\
 <artifacts_modified_reminder>
 You have modified {count} artifact(s) in this task.
@@ -241,6 +246,18 @@ def generate_ephemeral_message(state: ConversationState, brain_dir: str) -> str:
                     files=files_str, ctx_mode=state.active_task.mode
                 )
             )
+
+    # 3b. Confirm under-specified choices BEFORE committing — re-surfaced every
+    # planning turn until the agent asks the user. This is the stronger lever for
+    # "agent picked the dataset without asking": a static prompt rule got ignored
+    # (it read "find some data" as "pick silently"), so we nudge it at decision
+    # time. Self-limiting: stops once review is requested or it leaves plan phase.
+    if (
+        state.active_task
+        and state.active_task.is_plan_phase
+        and not state.pending_review_paths
+    ):
+        parts.append(CONFIRM_OPEN_CHOICES_REMINDER)
 
     # 4. General artifact modification reminder (non-plan phases)
     if state.active_task and not state.active_task.is_plan_phase:

--- a/pantheon/toolsets/task/ephemeral.py
+++ b/pantheon/toolsets/task/ephemeral.py
@@ -38,6 +38,21 @@ Remember that task boundaries should correspond to the artifact task.md, if you 
 Since you are NOT in an active task section, DO NOT call the `notify_user` tool unless you are requesting review of files.
 </no_active_task_reminder>"""
 
+# Bridges the gap between `active_task` (the in-memory state that drives this
+# message) and task.md (the visible checklist). The agent can close its active
+# task while task.md still has open items — then the reminder above wrongly reads
+# "it's fine to have no task", nobody nudges the agent to finish, and it either
+# leaves todos dangling or spins. Surfacing the open items keeps it honest.
+UNFINISHED_TODOS_REMINDER = """\
+<unfinished_todos_reminder>
+You have no active task, but task.md still has UNFINISHED checklist items:
+{items}
+The work is NOT complete yet. For each item: finish it and mark it [x] in task.md,
+or — if it genuinely cannot or should not be done — mark it [x] with a short
+"(skipped: reason)" note. Do not give your final wrap-up to the user until task.md
+has no remaining [ ] or [/] items. Take a concrete action now; do not just think.
+</unfinished_todos_reminder>"""
+
 # =============================================================================
 # Artifact Reminders
 # =============================================================================
@@ -128,6 +143,28 @@ Consider whether the current work belongs in a new task boundary.
 </too_many_steps_in_task_reminder>"""
 
 
+def _read_incomplete_todos(brain_dir: str) -> list[str]:
+    """Open items in the chat's task.md checklist — lines marked ``[ ]`` (todo) or
+    ``[/]`` (in progress). ``[x]`` / ``[-]`` (done / dropped) are excluded.
+
+    Read straight from task.md (the same source the user sees in Plan & Todo) so
+    the reminder can't drift from the persisted checklist."""
+    import re
+
+    path = os.path.join(brain_dir, "task.md")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+    except Exception:
+        return []
+    items: list[str] = []
+    for line in text.splitlines():
+        m = re.match(r"\s*[-*]\s*\[([ /xX\-])\]\s*(.+)", line)
+        if m and m.group(1) in (" ", "/"):
+            items.append(m.group(2).strip())
+    return items
+
+
 def generate_ephemeral_message(state: ConversationState, brain_dir: str) -> str:
     """Generate EPHEMERAL_MESSAGE based on current state.
 
@@ -177,6 +214,14 @@ def generate_ephemeral_message(state: ConversationState, brain_dir: str) -> str:
             )
     else:
         parts.append(NO_ACTIVE_TASK_REMINDER.format(reason=state.task_boundary_reason))
+
+        # No active task, but task.md may still have open items (the agent closed
+        # the task prematurely). Surface them so it finishes/closes them instead of
+        # leaving them dangling or spinning on a static "no task is fine" reminder.
+        open_todos = _read_incomplete_todos(brain_dir)
+        if open_todos:
+            items = "\n".join(f"  - {t}" for t in open_todos[:15])
+            parts.append(UNFINISHED_TODOS_REMINDER.format(items=items))
 
         # Add excessive tools reminder when not in task
         if state.tools_since_boundary >= EXCESSIVE_TOOLS_THRESHOLD:

--- a/pantheon/toolsets/task/task_state.py
+++ b/pantheon/toolsets/task/task_state.py
@@ -115,6 +115,11 @@ class TaskInfo:
     status: str
     summary: str
     start_step: int = 0
+    # Workspace-relative folder this task's outputs will land in, DECLARED up front
+    # (at planning / task_boundary time). Lets the UI live-preview the folder while
+    # the task runs — before the agent formally registers deliverables. May be None
+    # if the agent didn't declare one.
+    output_dir: Optional[str] = None
     
     @property
     def is_plan_phase(self) -> bool:
@@ -160,6 +165,12 @@ class ConversationState:
     active_task: Optional[TaskInfo] = None
     task_boundary_reason: str = "a task boundary has never been set yet in this conversation"
 
+    # Declared output folders, keyed by task_name (workspace-relative). Set when a
+    # task declares its output_dir at task_boundary time; CUMULATIVE across the
+    # conversation (survives active_task being cleared) so the UI can live-preview
+    # each task's folder and group previews "by task" alongside registered outputs.
+    task_dirs: dict[str, str] = field(default_factory=dict)
+
     # Counter tracking
     tools_since_boundary: int = 0
     tools_since_update: int = 0
@@ -176,6 +187,15 @@ class ConversationState:
     # Conditional flags (deprecated, kept for backward compatibility)
     plan_edited_in_planning: bool = False
     pending_review_paths: list[str] = field(default_factory=list)
+
+    # Decision-point gate. has_asked_user: has the agent EVER consulted the user
+    # via notify_user (cumulative, never reset). execution_gate_fired: has the
+    # one-time pre-execution checkpoint already triggered. Together they let
+    # task_boundary hard-stop ONCE before the first execution when the user was
+    # never consulted — so the agent can't autopilot past confirming an
+    # under-specified choice (a tool error it must address, not a passive nudge).
+    has_asked_user: bool = False
+    execution_gate_fired: bool = False
 
     def to_dict(self) -> dict:
         """Convert state to dictionary."""
@@ -198,7 +218,10 @@ class ConversationState:
         return cls(**init_data)
 
 
-    def on_task_boundary(self, name: str, mode: str, status: str, summary: str):
+    def on_task_boundary(
+        self, name: str, mode: str, status: str, summary: str,
+        output_dir: Optional[str] = None,
+    ):
         """Called when task_boundary tool is invoked."""
         is_new_task = self.active_task is None or self.active_task.name != name
 
@@ -212,9 +235,15 @@ class ConversationState:
             # Same task, increment update count (this is a step change)
             self.task_update_count += 1
 
+        # Persist the declared output folder (keyed by task) so it survives
+        # active_task resets; reuse the prior declaration when this call omits one.
+        if output_dir:
+            self.task_dirs[name] = output_dir
+        resolved_dir = output_dir or self.task_dirs.get(name)
+
         self.active_task = TaskInfo(
             name=name, mode=mode, status=status, summary=summary,
-            start_step=self.current_step
+            start_step=self.current_step, output_dir=resolved_dir,
         )
         self.tools_since_update = 0
         self.tools_since_think = 0  # 新增：重置 think 计数
@@ -223,6 +252,7 @@ class ConversationState:
     def on_notify_user(self, paths: list[str]):
         """Called when notify_user tool is invoked."""
         self.pending_review_paths = paths
+        self.has_asked_user = True   # the agent consulted the user → gate satisfied
         self.active_task = None
         self.tools_since_think = 0  # 新增：重置 think 计数
         self.task_boundary_reason = "there has been a notify_user action since the last task boundary"

--- a/pantheon/toolsets/task/task_toolset.py
+++ b/pantheon/toolsets/task/task_toolset.py
@@ -56,20 +56,26 @@ class TaskToolSet(ToolSet):
         under client_id, the UI-connection id; that was redundant and made the
         path non-deterministic for readers that don't know the client_id.)
 
-        Priority:
-        1. Use workdir if present in context (isolated-project scenario)
-        2. Fall back to settings.brain_dir
+        Anchor priority:
+        1. `project_root` — the chat's IMMUTABLE project root, set once by
+           ChatRoom.chat(). Prefer this over `workdir`: `workdir` is an
+           endpoint-cwd hint that proxy_toolset legitimately pops/overwrites on
+           the shared per-task context for every endpoint-toolset call, so by the
+           time a later task_boundary (or ephemeral refresh) runs it may be gone —
+           which silently relocated the brain to the global home dir, splitting it
+           away from the workspace. `project_root` is never mutated.
+        2. `workdir` — legacy fallback (e.g. isolated chats that only set workdir).
+        3. settings.brain_dir — global home, last resort.
         """
         chat_id = context.get("chat_id") or "default"
 
-        # Priority 1: Use workdir from context if available (isolated project)
-        workdir = context.get("workdir")
-        if workdir:
-            brain_path = Path(workdir) / ".pantheon" / "brain" / chat_id
-            logger.debug(f"[TaskToolSet] Using workdir brain_dir: {brain_path}")
+        root = context.get("project_root") or context.get("workdir")
+        if root:
+            brain_path = Path(root) / ".pantheon" / "brain" / chat_id
+            logger.debug(f"[TaskToolSet] Using project-root brain_dir: {brain_path}")
             return str(brain_path)
 
-        # Priority 2: Fall back to settings
+        # Last resort: the global home brain dir.
         from pantheon.settings import get_settings
         brain_path = get_settings().brain_dir / chat_id
         logger.debug(f"[TaskToolSet] Using settings brain_dir: {brain_path}")
@@ -353,7 +359,10 @@ class TaskToolSet(ToolSet):
         """
         import os
 
-        root = context.get("workdir") or os.getcwd()
+        # Prefer the immutable project anchor over `workdir` (which proxy_toolset
+        # clears mid-run for endpoint calls — see _get_brain_dir). os.getcwd() is
+        # the ChatRoom process dir, the wrong root, so it's only a last resort.
+        root = context.get("project_root") or context.get("workdir") or os.getcwd()
         p = os.path.expanduser(path)
         abs_path = p if os.path.isabs(p) else os.path.join(root, p)
         exists = os.path.exists(abs_path)

--- a/pantheon/toolsets/task/task_toolset.py
+++ b/pantheon/toolsets/task/task_toolset.py
@@ -89,6 +89,7 @@ class TaskToolSet(ToolSet):
         task_summary: str,
         task_status: str,
         predicted_task_size: int,
+        output_dir: str = "",
     ) -> dict:
         """
         CRITICAL: You must ALWAYS call this tool as the VERY FIRST tool in your list of tool calls, before any other tools.
@@ -96,7 +97,7 @@ class TaskToolSet(ToolSet):
 
         The tool should also be used to update the status and summary periodically throughout the task. When updating the status or summary of the current task, you must use the exact same task_name as before.
 
-        To avoid repeating the same values, use the special string "%SAME%" for mode, task_name, task_status, or task_summary to reuse the previous value.
+        To avoid repeating the same values, use the special string "%SAME%" for mode, task_name, task_status, task_summary, or output_dir to reuse the previous value.
 
         Args:
             task_name: Name of the task boundary. This is the identifier that groups steps together, should be human readable like 'Researching Existing Server Implementation'. This should correspond to a top-level item in task.md.
@@ -104,6 +105,7 @@ class TaskToolSet(ToolSet):
             task_summary: Concise summary of what has been accomplished throughout the entire task so far. Should be at most 1-2 lines, past tense. Cite important files between backticks.
             task_status: Active status of the current action, e.g 'Looking for files'. Should describe what you are GOING TO DO NEXT, not what you have done.
             predicted_task_size: Your best estimation on how many tool calls are needed to fulfill this task.
+            output_dir: The workspace-relative folder where THIS task's outputs (notebook, figures, data, reports) will live — e.g. 'scatac_pbmc5k' or 'scatac_pbmc5k/'. DECLARE THIS when you first set up the task (during PLANNING), even before the folder exists. The UI live-previews this folder so the user sees results appear as you produce them, before you formally register deliverables. Use "%SAME%" or omit to keep the previously declared folder. Leave empty only if this task produces no files.
         """
         # Handle %SAME% substitution
         task_name = self._last.get("task_name") if "%SAME%" in task_name else task_name
@@ -112,6 +114,7 @@ class TaskToolSet(ToolSet):
             self._last.get("summary") if "%SAME%" in task_summary else task_summary
         )
         task_status = self._last.get("status") if "%SAME%" in task_status else task_status
+        output_dir = self._last.get("output_dir") if "%SAME%" in (output_dir or "") else output_dir
 
         # Validate mode: accept known modes, warn for unknown but allow
         if not mode or not mode.strip():
@@ -123,15 +126,56 @@ class TaskToolSet(ToolSet):
                 f"Unknown mode '{mode}', proceeding anyway. Known modes: {ModeSemantics.ALL_KNOWN_MODES}"
             )
 
+        # Normalize (workspace-relative, no trailing slash). Empty/omitted ⇒ keep the
+        # previously declared folder (self._last still holds the prior call's value).
+        output_dir = (output_dir or "").strip().rstrip("/") or self._last.get("output_dir")
+
         # Store for next %SAME% reference
         self._last = {
             "task_name": task_name,
             "mode": mode_upper,
             "summary": task_summary,
             "status": task_status,
+            "output_dir": output_dir,
         }
 
-        self.state.on_task_boundary(task_name, mode_upper, task_status, task_summary)
+        # Decision-point GATE — one-time hard checkpoint before the FIRST execution.
+        # Prompt + ephemeral nudges proved unreliable (the model would autopilot from
+        # planning straight into execution, silently picking e.g. a dataset). So if
+        # the agent enters an execute mode without ever having consulted the user,
+        # fail this call ONCE: a tool error it must address forces a conscious "do I
+        # need to confirm?" decision instead of barreling through. Fires once (never
+        # loops), and for genuinely-specified tasks the agent simply re-calls and
+        # proceeds — so the user is not interrupted on clear tasks.
+        if (
+            ModeSemantics.is_execute_mode(mode_upper)
+            and not self.state.has_asked_user
+            and not self.state.execution_gate_fired
+        ):
+            self.state.execution_gate_fired = True
+            gate_context = self.get_context()
+            if gate_context:
+                self._save(self._get_brain_dir(gate_context))
+            return {
+                "success": False,
+                "error": (
+                    "DECISION CHECKPOINT — do not proceed yet. You are entering "
+                    "execution without having consulted the user. If the request left "
+                    "a consequential choice open, you MUST confirm first. In "
+                    "particular, vague phrasing like 'find some data' / 'analyze "
+                    "<topic>' with NO specific dataset/accession named IS "
+                    "under-specified — picking the dataset is the user's call: "
+                    "research candidates, then notify_user(blocked_on_user=true) with "
+                    "your proposed dataset + 1-2 alternatives and WAIT for the user. "
+                    "Only if the request already named the specific dataset/scope (or "
+                    "the choice is trivial / easily reversible) may you call "
+                    "task_boundary again now to proceed."
+                ),
+            }
+
+        self.state.on_task_boundary(
+            task_name, mode_upper, task_status, task_summary, output_dir=output_dir
+        )
 
         # Persist state using context from toolset
         context = self.get_context()

--- a/pantheon/utils/image_detection.py
+++ b/pantheon/utils/image_detection.py
@@ -8,8 +8,14 @@ logger = logging.getLogger(__name__)
 
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 
-# Standard directory (relative to workspace root) where agents should save
-# generated images so claw channels can detect and forward them.
+# Quick-preview image dir (relative to workspace root). Images saved here are
+# snapshot-detected and pushed INLINE — primarily so claw messaging channels
+# (Telegram/Discord/…), which have no Output panel, can show generated plots.
+# Deliverable figures belong in the task folder + register_output (the Output
+# panel live-previews the declared task folder); this dir is only for throwaway
+# inline previews. Scanning is deliberately top-level + per-dir (NOT a recursive
+# whole-workspace walk) — a shared filesystem can't attribute a new image to the
+# chat that made it, so concurrent chats would cross-contaminate.
 IMAGE_OUTPUT_DIR = ".pantheon/images"
 
 # Default limits (can be overridden via claw config images.max_size_bytes / images.max_dimension)

--- a/pantheon/utils/misc.py
+++ b/pantheon/utils/misc.py
@@ -70,6 +70,43 @@ async def run_func(func: Callable, *args, **kwargs):
         return await asyncio.to_thread(func, *args, **kwargs)
 
 
+def wire_safe_tool_args(args):
+    """Strip agent-internal, non-sendable entries from tool ``args`` before a tool
+    call crosses a process boundary (cloudpickle → remote toolset / endpoint).
+
+    The agent injects live closures into ``context_variables`` — ``_call_agent``
+    (spawns sub-agents) and ``_report_output`` (streams progress) — plus a
+    top-level ``_call_agent``. Those closures capture the running ``Agent``, which
+    holds ``asyncio.Future`` / ``asyncio.Task`` objects, so cloudpickle raises
+    ``cannot pickle '_asyncio.Future' object`` (foreground) or
+    ``'_asyncio.Task'`` (background). They are also meaningless to an
+    out-of-process toolset (they reference in-process state).
+
+    We drop only the non-sendable values (callables / coroutines / asyncio
+    Futures & Tasks); all plain context (workdir, chat_id, image_output_dir,
+    model_params, …) is preserved. In-process (LOCAL / embedded) tool calls never
+    reach this helper, so they keep the closures they may rely on.
+    """
+    if not isinstance(args, dict):
+        return args
+
+    def _unsendable(v) -> bool:
+        return (
+            callable(v)
+            or asyncio.isfuture(v)
+            or asyncio.iscoroutine(v)
+            or isinstance(v, asyncio.Task)
+        )
+
+    out = {}
+    for k, v in args.items():
+        if k == "context_variables" and isinstance(v, dict):
+            out[k] = {ck: cv for ck, cv in v.items() if not _unsendable(cv)}
+        elif not _unsendable(v):
+            out[k] = v
+    return out
+
+
 def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
     """Parse docstring Args section into a dict using docstring_parser library.
 

--- a/pantheon/utils/token_optimization.py
+++ b/pantheon/utils/token_optimization.py
@@ -52,6 +52,10 @@ COMPACTABLE_TOOL_SUFFIXES = {
 PER_TOOL_RESULT_SIZE_CHARS: dict[str, int | float] = {
     "read_file":   40_000,
     "view_file":   40_000,
+    # Viewing a skill exists precisely to LOAD its full content into context;
+    # externalizing it (preview + forcing a second read_file) defeats the purpose.
+    # Generous finite cap: inlines every realistic skill, still guards a runaway one.
+    "skill_view":  50_000,
     "web_fetch":   30_000,
     "web_crawl":   30_000,
     "web_search":  20_000,

--- a/tests/test_kernel_env.py
+++ b/tests/test_kernel_env.py
@@ -1,0 +1,49 @@
+"""Regression: a Jupyter kernel running a DIFFERENT Python (e.g. a conda env the
+user selected) must NOT inherit the endpoint interpreter's sys.path / PYTHONPATH.
+
+Injecting the endpoint's (.venv) import paths into a foreign-Python kernel makes it
+load C extensions (re/_sre, numpy, …) compiled for the wrong Python version, and it
+dies on startup with "Kernel died before replying to kernel_info". The same-Python
+default kernel still shares sys.path (legacy behavior). See
+jupyter_kernel._build_kernel_env / _is_same_interpreter.
+"""
+import os
+import sys
+
+from pantheon.toolsets.notebook.jupyter_kernel import JupyterKernelToolSet
+
+
+def _bare_toolset():
+    # Bypass __init__ (heavy setup) — the methods under test only need these.
+    ts = JupyterKernelToolSet.__new__(JupyterKernelToolSet)
+    ts._current_context_dict = lambda: {}
+    ts._get_effective_workdir = lambda: None
+    ts.workdir = "/tmp"
+    return ts
+
+
+def test_is_same_interpreter():
+    ts = _bare_toolset()
+    assert ts._is_same_interpreter(sys.executable) is True
+    assert ts._is_same_interpreter("/opt/conda/envs/sc/bin/python3.11") is False
+    # Unknown / relative paths default to True (legacy in-process default kernel).
+    assert ts._is_same_interpreter(None) is True
+    assert ts._is_same_interpreter("") is True
+
+
+def test_foreign_kernel_env_drops_pythonpath(monkeypatch):
+    ts = _bare_toolset()
+    monkeypatch.setenv("PYTHONPATH", "/endpoint/site-packages")
+    monkeypatch.setenv("PYTHONHOME", "/endpoint")
+    env = ts._build_kernel_env("/opt/conda/envs/sc/bin/python3.11")  # foreign interpreter
+    assert "PYTHONPATH" not in env
+    assert "PYTHONHOME" not in env
+
+
+def test_same_interpreter_shares_syspath():
+    ts = _bare_toolset()
+    env = ts._build_kernel_env(sys.executable)  # same interpreter
+    assert "PYTHONPATH" in env
+    real_paths = [p for p in sys.path if p]
+    if real_paths:
+        assert real_paths[0] in env["PYTHONPATH"].split(os.pathsep)

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -76,6 +76,16 @@ class TestAppendContextBlocks:
         assert "<image_output_constraint>" in result
         assert "/sandbox/imgs" in result
 
+    def test_image_constraint_steers_figures_into_task_folder(self):
+        """The reframed constraint points figures at the task folder + register_output
+        (the Output panel live-previews it) — NOT the old '.pantheon/images' dump."""
+        result = _append_context_blocks(
+            "base", {"workdir": "/sandbox", "image_output_dir": "/sandbox/imgs"}
+        )
+        assert "figures/" in result and "register_output" in result
+        assert "/sandbox/imgs" in result            # {img_dir} interpolated
+        assert "ALWAYS save them to" not in result  # old forced-dir wording gone
+
     def test_image_output_constraint_skipped_without_workdir(self):
         result = _append_context_blocks("base", {"image_output_dir": "/imgs"})
         assert "<image_output_constraint>" not in result

--- a/tests/test_task_system/test_plugin.py
+++ b/tests/test_task_system/test_plugin.py
@@ -146,6 +146,8 @@ class TestOnTeamCreated:
         team = _make_team(["main", "coder"])
         team.team_agents[0].instructions = "base instructions"
         team.team_agents[1].instructions = "sub instructions"
+        # No per-project root resolved → fall back to the global settings brain dir.
+        team._project_dir = None
 
         fake_settings = MagicMock()
         fake_settings.brain_dir = "/fake/.pantheon/brain"
@@ -158,8 +160,25 @@ class TestOnTeamCreated:
 
         assert "<task_brain_dir>" in primary_instr
         assert "/fake/.pantheon/brain" in primary_instr
-        assert "{client_id}" in primary_instr
+        assert "{chat_id}" in primary_instr
         assert "<task_brain_dir>" not in sub_instr  # sub-agent untouched
+
+    @pytest.mark.asyncio
+    async def test_anchors_brain_dir_to_per_project_root(self):
+        """When the team carries a project root, the brain dir + workspace-root
+        prompt point at THAT project — not the global home brain dir."""
+        plugin = TaskSystemPlugin()
+        team = _make_team(["main"])
+        team.team_agents[0].instructions = "base instructions"
+        team._project_dir = "/Users/me/Desktop/tmp"
+
+        await plugin.on_team_created(team)
+
+        instr = team.team_agents[0].instructions
+        assert "Your workspace root is /Users/me/Desktop/tmp" in instr
+        assert "/Users/me/Desktop/tmp/.pantheon/brain" in instr
+        # The global home brain dir must NOT leak in.
+        assert "/fake/.pantheon/brain" not in instr
 
     @pytest.mark.asyncio
     async def test_noop_when_no_agents(self):
@@ -238,3 +257,45 @@ class TestPluginBaseClass:
     def test_no_on_tool_calls_batch(self):
         from pantheon.team.plugin import TeamPlugin
         assert not hasattr(TeamPlugin, "on_tool_calls_batch")
+
+
+class TestUnfinishedTodosReminder:
+    """The ephemeral message is generated from `active_task` (in-memory state), but
+    the agent can close its task while task.md still has open items. The reminder
+    must read task.md and surface those open items — bridging the active_task ↔
+    task.md gap so the agent finishes/closes them instead of leaving them dangling
+    (and instead of spinning on a static 'no task is fine' reminder)."""
+
+    def test_reads_only_open_checklist_items(self, tmp_path):
+        from pantheon.toolsets.task.ephemeral import _read_incomplete_todos
+        (tmp_path / "task.md").write_text(
+            "- [x] done item\n"
+            "- [ ] open todo A\n"
+            "- [/] in-progress B — bg running\n"
+            "- [-] dropped item\n"
+            "plain prose, not a checklist line\n"
+        )
+        assert _read_incomplete_todos(str(tmp_path)) == [
+            "open todo A",
+            "in-progress B — bg running",
+        ]
+
+    def test_missing_task_md_returns_empty(self, tmp_path):
+        from pantheon.toolsets.task.ephemeral import _read_incomplete_todos
+        assert _read_incomplete_todos(str(tmp_path)) == []
+
+    def test_em_surfaces_open_todos_when_no_active_task(self, tmp_path):
+        from pantheon.toolsets.task.ephemeral import generate_ephemeral_message
+        from pantheon.toolsets.task.task_state import ConversationState
+        (tmp_path / "task.md").write_text("- [x] done\n- [ ] finish the notebook\n")
+        # Fresh state → no active task — exactly the "closed task, open todos" gap.
+        em = generate_ephemeral_message(ConversationState(), str(tmp_path))
+        assert "<unfinished_todos_reminder>" in em
+        assert "finish the notebook" in em
+
+    def test_em_silent_when_all_todos_done(self, tmp_path):
+        from pantheon.toolsets.task.ephemeral import generate_ephemeral_message
+        from pantheon.toolsets.task.task_state import ConversationState
+        (tmp_path / "task.md").write_text("- [x] done one\n- [x] done two\n")
+        em = generate_ephemeral_message(ConversationState(), str(tmp_path))
+        assert "<unfinished_todos_reminder>" not in em

--- a/tests/test_task_system/test_plugin.py
+++ b/tests/test_task_system/test_plugin.py
@@ -181,6 +181,49 @@ class TestOnTeamCreated:
         assert "/fake/.pantheon/brain" not in instr
 
     @pytest.mark.asyncio
+    async def test_instructs_per_task_folder_organization(self):
+        """The brain-dir prompt must tell the agent to put each analysis in its
+        OWN folder (not scatter files at the workspace root) — the fix for the
+        'everything dumped at root' organization complaint."""
+        plugin = TaskSystemPlugin()
+        team = _make_team(["main"])
+        team.team_agents[0].instructions = "base"
+        team._project_dir = "/proj"
+
+        await plugin.on_team_created(team)
+
+        instr = team.team_agents[0].instructions.lower()
+        assert "own folder" in instr or "dedicated" in instr
+        assert "subfolder" in instr
+        assert "scatter" in instr  # explicit "don't scatter at the root" guidance
+
+    @pytest.mark.asyncio
+    async def test_injects_decision_points_into_primary_only(self):
+        """The leader must get decision-point gating: ask the user at a genuine
+        fork (under-specified / expensive / irreversible), proceed otherwise — the
+        fix for 'agent stopped confirming consequential choices'."""
+        from unittest.mock import patch
+
+        plugin = TaskSystemPlugin()
+        team = _make_team(["main", "coder"])
+        team.team_agents[0].instructions = "base"
+        team.team_agents[1].instructions = "sub"
+        team._project_dir = None
+
+        fake_settings = MagicMock()
+        fake_settings.brain_dir = "/fake/.pantheon/brain"
+        with patch("pantheon.settings.get_settings", return_value=fake_settings):
+            await plugin.on_team_created(team)
+
+        primary = team.team_agents[0].instructions.lower()
+        assert "<decision_points>" in primary
+        assert "blocked_on_user" in primary             # HOW to ask
+        assert "pointless confirmations are" in primary  # and when NOT to
+        assert "find some data" in primary              # closes the "you pick" loophole
+        # Sub-agents don't gate user decisions — they execute delegated work.
+        assert "<decision_points>" not in team.team_agents[1].instructions
+
+    @pytest.mark.asyncio
     async def test_noop_when_no_agents(self):
         plugin = TaskSystemPlugin()
         team = _make_team([])

--- a/tests/test_task_toolset.py
+++ b/tests/test_task_toolset.py
@@ -353,9 +353,41 @@ class TestEphemeralMessage:
         state.on_tool_call(15)  # Make it stale (> 10 steps)
         
         msg = generate_ephemeral_message(state, ".pantheon/brain/test")
-        
+
         assert "<artifact_file_reminder>" in msg
         assert "/path/to/old.md" in msg
+
+
+class TestConfirmOpenChoicesReminder:
+    """During PLANNING, before the agent has asked anything, the EM must nudge it to
+    confirm under-specified choices (which dataset/method) — the stronger lever for
+    'agent picked the dataset without asking'. Self-limits once it asks / leaves plan."""
+
+    def test_fires_when_planning_and_not_yet_asked(self, tmp_path):
+        from pantheon.toolsets.task.ephemeral import generate_ephemeral_message
+        from pantheon.toolsets.task.task_state import ConversationState
+        s = ConversationState()
+        s.on_task_boundary("Plan it", "PLANNING", "status", "summary")
+        em = generate_ephemeral_message(s, str(tmp_path))
+        assert "<confirm_open_choices>" in em
+        assert "find some data" in em   # the loophole it must not rationalize past
+
+    def test_silent_once_review_requested(self, tmp_path):
+        from pantheon.toolsets.task.ephemeral import generate_ephemeral_message
+        from pantheon.toolsets.task.task_state import ConversationState
+        s = ConversationState()
+        s.on_task_boundary("Plan it", "PLANNING", "status", "summary")
+        s.pending_review_paths = ["/x/plan.md"]   # agent already asked the user
+        em = generate_ephemeral_message(s, str(tmp_path))
+        assert "<confirm_open_choices>" not in em
+
+    def test_silent_in_execution_phase(self, tmp_path):
+        from pantheon.toolsets.task.ephemeral import generate_ephemeral_message
+        from pantheon.toolsets.task.task_state import ConversationState
+        s = ConversationState()
+        s.on_task_boundary("Do it", "EXECUTION", "status", "summary")
+        em = generate_ephemeral_message(s, str(tmp_path))
+        assert "<confirm_open_choices>" not in em   # only the plan/research window
 
 
 class TestTaskToolSet:
@@ -400,8 +432,9 @@ class TestTaskToolSet:
     async def test_task_boundary_analysis_mode(self):
         """Test task_boundary accepts ANALYSIS mode."""
         from pantheon.toolsets.task.task_toolset import TaskToolSet
-        
+
         ts = TaskToolSet()
+        ts.state.has_asked_user = True   # satisfy the pre-execution gate (tested separately)
         result = await ts.task_boundary(
             task_name="Analysis Task",
             mode="ANALYSIS",
@@ -576,6 +609,121 @@ class TestBrainDirAnchor:
         )
         assert abs_path == "/Users/me/Desktop/tmp/outputs/fig.png"
         assert store_path == "outputs/fig.png"  # workspace-relative for the tree
+
+
+class TestTaskOutputDir:
+    """task_boundary declares the task's output folder up front (at PLANNING), so
+    the UI can live-preview that folder before the agent registers deliverables."""
+
+    @pytest.mark.asyncio
+    async def test_records_declared_output_dir(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        await ts.task_boundary("scATAC", "PLANNING", "sum", "status", 5,
+                               output_dir="scatac_pbmc5k/")
+        assert ts.state.active_task.output_dir == "scatac_pbmc5k"   # trailing slash stripped
+        assert ts.state.task_dirs["scATAC"] == "scatac_pbmc5k"
+
+    @pytest.mark.asyncio
+    async def test_output_dir_persists_when_omitted_on_update(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        await ts.task_boundary("scATAC", "PLANNING", "s", "st", 5, output_dir="scatac_pbmc5k")
+        # A later update of the SAME task omits output_dir → keeps the declared one.
+        await ts.task_boundary("scATAC", "EXECUTION", "s2", "st2", 5)
+        assert ts.state.active_task.output_dir == "scatac_pbmc5k"
+        assert ts.state.task_dirs["scATAC"] == "scatac_pbmc5k"
+
+    @pytest.mark.asyncio
+    async def test_output_dir_same_sentinel_reuses(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        await ts.task_boundary("scATAC", "PLANNING", "s", "st", 5, output_dir="scatac_pbmc5k")
+        await ts.task_boundary("%SAME%", "%SAME%", "%SAME%", "%SAME%", 5, output_dir="%SAME%")
+        assert ts.state.active_task.output_dir == "scatac_pbmc5k"
+
+    @pytest.mark.asyncio
+    async def test_second_task_gets_its_own_dir(self):
+        """Two tasks in one chat → two folders, keyed by task (drives 'By task')."""
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        await ts.task_boundary("scATAC", "PLANNING", "s", "st", 5, output_dir="scatac_pbmc5k")
+        await ts.task_boundary("Visium", "PLANNING", "s", "st", 5, output_dir="visium_qc")
+        assert ts.state.task_dirs == {"scATAC": "scatac_pbmc5k", "Visium": "visium_qc"}
+
+    def test_state_roundtrip_preserves_dirs(self):
+        from pantheon.toolsets.task.task_state import ConversationState
+        s = ConversationState()
+        s.on_task_boundary("T", "PLANNING", "st", "sum", output_dir="folder_a")
+        restored = ConversationState.from_dict(s.to_dict())
+        assert restored.task_dirs == {"T": "folder_a"}
+        assert restored.active_task.output_dir == "folder_a"
+
+    def test_backward_compat_old_state_without_dirs(self):
+        """Pre-output_dir task_state.json must still load cleanly."""
+        from pantheon.toolsets.task.task_state import ConversationState
+        old = {
+            "active_task": {"name": "T", "mode": "PLANNING", "status": "s",
+                            "summary": "x", "start_step": 3},
+            "outputs": [],
+        }
+        s = ConversationState.from_dict(old)
+        assert s.task_dirs == {}
+        assert s.active_task.output_dir is None
+
+
+class TestExecutionGate:
+    """One-time hard checkpoint: the FIRST entry into an execute mode WITHOUT having
+    consulted the user fails (a tool error the agent must address), forcing a
+    conscious confirm-or-proceed decision. Fires once (never loops); permanently
+    satisfied once the agent calls notify_user. This is the reliable backstop after
+    prompt + ephemeral nudges proved unreliable."""
+
+    @pytest.mark.asyncio
+    async def test_gates_first_execution_when_user_not_asked(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        r = await ts.task_boundary("Analyze", "EXECUTION", "sum", "status", 5)
+        assert r["success"] is False
+        assert "CHECKPOINT" in r["error"]
+        assert ts.state.active_task is None          # blocked → did not transition
+        assert ts.state.execution_gate_fired is True
+
+    @pytest.mark.asyncio
+    async def test_proceeds_on_retry_after_gate(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        await ts.task_boundary("Analyze", "EXECUTION", "s", "st", 5)      # gated (fires once)
+        r = await ts.task_boundary("Analyze", "EXECUTION", "s", "st", 5)  # retry → passes
+        assert r["success"] is True
+        assert ts.state.active_task.mode == "EXECUTION"
+
+    @pytest.mark.asyncio
+    async def test_not_gated_after_notify_user(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        await ts.notify_user(
+            paths_to_review=[], blocked_on_user=True, message="Which dataset?",
+            confidence_justification="x", confidence_score=0.5, questions=[],
+        )
+        assert ts.state.has_asked_user is True
+        r = await ts.task_boundary("Analyze", "EXECUTION", "s", "st", 5)
+        assert r["success"] is True                  # already consulted the user
+
+    @pytest.mark.asyncio
+    async def test_planning_is_never_gated(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        r = await ts.task_boundary("Plan", "PLANNING", "s", "st", 5)
+        assert r["success"] is True
+        assert ts.state.execution_gate_fired is False
+
+    @pytest.mark.asyncio
+    async def test_analysis_mode_also_gated(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        r = await ts.task_boundary("Analyze", "ANALYSIS", "s", "st", 5)   # ANALYSIS = execute phase
+        assert r["success"] is False
 
 
 if __name__ == "__main__":

--- a/tests/test_task_toolset.py
+++ b/tests/test_task_toolset.py
@@ -522,5 +522,61 @@ class TestTaskToolSet:
         assert "<EPHEMERAL_MESSAGE>" in eu["content"]
 
 
+class TestBrainDirAnchor:
+    """The brain dir must anchor to the IMMUTABLE `project_root`, not the mutable
+    `workdir`. proxy_toolset pops/overwrites `workdir` on the shared per-task
+    context for every endpoint-toolset call (steering the endpoint's cwd); if the
+    brain followed `workdir`, the first notebook/shell call would relocate the
+    task brain to the global home dir mid-run — splitting brain from workspace.
+    """
+
+    def test_prefers_project_root_over_workdir(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        # workdir is the (transient) endpoint hint; project_root is the anchor.
+        brain = ts._get_brain_dir({
+            "chat_id": "c1",
+            "project_root": "/Users/me/Desktop/tmp",
+            "workdir": "/some/endpoint/override",
+        })
+        assert brain == "/Users/me/Desktop/tmp/.pantheon/brain/c1"
+
+    def test_survives_workdir_being_popped(self):
+        """The real failure mode: a later turn whose context has had `workdir`
+        popped by proxy_toolset still resolves to the project, not global home."""
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        brain = ts._get_brain_dir({"chat_id": "c1", "project_root": "/proj"})  # no workdir
+        assert brain == "/proj/.pantheon/brain/c1"
+
+    def test_falls_back_to_workdir_when_no_project_root(self):
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        brain = ts._get_brain_dir({"chat_id": "c1", "workdir": "/legacy/iso"})
+        assert brain == "/legacy/iso/.pantheon/brain/c1"
+
+    def test_falls_back_to_settings_when_no_root(self):
+        from unittest.mock import patch, MagicMock
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        fake = MagicMock()
+        fake.brain_dir = Path("/home/.pantheon/brain")
+        with patch("pantheon.settings.get_settings", return_value=fake):
+            brain = ts._get_brain_dir({"chat_id": "c1"})
+        assert brain == str(Path("/home/.pantheon/brain/c1"))
+
+    def test_resolve_output_path_uses_project_root(self):
+        """register_output's path resolution shares the same anchor — a relative
+        deliverable must resolve under the project, never os.getcwd()."""
+        from pantheon.toolsets.task.task_toolset import TaskToolSet
+        ts = TaskToolSet()
+        abs_path, _exists, _is_dir, store_path = ts._resolve_output_path(
+            "outputs/fig.png",
+            {"project_root": "/Users/me/Desktop/tmp"},  # workdir absent (popped)
+        )
+        assert abs_path == "/Users/me/Desktop/tmp/outputs/fig.png"
+        assert store_path == "outputs/fig.png"  # workspace-relative for the tree
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_token_optimization.py
+++ b/tests/test_token_optimization.py
@@ -1694,6 +1694,27 @@ def test_per_tool_limit_values():
     assert get_per_tool_limit("unknown", 30_000) == 30_000
     # MCP-prefixed tool name normalization
     assert get_per_tool_limit("mcp__server__grep", 200_000) == 20_000
+    # skill_view: explicit high limit so a skill's full content inlines (not
+    # externalized + re-read) EVEN when the global limit is low — an explicit
+    # entry returns directly, so it does NOT collapse to min(50K, low_global).
+    assert get_per_tool_limit("skill_view", 2_000) == 50_000
+    assert get_per_tool_limit("skills__skill_view", 2_000) == 50_000  # prefix normalized
+
+
+def test_skill_view_full_content_inlined_not_externalized():
+    """Regression: viewing a skill returns its full content inline — NOT the
+    <persisted-output> preview that forces a second read_file. Reproduces the real
+    case: an ~11KB skill with a LOW global limit (which previously externalized it)."""
+    from pantheon.utils.llm import process_tool_result
+
+    skill_content = "SKILL CONTENT LINE\n" * 650  # ~12KB, like the live_view index
+    assert len(skill_content) > 11_000
+    out = process_tool_result(skill_content, max_length=2_000, tool_name="skills__skill_view")
+    out = out if isinstance(out, str) else str(out)
+
+    assert "<persisted-output>" not in out      # not spilled to disk
+    assert "Output too large" not in out
+    assert len(out) > 11_000                     # full content inline, not a ~2KB preview
 
 
 def test_full_pipeline_layer2_then_layer3(tmp_path):

--- a/tests/test_wire_safe_tool_args.py
+++ b/tests/test_wire_safe_tool_args.py
@@ -1,0 +1,79 @@
+"""Regression test for the cross-process tool-call sanitizer.
+
+Bug: the agent injects live closures into ``context_variables`` (``_call_agent``,
+``_report_output``) plus a top-level ``_call_agent``. These capture the running
+Agent, which holds asyncio Future/Task objects. With the multi-project refactor,
+tool calls are cloudpickled to remote toolset/endpoint subprocesses, so every I/O
+tool died with ``cannot pickle '_asyncio.Future' object`` (foreground) or
+``'_asyncio.Task'`` (background).
+
+``wire_safe_tool_args`` strips the non-sendable entries while preserving all plain
+context, and runs only on the remote (cross-process) path.
+"""
+import asyncio
+
+import cloudpickle
+import pytest
+
+from pantheon.utils.misc import wire_safe_tool_args
+
+
+def test_non_dict_args_passthrough():
+    assert wire_safe_tool_args(None) is None
+    assert wire_safe_tool_args("notebook_path") == "notebook_path"
+
+
+@pytest.mark.asyncio
+async def test_strips_unsendable_and_stays_picklable():
+    loop = asyncio.get_event_loop()
+    fut = loop.create_future()
+    task = asyncio.ensure_future(asyncio.sleep(0))
+
+    def _call_agent_wrap(*a, **k):
+        return fut  # closure captures an asyncio.Future -> unpicklable
+
+    args = {
+        "action": "create",
+        "notebook_path": "/x/y.ipynb",
+        "_background": False,
+        "_call_agent": _call_agent_wrap,  # top-level closure (forwarded via _SKIP_PARAMS)
+        "context_variables": {
+            "workdir": "/Users/me/Desktop/tmp",
+            "chat_id": "9c89f7e9",
+            "model_params": {"temperature": 0.2},
+            "_call_agent": _call_agent_wrap,
+            "_report_output": lambda line: None,
+            "_live_future": fut,
+            "_live_task": task,
+        },
+    }
+
+    # Reproduce the bug: the raw payload cannot be cloudpickled.
+    with pytest.raises(TypeError):
+        cloudpickle.dumps(args)
+
+    safe = wire_safe_tool_args(args)
+
+    # The sanitized payload MUST be wire-safe.
+    cloudpickle.dumps(safe)
+
+    # Real tool arguments + plain context are preserved verbatim.
+    assert safe["action"] == "create"
+    assert safe["notebook_path"] == "/x/y.ipynb"
+    assert safe["_background"] is False
+    cv = safe["context_variables"]
+    assert cv["workdir"] == "/Users/me/Desktop/tmp"
+    assert cv["chat_id"] == "9c89f7e9"
+    assert cv["model_params"] == {"temperature": 0.2}
+
+    # The non-sendable closures / asyncio objects are gone.
+    assert "_call_agent" not in safe
+    for k in ("_call_agent", "_report_output", "_live_future", "_live_task"):
+        assert k not in cv
+
+    task.cancel()
+
+
+def test_preserves_plain_args_without_context():
+    args = {"action": "write", "path": "report.md", "content": "x" * 10}
+    assert wire_safe_tool_args(args) == args


### PR DESCRIPTION
## What

Brings `feat/tcp-remote-backend` up to **v0.6.3**, consolidating this branch's work on top of latest `main`.

### Task system — open-ended analysis tasks
- **Per-task output folders + live preview**: `task_boundary` gains `output_dir` (declared at planning); the UI live-previews that folder before deliverables are registered. The prompt requires a dedicated per-task folder; figures go to `<task>/figures/`.
- **Decision-point gating**: confirm an under-specified, consequential choice (which dataset/method/scope) before executing — "find some data" is not "pick silently". A one-time hard checkpoint (`task_boundary` fails before the first execution if the user was never consulted) backstops the prompt/ephemeral nudges.

### Reliability fixes
- `fix(remote)`: strip non-picklable closures (Future/Task) from tool args before cloudpickle — fixes "cannot pickle '_asyncio.Future'".
- `fix(notebook)`: don't leak the endpoint's sys.path into a foreign-Python kernel ("Kernel died before replying to kernel_info").
- `fix(multi-project)`: anchor the task brain + outputs to an immutable `project_root` (was landing in the global home dir for project-mode chats).
- `fix(tool-output)`: `skill_view` returns its full content inline instead of spilling to disk (no more forced second read).

### Docs
- live-view: steer Hi-C to the gosling skill; warn against hand-rolling a raw HiGlass viewer (the PIXI-missing `hglib is not defined` failure).

Also merges latest `main` (chat-export canonicalization, low-model chat helpers, codex Responses-API routing) and bumps the version to `0.6.3`.
