### PR TITLE
Notebook cwd + skill resolution + template/file-viewer fixes

### DIFF
--- a/pantheon/factory/templates/prompts/jupyter_notebook.md
+++ b/pantheon/factory/templates/prompts/jupyter_notebook.md
@@ -1,0 +1,51 @@
+---
+id: jupyter_notebook
+name: Jupyter Notebook Usage
+description: |
+  When to reach for a notebook vs. scripts, and how file paths resolve inside a
+  notebook vs. your other tools. Included by agents that carry the
+  integrated_notebook toolset.
+---
+
+### Notebooks vs. Scripts — pick the right medium
+
+When the work is **data analysis, exploration, or scientific computation**, do
+it in an **integrated notebook** (`integrated_notebook`), not ad-hoc scripts. A
+notebook keeps narrative, code, and outputs (tables, figures) together in one
+re-runnable document — which is exactly what makes analysis **reproducible and
+readable**. Default to a notebook for: EDA, statistical analysis,
+plotting/visualization, iterative data exploration, and any "analyze / explore /
+investigate this data" request. Register the notebook as a deliverable with
+`register_output`.
+
+Use **scripts, direct file edits, or the shell** for everything else: quick
+one-off operations, data/file wrangling utilities, **software development**
+(building tools, libraries, apps), and writing or running **tests**. These don't
+benefit from a notebook's narrative format and belong in version-controlled
+source files.
+
+When a task mixes both (e.g., build a small tool, then analyze its output), use
+a script for the tooling and a notebook for the analysis.
+
+### Notebook file paths
+
+A notebook's kernel runs with its working directory set to the **notebook's own
+folder** (standard Jupyter), so relative paths in a cell resolve **next to the
+`.ipynb`**, not at the workspace root:
+
+```python
+# cell in scatac_pbmc500/analysis.ipynb
+plt.savefig("figures/umap.png")        # -> scatac_pbmc500/figures/umap.png
+```
+
+Your non-notebook tools — file manager, shell, `register_output`, `observe_images`
+— operate from the **workspace root**. So to read, verify, or register a file a
+notebook wrote, give its path from the workspace root (include the notebook's
+folder):
+
+```python
+register_output("scatac_pbmc500/figures/umap.png")   # not "figures/umap.png"
+```
+
+Absolute paths resolve identically from any tool — use them when you want to avoid
+the relative-vs-root distinction entirely.

--- a/pantheon/factory/templates/teams/default.md
+++ b/pantheon/factory/templates/teams/default.md
@@ -80,25 +80,7 @@ may still go to `scientific_illustrator`.) If you catch yourself about to
 delegate "run / compute / generate / analyze / segment ..." to a researcher,
 stop — that work is yours.
 
-### Notebooks vs. Scripts — pick the right medium
-
-When the work is **data analysis, exploration, or scientific computation**, do
-it in an **integrated notebook** (`integrated_notebook`), not ad-hoc scripts. A
-notebook keeps narrative, code, and outputs (tables, figures) together in one
-re-runnable document — which is exactly what makes analysis **reproducible and
-readable**. Default to a notebook for: EDA, statistical analysis,
-plotting/visualization, iterative data exploration, and any "analyze / explore /
-investigate this data" request. Register the notebook as a deliverable with
-`register_output`.
-
-Use **scripts, direct file edits, or the shell** for everything else: quick
-one-off operations, data/file wrangling utilities, **software development**
-(building tools, libraries, apps), and writing or running **tests**. These don't
-benefit from a notebook's narrative format and belong in version-controlled
-source files.
-
-When a task mixes both (e.g., build a small tool, then analyze its output), use
-a script for the tooling and a notebook for the analysis.
+{{jupyter_notebook}}
 
 ### Parallel Delegation
 

--- a/pantheon/internal/learning_system/store.py
+++ b/pantheon/internal/learning_system/store.py
@@ -67,8 +67,15 @@ class SkillStore:
         return headers[:MAX_SKILLS]
 
     def load_skill(self, name: str) -> SkillEntry | None:
