### PR TITLE
feat(chatroom): multi-window backend — real per-project endpoints in bundle + store-based chat listing

### DIFF
--- a/pantheon/chatroom/__main__.py
+++ b/pantheon/chatroom/__main__.py
@@ -130,6 +130,23 @@ def oauth(action: str = "status", provider: str = "codex"):
         print("Actions: login, import, status, logout")
 
 
+async def endpoint_cmd(
+    workspace_path: str | None = None,
+    id_hash: str | None = None,
+    config_path: str | None = None,
+):
+    """Run a per-project Endpoint as a subcommand of THIS binary.
+
+    The chatroom spawns per-project endpoints. In a PyInstaller bundle the exe's
+    entry point is fixed to this module, so `-m pantheon.endpoint` does NOT work
+    (it falls through to `start`, launching a second chatroom that wrongly opens
+    a browser and exposes the wrong working dir). The chatroom instead invokes
+    `<exe> endpoint --workspace_path … --id_hash …`, and Fire routes it here.
+    Imported lazily to avoid an import cycle at startup."""
+    from pantheon.endpoint.__main__ import start_endpoint
+    await start_endpoint(config_path=config_path, workspace_path=workspace_path, id_hash=id_hash)
+
+
 if __name__ == "__main__":
     # Check for API keys and run setup wizard if none found
     check_and_run_setup()
@@ -142,6 +159,6 @@ if __name__ == "__main__":
     if len(sys.argv) == 1 or (len(sys.argv) > 1 and sys.argv[1].startswith("-")):
         sys.argv.insert(1, "start")
     fire.Fire(
-        {"start": start_services, "oauth": oauth},
+        {"start": start_services, "endpoint": endpoint_cmd, "oauth": oauth},
         name="pantheon-chatroom",
     )

--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -292,11 +292,25 @@ class ChatRoom(ToolSet):
         internal = os.getenv("PANTHEON_INTERNAL_BACKEND", "tcp")
         env["PANTHEON_REMOTE_BACKEND"] = internal  # endpoint primary = internal transport (ChatRoom side)
         env.setdefault("PANTHEON_FRONTEND_BACKEND", "nats")  # endpoint secondary = frontend
+        # Safety net: a spawned endpoint must NEVER auto-open a browser. If the
+        # binary ever falls through to start_services, this still suppresses it.
+        env["PANTHEON_DISABLE_AUTO_UI"] = "1"
 
