### PR TITLE
feat(cli): headless one-shot (-i) + resume (-r) + autonomous no-ask mode

### DIFF
--- a/pantheon/__main__.py
+++ b/pantheon/__main__.py
@@ -146,6 +146,23 @@ def main():
     except RuntimeError:
         asyncio.set_event_loop(asyncio.new_event_loop())
 
+    # Normalize the `cli` subcommand's flags before Fire parses them:
+    #   -r / -r=<id>  ->  --resume / --resume=<id>   (short alias)
+    #   --once        ->  deprecated no-op (passing -i now implies one-shot); drop it
+    #                     so existing callers (benchmark harness / older images) keep working.
+    if len(sys.argv) > 1 and sys.argv[1] == "cli":
+        _rest = []
+        for tok in sys.argv[2:]:
+            if tok == "-r":
+                _rest.append("--resume")
+            elif tok.startswith("-r="):
+                _rest.append("--resume=" + tok[3:])
+            elif tok == "--once" or tok.startswith("--once="):
+                continue
+            else:
+                _rest.append(tok)
+        sys.argv = sys.argv[:2] + _rest
+
     # Import REAL functions — Fire reads their signatures for --help
     from pantheon.repl.__main__ import start as cli
     from pantheon.chatroom.start import start_services as ui

--- a/pantheon/repl/__main__.py
+++ b/pantheon/repl/__main__.py
@@ -54,6 +54,7 @@ def start(
     quiet: bool = None,
     resync: bool = False,
     i: str = None,
+    model: str = None,
 ):
     """Start Pantheon REPL.
 
@@ -62,12 +63,14 @@ def start(
         memory_dir: Directory for chat persistence. (default from settings: .pantheon)
         workspace: Workspace directory for Endpoint.
         chat_id: Resume specific chat by ID.
-        resume: Resume a previous chat. Use --resume to resume the last chat,
-                or --resume=<id> / --resume=<number> to resume a specific one.
+        resume: Resume a previous chat. Use -r / --resume to resume the most recent
+                chat, or -r=<id> / --resume=<id> (or a number / name prefix) for a
+                specific one. Combine with -i to continue that chat's context one-shot.
         log_level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL). Default: CRITICAL.
         quiet: Disable all logging. Use --quiet to enable. (default: False)
         resync: Force resync templates by deleting skills/agents/teams directories. (default: False)
-        i: Initial input message to send immediately after startup.
+        i: Initial input message. Providing it runs headless one-shot (send it,
+           print the result, exit); omit it to start the interactive REPL.
     """
     # Load settings for defaults (CLI > Settings > code defaults)
     from pantheon.settings import get_settings