-        """Load full skill content by name using project -> global -> factory."""
-        found = self._find_skill_dir_with_base(name)
+        """Load full skill content by name using project -> global -> factory.
+
+        Resolution is forgiving so an agent can follow a SKILL.md's relative links
+        verbatim: a parent-relative path ("sc_best_practices/chromatin_accessibility"),
+        a bare nested leaf ("database_access"), or a link with a trailing "/SKILL.md"
+        all resolve to the right (possibly nested) skill — see
+        _find_skill_dir_forgiving().
+        """
+        found = self._find_skill_dir_with_base(name) or self._find_skill_dir_forgiving(name)
         if not found:
             return None
         skill_dir, base_dir, scope = found
@@ -94,6 +101,10 @@ class SkillStore:
             raise ValueError(err)
 
         skill_dir = self._find_skill_dir(name)
+        if not skill_dir:
+            # Forgiving fallback for parent-relative skill refs (read-only path).
+            forgiving = self._find_skill_dir_forgiving(name)
+            skill_dir = forgiving[0] if forgiving else None
         if not skill_dir:
             return None
 
@@ -362,6 +373,95 @@ class SkillStore:
                 dirs[:] = []
                 continue
             dirs[:] = [d for d in dirs if not d.startswith(".")]
+
+    @staticmethod
+    def _walk_skill_dirs(base_dir: Path):
+        """Yield (skill_dir, rel_parts) for EVERY skill in base_dir, nested included.
+
+        Unlike _iter_skill_files (which prunes at the first SKILL.md to list only
+        top-level skills), this descends fully so nested sub-skills stay visible —
+        required to resolve a parent-relative reference like "database_access" or
+        "sc_best_practices/chromatin_accessibility" back to its full path.
+        """
+        if not base_dir or not base_dir.exists():
+            return
+        for root, dirs, files in os.walk(base_dir):
+            dirs[:] = [d for d in dirs if not d.startswith(".")]
+            if "SKILL.md" in files:
+                d = Path(root)
+                yield d, d.relative_to(base_dir).parts
+
+    @staticmethod
+    def _norm_skill_ref(name: str) -> str:
+        """Strip a trailing '/SKILL.md' (a SKILL.md link names its own skill)."""
+        norm = name.strip().strip("/")
+        if norm.endswith("/SKILL.md"):
+            norm = norm[: -len("/SKILL.md")]
+        return norm
+
+    def _find_skill_dir_forgiving(self, name: str) -> tuple[Path, Path, str] | None:
+        """Resolve a parent-relative skill reference to its full nested path.
+
+        For agents that follow a SKILL.md's relative links verbatim and drop the
+        parent prefix (e.g. "database_access" or "sc_best_practices/..." instead of
+        "omics/database_access"). Strips a trailing "/SKILL.md", then matches the
+        UNIQUE skill whose path ends with the requested segments. Refuses to guess
+        when ambiguous. Read-only — not used on the write path, so create()'s
+        collision check stays exact.
+        """
+        norm = self._norm_skill_ref(name)
+        if not norm or norm == "SKILL.md":
+            return None
+        want = tuple(Path(norm).parts)
+        for base_dir, scope in self._skill_layers():
+            matches = [
+                d
+                for d, rel in self._walk_skill_dirs(base_dir)
+                if len(want) <= len(rel) and rel[-len(want):] == want
+            ]
+            if len(matches) == 1:
+                return matches[0], base_dir, scope
+            if len(matches) > 1:
+                return None
+        return None
+
+    def suggest_for(self, name: str, limit: int = 4) -> list[str]:
+        """Suggest the correct skill_view() call(s) for a name that didn't resolve.
+
+        Matches nested skills by path-suffix and, when the name's tail looks like a
+        supporting file, the skill that owns it — so a wrong guess gets the exact
+        call to make next instead of a bare 'not found'.
+        """
+        norm = self._norm_skill_ref(name)
+        if not norm:
+            return []
+        parts = tuple(Path(norm).parts)
+
+        def suffix_skill_matches(want: tuple) -> list[str]:
+            hits: list[str] = []
+            for base_dir, _scope in self._skill_layers():
+                for _d, rel in self._walk_skill_dirs(base_dir):
+                    if rel and len(want) <= len(rel) and rel[-len(want):] == want:
+                        hits.append("/".join(rel))
+            return hits
+
+        out: list[str] = []
+        seen: set[str] = set()
+
+        def add(s: str) -> None:
+            if s not in seen:
+                seen.add(s)
+                out.append(s)
+
+        # (a) the name (minus /SKILL.md) is itself a nested skill
+        for ident in suffix_skill_matches(parts):
+            add(f"skill_view(name='{ident}')")
+        # (b) the tail looks like a supporting file -> point at its owning skill
+        tail = parts[-1] if parts else ""
+        if len(parts) >= 2 and "." in tail:
+            for ident in suffix_skill_matches(parts[:-1]):
+                add(f"skill_view(name='{ident}', file_path='{tail}')")
+        return out[:limit]
 
     @staticmethod
     def _atomic_write(path: Path, content: str) -> None:

--- a/pantheon/internal/learning_system/toolset.py
+++ b/pantheon/internal/learning_system/toolset.py
@@ -109,7 +109,7 @@ class SkillToolSet(ToolSet):
             if not entry:
                 return self._json({
                     "success": False,
-                    "error": f"Skill '{name}' not found. Use skill_list() to see available skills.",
+                    "error": self._not_found_msg(name),
                 })
             # A SKILL.md path points at a (possibly nested) skill's MAIN file —
             # itself a skill, not a supporting file. Resolve it to that skill so
@@ -153,10 +153,29 @@ class SkillToolSet(ToolSet):
         if not entry:
             return self._json({
                 "success": False,
-                "error": f"Skill '{name}' not found. Use skill_list() to see available skills.",
+                "error": self._not_found_msg(name),
             })
 
         return self._skill_view_result(entry)
+
+    def _not_found_msg(self, name: str) -> str:
+        """Not-found error enriched with concrete skill_view() suggestions when the
+        name looks like a parent-relative reference followed from a SKILL.md link."""
+        store = self._runtime.store
+        suggestions = []
+        if store:
+            try:
+                suggestions = store.suggest_for(name)
+            except Exception:
+                suggestions = []
+        if suggestions:
+            return (
+                f"Skill '{name}' not found. Did you mean: "
+                + " | ".join(suggestions)
+                + " ? (Nested skills/files need the full path, or use "
+                "skill_view(name=<parent>, file_path=...).)"
+            )
+        return f"Skill '{name}' not found. Use skill_list() to see available skills."
 
     def _skill_view_result(self, entry) -> str:
         """Build the full-skill JSON result. Shared by the no-file_path branch

--- a/pantheon/toolsets/file/file_manager.py
+++ b/pantheon/toolsets/file/file_manager.py
@@ -111,6 +111,37 @@ def _replace_in_content(
         return new_content, replaced, None
 
 
+def _resolve_template_layer_path(file_path: str) -> Path | None:
+    """Resolve a `.pantheon/{prompts,teams,agents}/<name>.md` reference through the
+    template precedence (global ~/.pantheon -> factory package templates) when the
+    workspace has no project-level copy. Read-only, namespace-scoped, no path
+    traversal; None if not such a reference or nothing resolves.
+
+    Module-level on purpose: a ToolSet subclass method here would be auto-registered
+    and asyncified into a coroutine tool.
+    """
+    rel = str(file_path).replace("\\", "/")
+    marker = ".pantheon/"
+    idx = rel.find(marker)
+    if idx == -1:
+        return None
+    segs = [s for s in rel[idx + len(marker):].split("/") if s]
+    if len(segs) < 2 or segs[0] not in ("prompts", "teams", "agents") or ".." in segs:
+        return None
+    sub = Path(*segs)
+    bases: list[Path] = [Path.home() / ".pantheon"]
+    try:
+        import pantheon.factory as _factory
+        bases.append(Path(_factory.__file__).resolve().parent / "templates")
+    except Exception:
+        pass
+    for base in bases:
+        cand = base / sub
+        if cand.is_file():
+            return cand
+    return None
+
+
 class FileManagerToolSetBase(ToolSet):
     """Base class for file manager toolsets.
 
@@ -769,6 +800,11 @@ class FileManagerToolSet(FileManagerToolSetBase):
 
         # Support both absolute and relative paths
         target_path = self._resolve_path(file_path)