-        cmd = [
-            sys.executable, "-m", "pantheon.endpoint", "start",
-            "--workspace_path", project_path, "--id_hash", id_hash,
-        ]
+        if getattr(sys, "frozen", False):
+            # PyInstaller bundle: `-m pantheon.endpoint` does NOT work — the exe's
+            # entry point is fixed to pantheon.chatroom, so `-m …` falls through to
+            # `start` and launches a second chatroom (wrong: opens a browser, wrong
+            # work dir). Use the chatroom exe's `endpoint` subcommand instead; it
+            # routes to the same start_endpoint() and is reachable from the binary.
+            cmd = [
+                sys.executable, "endpoint",
+                "--workspace_path", project_path, "--id_hash", id_hash,
+            ]
+        else:
+            cmd = [
+                sys.executable, "-m", "pantheon.endpoint", "start",
+                "--workspace_path", project_path, "--id_hash", id_hash,
+            ]
         logger.info(f"[multi-project] spawning endpoint for {project_path} (sid={sid[:12]}…)")
         log_fh = open(log_file, "w", encoding="utf-8")
         proc = await asyncio.create_subprocess_exec(
@@ -1564,7 +1578,19 @@ class ChatRoom(ToolSet):
             except ValueError as exc:
                 return {"success": False, "message": str(exc)}
 
-        memory = await run_func(self.memory_manager.new_memory, chat_name)
+        # Create the chat's memory in the NAMED project's own store (not the global
+        # active project) — so a desktop window scoped to project P puts its new
+        # chats in P regardless of which project another window made active.
+        _target_dir = None
+        if project_name and hasattr(self.memory_manager, "new_memory_in"):
+            for _p in self.project_manager.list_projects():
+                if _p.get("name") == project_name and _p.get("path"):
+                    _target_dir = project_memory_dir(_p["path"])
+                    break
+        if _target_dir:
+            memory = await run_func(self.memory_manager.new_memory_in, _target_dir, chat_name)
+        else:
+            memory = await run_func(self.memory_manager.new_memory, chat_name)
         memory.set_metadata("last_activity_date", datetime.now().isoformat())
 
         project = copy.deepcopy(project_metadata) if project_metadata else {}
@@ -1714,7 +1740,37 @@ class ChatRoom(ToolSet):
             - chats: A list of dictionaries, each containing the info of a chat.
         """
         try:
-            metadata_items = await run_func(self.memory_manager.list_memory_metadata, True)
+            # Scoping a chat list to a project (a desktop window).
+            _filter_by_name = False
+            if project_name is not None:
+                # If project_name is a REGISTERED project (desktop window), list
+                # ITS store directly. Its chats physically live there but are NOT
+                # reliably tagged with project.name (pre-existing chats carry only
+                # workspace_mode), so a name-tag filter would wrongly hide them.
+                _proj = next(
+                    (p for p in self.project_manager.list_projects()
+                     if p.get("name") == project_name),
+                    None,
+                )
+                if _proj is not None and hasattr(self.memory_manager, "list_memory_metadata_in"):
+                    metadata_items = await run_func(
+                        self.memory_manager.list_memory_metadata_in,
+                        project_memory_dir(_proj["path"]), True,
+                    )
+                elif hasattr(self.memory_manager, "list_all_memory_metadata"):
+                    # Not a registered project (e.g. hub test-user isolation keyed
+                    # by user id): aggregate across stores and filter by name tag.
+                    _dirs = [project_memory_dir(p["path"]) for p in self.project_manager.list_projects()]
+                    metadata_items = await run_func(
+                        self.memory_manager.list_all_memory_metadata, _dirs, True
+                    )
+                    _filter_by_name = True
+                else:
+                    metadata_items = await run_func(self.memory_manager.list_memory_metadata, True)
+                    _filter_by_name = True
+            else:
+                # Single-window / web / home-window default: active store only.
+                metadata_items = await run_func(self.memory_manager.list_memory_metadata, True)
             chats = []
             skipped_chats = []
             for item in metadata_items:
@@ -1730,8 +1786,10 @@ class ChatRoom(ToolSet):
                     continue
                 project = extra_data.get("project", None)
 
-                # Filter by project_name if specified
-                if project_name is not None:
+                # Filter by project_name only on the aggregate-by-name-tag path
+                # (hub test-user isolation). The registered-project path already
+                # listed exactly that project's store, so no name filter there.
+                if project_name is not None and _filter_by_name:
                     chat_project_name = project.get("name") if isinstance(project, dict) else None
                     if chat_project_name != project_name:
                         continue

--- a/pantheon/chatroom/routed_memory.py
+++ b/pantheon/chatroom/routed_memory.py
@@ -115,6 +115,55 @@ class ProjectRoutedMemoryManager:
     def list_memory_metadata(self, include_errors: bool = False):
         return self._mgr(self._active_dir).list_memory_metadata(include_errors)
 
+    # ---- explicit-project ops (for per-window / multi-project views) ------
+    # The desktop runs one window PER project against ONE shared backend, so the
+    # chat list and new-chat must be scoped to a *specific* project — not the
+    # single global active dir. These target a project explicitly.
+    def new_memory_in(self, project_dir: str | Path, name: str | None = None):
+        """Create a new chat in a SPECIFIC project's store (not the active one)."""
+        d = str(Path(project_dir).resolve())
+        memory = self._mgr(d).new_memory(name)
+        self._chat_dir[memory.id] = d
+        return memory
+
+    def list_memory_metadata_in(self, project_dir: str | Path, include_errors: bool = False):
+        """List chat metadata in ONE specific project's store (by directory).
+
+        A desktop project window must show the chats that physically live in its
+        project's store — chats are organised by store, NOT reliably tagged with a
+        ``project.name`` (pre-existing chats carry only ``workspace_mode``), so a
+        name-tag filter would hide them. This lists the store directly instead."""
+        d = str(Path(project_dir).resolve())
+        return self._mgr(d).list_memory_metadata(include_errors)
+
+    def list_all_memory_metadata(self, dirs=None, include_errors: bool = False):
+        """Aggregate chat metadata across ALL known project stores — the home dir,
+        the active dir, the configured search dirs, and any extra ``dirs`` passed
+        in — deduped by chat id (first store wins). Callers filter by project name.
+        This is what lets each window list its own project's chats regardless of
+        which project is globally 'active'."""
+        all_dirs: list[str] = [self._home_dir, self._active_dir, *self._search_dirs]
+        for d in (dirs or []):
+            try:
+                all_dirs.append(str(Path(d).resolve()))
+            except Exception:
+                continue
+        seen: set[str] = set()
+        out: list = []
+        for d in dict.fromkeys(all_dirs):  # dedupe dirs, preserve order
+            try:
+                for item in self._mgr(d).list_memory_metadata(include_errors):
+                    cid = item.get("id") if isinstance(item, dict) else None
+                    if cid is not None:
+                        if cid in seen:
+                            continue
+                        seen.add(cid)
+                    out.append(item)
+            except Exception as e:
+                logger.debug(f"[routed memory] list {d} failed: {e}")
+                continue
+        return out
+
     @property
     def path(self):
         return self._mgr(self._active_dir).path

--- a/pantheon/chatroom/start.py
+++ b/pantheon/chatroom/start.py
@@ -388,6 +388,13 @@ async def start_services(
         total = tm.force_sync_factory_templates()
         logger.info(f"[sync-templates] Synced {total} template(s) from factory")
 
+    # Hard kill-switch: an env var (set by the desktop and when the chatroom
+    # spawns per-project endpoints) forces the browser auto-open OFF regardless
+    # of the parsed flag — belt-and-suspenders against a misrouted subprocess.
+    import os as _os
+    if _os.getenv("PANTHEON_DISABLE_AUTO_UI", "").lower() in ("1", "true", "yes", "on"):
+        auto_ui = False
+
     # Validate auto_ui parameter
     if auto_ui and not auto_start_nats:
         raise ValueError(

--- a/tests/test_routed_memory_multiproject.py
+++ b/tests/test_routed_memory_multiproject.py
@@ -1,0 +1,68 @@
+"""Phase 0 (desktop multi-window): the routed memory manager must support
+per-project ops against ONE shared backend — list chats across ALL projects (each
+window then filters to its own) and create a new chat in a SPECIFIC project store,
+not just the single global active dir.
+"""
+from pathlib import Path
+
+from pantheon.chatroom.routed_memory import (
+    ProjectRoutedMemoryManager,
+    project_memory_dir,
+)
+
+
+def _mk_project(base: Path, name: str) -> str:
+    proj = base / name
+    (proj / ".pantheon" / "memory").mkdir(parents=True, exist_ok=True)
+    return str(proj)
+
+
+def test_new_memory_in_targets_specific_project(tmp_path):
+    mgr = ProjectRoutedMemoryManager(str(tmp_path / "home"))
+    dirA = project_memory_dir(_mk_project(tmp_path, "projA"))
+    dirB = project_memory_dir(_mk_project(tmp_path, "projB"))
+
+    # Active is A, but create a chat EXPLICITLY in B.
+    mgr.set_active_dir(dirA)
+    memB = mgr.new_memory_in(dirB, "in B")
+    memB.set_metadata("name", "in B")  # persist (mirrors create_chat)
+
+    # The chat is routed to B's store, not the active A.
+    assert mgr._chat_dir[memB.id] == str(Path(dirB).resolve())
+    assert mgr._dir_for_chat(memB.id) == str(Path(dirB).resolve())
+
+    # A new chat via the active path still lands in A.
+    memA = mgr.new_memory("in A")
+    memA.set_metadata("name", "in A")
+    assert mgr._dir_for_chat(memA.id) == str(Path(dirA).resolve())
+
+
+def test_list_all_aggregates_across_projects_regardless_of_active(tmp_path):
+    mgr = ProjectRoutedMemoryManager(str(tmp_path / "home"))
+    dirA = project_memory_dir(_mk_project(tmp_path, "projA"))
+    dirB = project_memory_dir(_mk_project(tmp_path, "projB"))
+    mgr.set_search_dirs([dirA, dirB])
+    mgr.set_active_dir(dirA)
+
+    a = mgr.new_memory_in(dirA, "chat A"); a.set_metadata("name", "chat A")
+    b = mgr.new_memory_in(dirB, "chat B"); b.set_metadata("name", "chat B")
+
+    # Legacy active-only list sees only A's chat.
+    active_ids = {m["id"] for m in mgr.list_memory_metadata(True)}
+    assert a.id in active_ids and b.id not in active_ids
+
+    # Aggregate list sees BOTH — this is what lets each window list its own
+    # project's chats regardless of which project is globally active.
+    all_ids = {m["id"] for m in mgr.list_all_memory_metadata([dirA, dirB], True)}
+    assert a.id in all_ids and b.id in all_ids
+
+
+def test_list_all_dedupes_by_chat_id(tmp_path):
+    mgr = ProjectRoutedMemoryManager(str(tmp_path / "home"))
+    dirA = project_memory_dir(_mk_project(tmp_path, "projA"))
+    a = mgr.new_memory_in(dirA, "chat A"); a.set_metadata("name", "chat A")
+
+    # Same dir reached via search_dirs AND the extra dirs arg → counted once.
+    mgr.set_search_dirs([dirA])
+    items = mgr.list_all_memory_metadata([dirA, dirA], True)
+    assert [m["id"] for m in items].count(a.id) == 1


### PR DESCRIPTION
Backend support for the pantheon-desktop multi-window feature (one window per project, one shared backend).

- **routed_memory**: `new_memory_in` / `list_all_memory_metadata` / `list_memory_metadata_in` for per-project (per-window) chat stores.
- **room.list_chats**: list a registered project's store directly — chats live in a store, not reliably tagged with `project.name`, so a name filter hid them.
- **room._spawn_project_endpoint**: when frozen (PyInstaller), spawn via the chatroom exe's `endpoint` subcommand. `-m pantheon.endpoint` does not work in a frozen binary → it fell through to `start_services` (a misrouted chatroom that opened a browser + exposed the wrong work dir). + `PANTHEON_DISABLE_AUTO_UI` kill-switch.
- **chatroom/__main__**: add `endpoint` subcommand routing to `start_endpoint`.

Pairs with pantheon-ui `feat/desktop-multi-window`. Verified end-to-end on the bundled macOS app.