### PR TITLE
fix(adapters): bound LLM request timeout so a stalled endpoint fails fast

### DIFF
--- a/pantheon/utils/adapters/anthropic_adapter.py
+++ b/pantheon/utils/adapters/anthropic_adapter.py
@@ -277,8 +277,15 @@ class AnthropicAdapter(BaseAdapter):
         api_key: str | None = None,
     ):
         from anthropic import AsyncAnthropic
+        import httpx
 
-        kwargs = {}
+        # Bound the request so a stalled endpoint fails fast (~120s) and lets
+        # pantheon's own num_retries loop retry, instead of hanging on the SDK
+        # default (~600s). max_retries=0: don't also retry inside the SDK.
+        kwargs = {
+            "timeout": httpx.Timeout(120.0, connect=10.0),
+            "max_retries": 0,
+        }
         if base_url:
             kwargs["base_url"] = base_url
         if api_key:

--- a/pantheon/utils/adapters/openai_adapter.py
+++ b/pantheon/utils/adapters/openai_adapter.py
@@ -119,7 +119,14 @@ class OpenAIAdapter(BaseAdapter):
         api_key: str | None = None,
     ) -> AsyncOpenAI:
         """Create an AsyncOpenAI client with optional overrides."""
-        kwargs = {}
+        import httpx
+        # Bound the request so a stalled endpoint fails fast (~120s) and lets
+        # pantheon's own num_retries loop retry, instead of hanging on the SDK
+        # default (~600s). max_retries=0: don't also retry inside the SDK.
+        kwargs = {
+            "timeout": httpx.Timeout(120.0, connect=10.0),
+            "max_retries": 0,
+        }
         if base_url:
             kwargs["base_url"] = base_url
         if api_key:


### PR DESCRIPTION
## Problem

`AnthropicAdapter` and `OpenAIAdapter` construct their SDK clients with no timeout, so a stalled/hung endpoint blocks on the SDK default (~600s). In headless/benchmark runs this looked like a freeze for many minutes — in one case a container stayed wedged for ~1h before being killed.

## Fix

When building each client, pass:
```python
kwargs = {"timeout": httpx.Timeout(120.0, connect=10.0), "max_retries": 0}
```
- a stall now fails fast at ~120s (10s connect);
- `max_retries=0` so the SDK doesn't *also* retry — pantheon's own `num_retries` loop owns retries.

## Scope
Touches only client construction in the two adapters. **Independent of and complementary to `4307a4c`** (skip-empty-messages) — that fix is preserved untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)