+        if not target_path.exists():
+            # Template references (.pantheon/{prompts,teams,agents}/*) resolve
+            # through layer precedence — fall back to global/factory when the
+            # workspace has no project-level copy.
+            target_path = _resolve_template_layer_path(file_path) or target_path
         if not target_path.exists():
             return {"success": False, "error": "File does not exist"}
         if not target_path.is_file():

--- a/pantheon/toolsets/notebook/integrated_notebook.py
+++ b/pantheon/toolsets/notebook/integrated_notebook.py
@@ -407,6 +407,21 @@ class IntegratedNotebookToolSet(ToolSet):
             "message": f"Kernel '{kernel_name}' registered. Use kernel_spec='{kernel_name}' when creating notebooks.",
         }
 
+    def _notebook_dir(self, notebook_path: str) -> str | None:
+        """Absolute directory containing the notebook file, so its kernel starts
+        there and relative paths inside the notebook (e.g. savefig("figures/x.png"))
+        land next to the .ipynb — standard Jupyter behavior. Returns None to let
+        create_session fall back to the workspace workdir when it can't resolve."""
+        try:
+            base = self._get_effective_workdir() or self.workdir
+            p = Path(notebook_path)
+            if not p.is_absolute():
+                p = Path(base) / p
+            nb_dir = p.resolve().parent
+            return str(nb_dir) if nb_dir.is_dir() else None
+        except Exception:
+            return None
+
     async def _get_or_create_context(
         self, notebook_path: str, session_id: str, kernel_spec: str = "python3"
     ) -> NotebookContext:
@@ -444,8 +459,12 @@ class IntegratedNotebookToolSet(ToolSet):
                         )
                     notebook_file_is_new = True
 
-                # 2. Create kernel session (internal)
-                kernel_result = await self.kernel_toolset.create_session(kernel_spec)
+                # 2. Create kernel session (internal). Start it in the notebook's
+                # OWN directory so relative paths inside the notebook resolve next
+                # to the .ipynb (standard Jupyter behavior), not at the workspace root.
+                kernel_result = await self.kernel_toolset.create_session(
+                    kernel_spec, cwd=self._notebook_dir(notebook_path)
+                )
                 if not kernel_result["success"]:
                     raise Exception(f"Failed to create kernel: {kernel_result['error']}")
 
@@ -481,6 +500,7 @@ class IntegratedNotebookToolSet(ToolSet):
                     kernel_result = await self.kernel_toolset.create_session(
                         kernel_spec=context.kernel_spec,
                         kernel_session_id=context.kernel_session_id,
+                        cwd=self._notebook_dir(notebook_path),
                     )
 
                     if not kernel_result["success"]:

--- a/pantheon/toolsets/notebook/jupyter_kernel.py
+++ b/pantheon/toolsets/notebook/jupyter_kernel.py
@@ -377,9 +377,17 @@ class JupyterKernelToolSet(ToolSet):
 
     @tool
     async def create_session(
-        self, kernel_spec: str = "python3", kernel_session_id: str = None
+        self, kernel_spec: str = "python3", kernel_session_id: str = None,
+        cwd: str | None = None,
     ) -> dict:
-        """Create new kernel session"""
+        """Create new kernel session.
+
+        cwd: absolute working directory to start the kernel in. The notebook
+        layer passes the .ipynb's OWN folder so relative paths inside the
+        notebook (e.g. savefig("figures/x.png")) land next to the notebook —
+        standard Jupyter behavior. Falls back to the effective workspace workdir
+        when not given or not an existing directory.
+        """
         import json
         try:
             if kernel_session_id is None:
@@ -425,7 +433,13 @@ class JupyterKernelToolSet(ToolSet):
                 for k, v in sorted_env[:3]:
                     logger.warning(f"Large Env Var: {k} (Size: {len(str(v))} bytes)")
 
-            await km.start_kernel(cwd=self._get_effective_workdir() or self.workdir, env=env)
+            kernel_cwd = cwd if (cwd and os.path.isdir(cwd)) else (self._get_effective_workdir() or self.workdir)
+            if cwd and cwd != kernel_cwd:
+                logger.warning(
+                    f"create_session: requested cwd '{cwd}' is not a directory; "
+                    f"falling back to '{kernel_cwd}'"
+                )
+            await km.start_kernel(cwd=kernel_cwd, env=env)
 
             # Wait for kernel to be ready
             kc = km.client()