@@ -141,10 +144,16 @@ def start(
                 return
             chat_id = found["id"]
 
-    # Check for API keys and run setup wizard if none found
-    from .setup_wizard import check_and_run_setup
+    # Providing an initial input (-i) implies a headless one-shot run: send the
+    # message, print the result, and exit. Without -i, start the interactive REPL.
+    run_once = i is not None
 
-    check_and_run_setup()
+    # Check for API keys and run the setup wizard if none found — but skip it in
+    # headless one-shot mode (assume keys preconfigured) so automation never blocks.
+    if not run_once:
+        from .setup_wizard import check_and_run_setup
+
+        check_and_run_setup()
 
     asyncio.run(
         _start_async(
@@ -155,6 +164,8 @@ def start(
             log_level=log_level,
             quiet=quiet,
             initial_input=i,
+            once=run_once,
+            model=model,
         )
     )
 
@@ -168,6 +179,8 @@ async def _start_async(
     log_level: str = "CRITICAL",
     quiet: bool = False,
     initial_input: str = None,
+    once: bool = False,
+    model: str = None,
 ):
     """Async implementation of start."""
     from pantheon.settings import get_settings
@@ -301,10 +314,26 @@ async def _start_async(
     # Disable logging unless explicitly set to DEBUG
     disable_logging = quiet and log_level != "DEBUG"
 
-    await repl.run(message=initial_input, disable_logging=disable_logging, log_level=log_level)
+    await repl.run(message=initial_input, disable_logging=disable_logging, log_level=log_level, once=once, model=model)
 
 
 if __name__ == "__main__":
+    # Normalize argv before Fire parses it:
+    #   -r / -r=<id>   -> short alias for --resume / --resume=<id>
+    #   --once         -> deprecated no-op (passing -i now implies one-shot); drop it
+    #                     so existing callers (benchmark harness / older images) don't break.
+    _argv = []
+    for tok in sys.argv:
+        if tok == "-r":
+            _argv.append("--resume")
+        elif tok.startswith("-r="):
+            _argv.append("--resume=" + tok[3:])
+        elif tok == "--once" or tok.startswith("--once="):
+            continue
+        else:
+            _argv.append(tok)
+    sys.argv = _argv
+
     # Support two call styles:
     # 1. python -m pantheon.repl start --template xxx
     # 2. python -m pantheon.repl --template xxx (implicit start)

--- a/pantheon/repl/core.py
+++ b/pantheon/repl/core.py
@@ -191,6 +191,9 @@ class Repl(ReplUI):
         # Pending user approval for notify_user        # Pending operations state
         self._pending_approval: dict | None = None
         self._pending_clear_confirmation: bool = False  # For /clear confirmation
+        # Headless one-shot mode: auto-approve plan/approval gates (no human at the keyboard)
+        self._auto_approve: bool = False
+        self._auto_approve_depth: int = 0
 
     def _create_chatroom_from_agent(
         self, agent: Agent | Team, memory_dir: str
@@ -730,13 +733,17 @@ class Repl(ReplUI):
         except Exception as e:
             logger.debug(f"[WARMUP] Tools warmup error (non-critical): {e}")
 
-    async def run(self, message: str | dict | None = None, disable_logging: bool = True, log_to_file: bool = True, log_level: str = "CRITICAL"):
+    async def run(self, message: str | dict | None = None, disable_logging: bool = True, log_to_file: bool = True, log_level: str = "CRITICAL", once: bool = False, model: str | None = None):
         """Main REPL loop.
-        
+
         Args:
             message: Optional initial message to process
             disable_logging: If True, suppress console logging (only show ERROR)
             log_to_file: If True, save all logs to .pantheon/logs/ (even when console logging is suppressed)
+            once: Headless one-shot mode — run `message` to completion through the
+                normal default team, then exit. No interactive prompt_toolkit UI
+                (no tty required). Used by the benchmark runner.
+            model: Optional model name/tag to apply to the team before running (once mode).
         """
         # Setup file logging FIRST (before suppressing console output)
         # This ensures all logs are captured to file for debugging
@@ -762,6 +769,37 @@ class Repl(ReplUI):
 
         # Print greeting first (REPL shows immediately)
         await self.print_greeting()
+
+        # Headless one-shot mode: run a single message to completion, then exit.
+        # Runs the SAME default team / skills / prompts as interactive `pantheon cli`,
+        # just without the prompt_toolkit TUI (no tty needed) — for the benchmark runner.
+        # _process_message() already supports prompt_app=None (falls back to a Live console).
+        if once:
+            # Headless one-shot (-i): signal the task system so notify_user never
+            # blocks on a non-existent user and the ephemeral reminders tell the
+            # agent to decide autonomously instead of asking/approving/choosing.
+            import os  # local: run() shadows the module-level os with a later import
+            os.environ["PANTHEON_HEADLESS"] = "1"
+            try:
+                self._init_renderers()
+            except Exception:
+                pass
+            # Headless: no human to approve plan-gates, so auto-approve and drive
+            # the agent to completion instead of cancelling at the approval dialog.
+            self._auto_approve = True
+            self._auto_approve_depth = 0
+            if model:
+                try:
+                    await self._handle_model_command(str(model))
+                except Exception as e:
+                    self.console.print(f"[yellow]--model override failed: {e}[/yellow]")
+            if message is not None:
+                await self._handle_message_or_command(message)
+            try:
+                await self._print_session_summary()
+            except Exception:
+                pass
+            return
 
         # Initialize prompt_toolkit app if enabled
         if self._use_prompt_toolkit:
@@ -1500,8 +1538,40 @@ class Repl(ReplUI):
         
         # Handle pending approval (notify_user with interrupt=True)
         if self._pending_approval:
-            await self._handle_pending_approval()
-    
+            if self._auto_approve:
+                await self._auto_approve_pending()
+            else:
+                await self._handle_pending_approval()
+
+    async def _auto_approve_pending(self):
+        """Headless auto-approval: approve the agent's plan/approval gate and drive
+        it to completion. No human is at the keyboard in `--once` mode, so the
+        interactive dialog would always cancel; instead we feed an approval back
+        into the same chat (preserving context) and let the agent execute.
+
+        Re-entrant: `_handle_message_or_command` re-checks `_pending_approval`
+        at the end, so a multi-step plan that gates several times keeps flowing.
+        A depth guard prevents an agent that gates every turn from looping forever.
+        """
+        approval_data = self._pending_approval or {}
+        self._pending_approval = None
+        self._auto_approve_depth += 1
+        if self._auto_approve_depth > 8:
+            self.console.print(
+                "[yellow]⚠ auto-approve limit reached (8); stopping to avoid a loop[/yellow]"
+            )
+            return
+        self.console.print("[green]✓ Auto-approved (headless --once)[/green]")
+        # If the gate asked structured questions, we can't answer them blindly;
+        # still nudge the agent to proceed with sensible defaults.
+        approve_msg = (
+            "Approved — proceed and execute the plan to completion now. "
+            "Do NOT ask for any further confirmation or approval; make reasonable "
+            "default choices for any open questions, run all remaining steps "
+            "autonomously, and save the final output to the requested path."
+        )
+        await self._handle_message_or_command(approve_msg)
+
     async def _handle_pending_approval(self):
         """Handle pending user approval with interactive dialog.
 

--- a/pantheon/toolsets/task/ephemeral.py
+++ b/pantheon/toolsets/task/ephemeral.py
@@ -170,6 +170,20 @@ def _read_incomplete_todos(brain_dir: str) -> list[str]:
     return items
 
 
+# Headless (-i / one-shot) — no user is present to answer. Counters the agent's
+# instinct (reinforced by the reminders below) to stop and ask: decide for itself.
+HEADLESS_AUTONOMOUS_REMINDER = """\
+<headless_autonomous_reminder>
+You are running HEADLESS: there is NO user present. You cannot ask questions,
+request approval, or offer choices — nobody will answer. Do NOT call
+notify_user(blocked_on_user=true) and do NOT pose questions to the user. For any
+consequential or under-specified decision (which dataset/method/scope, an
+expensive or irreversible step), choose the most reasonable default yourself,
+state your assumption briefly in your work, and proceed to completion
+autonomously. Use notify_user only to register final deliverables.
+</headless_autonomous_reminder>"""
+
+
 def generate_ephemeral_message(state: ConversationState, brain_dir: str) -> str:
     """Generate EPHEMERAL_MESSAGE based on current state.
 
@@ -181,6 +195,12 @@ def generate_ephemeral_message(state: ConversationState, brain_dir: str) -> str:
         XML-formatted ephemeral message content
     """
     parts = []
+
+    # Headless (-i / one-shot): no user to ask. Lead with a reminder to decide
+    # autonomously instead of trying to block on approvals/choices it can't get.
+    headless = os.environ.get("PANTHEON_HEADLESS") == "1"
+    if headless:
+        parts.append(HEADLESS_AUTONOMOUS_REMINDER)
 
     # 1. artifact_reminder (always included)
     if state.created_artifacts:
@@ -253,7 +273,8 @@ def generate_ephemeral_message(state: ConversationState, brain_dir: str) -> str:
     # (it read "find some data" as "pick silently"), so we nudge it at decision
     # time. Self-limiting: stops once review is requested or it leaves plan phase.
     if (
-        state.active_task
+        not headless  # headless: never nudge the agent to ask the user — nobody's there
+        and state.active_task
         and state.active_task.is_plan_phase
         and not state.pending_review_paths
     ):

--- a/pantheon/toolsets/task/task_toolset.py
+++ b/pantheon/toolsets/task/task_toolset.py
@@ -5,6 +5,7 @@ workflow modes (PLANNING/EXECUTION/VERIFICATION or RESEARCH/ANALYSIS/INTERPRETAT
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -151,6 +152,7 @@ class TaskToolSet(ToolSet):
             ModeSemantics.is_execute_mode(mode_upper)
             and not self.state.has_asked_user
             and not self.state.execution_gate_fired
+            and os.environ.get("PANTHEON_HEADLESS") != "1"  # headless: no user to confirm with
         ):
             self.state.execution_gate_fired = True
             gate_context = self.get_context()
@@ -381,6 +383,17 @@ class TaskToolSet(ToolSet):
         # This ensures logical consistency - asking questions implies waiting for answers
         has_questions = len(questions) > 0
         actual_interrupt = blocked_on_user or has_questions
+
+        # Headless (-i / one-shot): nobody is available to approve or answer. Never
+        # hand control back to a non-existent user — drop the interrupt and tell the
+        # agent to choose a sensible default and keep going to completion.
+        if actual_interrupt and os.environ.get("PANTHEON_HEADLESS") == "1":
+            actual_interrupt = False
+            message = (message or "") + (
+                "\n\n[Headless mode: no user is available to approve or answer. Do not "
+                "wait — pick the most reasonable default for any open decision, note "
+                "your assumption, and proceed to completion autonomously.]"
+            )
 
         return {
             "success": True,


### PR DESCRIPTION
## What

Makes `pantheon cli` fully scriptable (benchmarks, automation, cron) and ensures it never blocks on a non-existent user.

### Flags
- **`-i "<prompt>"` ⇒ headless one-shot**: run the prompt to completion, print, exit; skips the setup wizard. No separate `--once` flag. `--once` is still accepted as a **deprecated no-op** so the benchmark harness / older images keep working. Omit `-i` for the interactive REPL.
- **`-r` / `--resume [id]`**: resume a previous chat — most recent if no id, or `-r=<id>` / by number / name-prefix. Combine with `-i` to continue that chat's **context** in one shot.

### Headless = autonomous (no asking)
With no user present, the agent must not ask, request approval, or offer choices. The once path sets `PANTHEON_HEADLESS`, which:
- makes `notify_user` never hand control back — `interrupt` is forced off and the result tells the agent to choose a default and proceed;
- suppresses the `CONFIRM_OPEN_CHOICES` ephemeral nudge and the first-execution decision-point gate (both layered on top of, **not** reverting, the current EM);
- injects a `HEADLESS_AUTONOMOUS_REMINDER` so the agent proactively decides for itself.

## Files
`pantheon/__main__.py` (flag normalization), `pantheon/repl/__main__.py` (`-i`⇒once, `-r`), `pantheon/repl/core.py` (once mode + `PANTHEON_HEADLESS`), `pantheon/toolsets/task/ephemeral.py` + `task_toolset.py` (headless no-ask).

## Testing
Validated end-to-end via the docker agent image with this source mounted:
- `pantheon cli -i "..."` runs one-shot and exits (no `--once`).
- `pantheon cli -r -i "..."` resumed the most-recent session and **recalled context** from the prior run.
- An deliberately under-specified task ("start a single-cell analysis", no dataset named) **completed autonomously** — the agent chose a sensible dataset and finished instead of stopping to ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)