--- a/pantheon/utils/adapters/anthropic_adapter.py
+++ b/pantheon/utils/adapters/anthropic_adapter.py
@@ -84,6 +84,19 @@ def _wrap_anthropic_error(e: Exception) -> Exception:
 # ============ Message Format Conversion ============
 
 
+def _msg_has_content(content: Any) -> bool:
+    """Whether a message carries any content. Anthropic 400s on an empty user
+    message ('user messages must have non-empty content'), which a bare approval
+    / empty user turn (content == [] or '') would otherwise produce."""
+    if content is None:
+        return False
+    if isinstance(content, str):
+        return content.strip() != ""
+    if isinstance(content, list):
+        return len(content) > 0
+    return bool(content)
+
+
 def _convert_messages_to_anthropic(messages: list[dict]) -> tuple[str | list | None, list[dict]]:
     """Convert OpenAI-format messages to Anthropic format.
 
@@ -147,7 +160,9 @@ def _convert_messages_to_anthropic(messages: list[dict]) -> tuple[str | list | N
                         result_content.extend(content)
                 converted.append({"role": "user", "content": result_content})
                 pending_tool_results = []
-            else:
+            elif _msg_has_content(content):
+                # Skip a bare/empty user turn (e.g. an approval action with no
+                # text) — an empty user message is rejected by the API.
                 converted.append({"role": "user", "content": content})
             continue
 
@@ -195,6 +210,11 @@ def _convert_messages_to_anthropic(messages: list[dict]) -> tuple[str | list | N
     # Flush remaining tool results
     if pending_tool_results:
         converted.append({"role": "user", "content": list(pending_tool_results)})
+
+    # Belt-and-suspenders: drop any message that still has empty content (a bare
+    # approval / empty user turn) before the alternation-merge, so the merge sees
+    # only real content and the API never gets an empty user message.
+    converted = [m for m in converted if _msg_has_content(m.get("content"))]
 
     # Anthropic requires alternating user/assistant messages
     # Merge consecutive same-role messages

--- a/tests/test_learning_system/test_store.py
+++ b/tests/test_learning_system/test_store.py
@@ -174,6 +174,96 @@ class TestLoadSkill:
         assert "packaged factory skill" in entry.content
 
 
+def _write_skill(base, rel, name, body="Body.\n"):
+    md = base / rel / "SKILL.md"
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text(
+        f"---\nname: {name}\ndescription: {name} skill\n---\n\n{body}",
+        encoding="utf-8",
+    )
+    return md
+
+
+class TestNestedSkillResolution:
+    """An agent following a SKILL.md's RELATIVE links drops the parent prefix
+    (e.g. 'database_access' instead of 'omics/database_access'). load_skill /
+    load_file must still resolve those to the right nested skill; writes must not.
+    Mirrors the omics/* skill tree that broke skill reads."""
+
+    @pytest.fixture
+    def nested_store(self, tmp_path):
+        factory = tmp_path / "factory" / "skills"
+        _write_skill(factory, "omics", "omics")
+        _write_skill(factory, "omics/database_access", "database_access")
+        _write_skill(factory, "omics/sc_best_practices", "sc_best_practices")
+        (factory / "omics/sc_best_practices" / "chromatin.md").write_text(
+            "chromatin notes", encoding="utf-8"
+        )
+        _write_skill(factory, "omics/upstream/nfcore", "nfcore")
+        return SkillStore(
+            tmp_path / "p" / "s",
+            tmp_path / "p" / "r",
+            global_skills_dir=tmp_path / "g" / "s",
+            factory_skills_dir=factory,
+        )
+
+    def test_full_path_still_resolves(self, nested_store):
+        assert nested_store.load_skill("omics/database_access").path == "omics/database_access"
+
+    def test_link_text_with_skill_md_suffix(self, nested_store):
+        # The agent's exact failing form: skill_view(name="database_access/SKILL.md")
+        assert nested_store.load_skill("database_access/SKILL.md").path == "omics/database_access"
+
+    def test_bare_nested_leaf(self, nested_store):
+        assert nested_store.load_skill("database_access").path == "omics/database_access"
+
+    def test_partial_and_deep_leaf(self, nested_store):
+        assert nested_store.load_skill("upstream/nfcore").path == "omics/upstream/nfcore"
+        assert nested_store.load_skill("nfcore").path == "omics/upstream/nfcore"
+
+    def test_real_miss_returns_none(self, nested_store):
+        assert nested_store.load_skill("does_not_exist") is None
+
+    def test_supporting_file_with_dropped_prefix(self, nested_store):
+        # skill_view(name="sc_best_practices", file_path="chromatin.md")
+        assert nested_store.load_file("sc_best_practices", "chromatin.md") == "chromatin notes"
+
+    def test_ambiguous_leaf_refuses_to_guess(self, tmp_path):
+        # Two same-named sub-skills under DIFFERENT parents (each a real skill, so
+        # the leaf is pruned from the exact-resolver and only the guarded forgiving
+        # resolver can see it). It must refuse to guess and suggest both.
+        factory = tmp_path / "factory" / "skills"
+        _write_skill(factory, "omics", "omics")
+        _write_skill(factory, "omics/database_access", "database_access")
+        _write_skill(factory, "proteomics", "proteomics")
+        _write_skill(factory, "proteomics/database_access", "database_access2")
+        store = SkillStore(
+            tmp_path / "p" / "s", tmp_path / "p" / "r", factory_skills_dir=factory
+        )
+        assert store.load_skill("database_access") is None  # two matches -> no guess
+        sugg = store.suggest_for("database_access")
+        assert "skill_view(name='omics/database_access')" in sugg
+        assert "skill_view(name='proteomics/database_access')" in sugg
+
+    def test_suggestions_point_at_correct_call(self, nested_store):
+        assert "skill_view(name='omics/database_access')" in nested_store.suggest_for(
+            "database_access/SKILL.md"
+        )
+        assert (
+            "skill_view(name='omics/sc_best_practices', file_path='chromatin.md')"
+            in nested_store.suggest_for("sc_best_practices/chromatin.md")
+        )
+
+    def test_write_path_stays_exact(self, nested_store):
+        # Forgiving resolution is read-only: creating a top-level "database_access"
+        # must NOT collide with the nested omics/database_access.
+        path = nested_store.create_skill(
+            "database_access",
+            "---\nname: database_access\ndescription: top-level one\n---\n\nNew.\n",
+        )
+        assert path == nested_store.skills_dir / "database_access" / "SKILL.md"
+
+
 class TestSupportingFiles:
     def test_write_and_load(self, store_with_skill):
         store_with_skill.write_supporting_file(


### PR DESCRIPTION
Five focused fixes from this session (each its own commit):

- **anthropic-adapter** — skip empty messages so a tool-approval-only turn no longer triggers Anthropic 400 `messages must have non-empty content`.
- **learning-system** — resolve nested skills by leaf/partial path (forgiving fallback across project → global → factory, refusing ambiguous matches), so an agent following a `SKILL.md`'s relative links (e.g. `database_access/SKILL.md`, `sc_best_practices/chromatin_accessibility.md`) resolves to the nested skill instead of "not found"; not-found errors now suggest the correct `skill_view(...)` call. +9 regression tests.
- **notebook** — start the kernel in the notebook's own directory, so a relative path like `savefig("figures/x.png")` lands next to the `.ipynb` instead of the workspace root (standard Jupyter behaviour; falls back to the workspace workdir when unset).
- **templates** — extract the default team leader's "Notebooks vs. Scripts" guidance into a shared `prompts/jupyter_notebook.md` (included via `{{jupyter_notebook}}`), plus the notebook file-path rule.
- **file-manager** — resolve `.pantheon/{prompts,teams,agents}/*.md` through layer precedence in `read_file`, so the file viewer (and agent) can open a prompt/team/agent that only lives in a higher layer instead of "File does not exist". Read-only, namespace-scoped, no path traversal; a project-level copy still wins.

Tests: learning-system 114 passed, file_manager 12 passed, notebook-cwd e2e verified.
