### PR TITLE
store: automated skill reviewer (`pantheon store review`) + rubric

### DIFF
--- a/pantheon/factory/templates/skills/meta/skill_review.md
+++ b/pantheon/factory/templates/skills/meta/skill_review.md
@@ -1,0 +1,99 @@
+---
+id: skill-review
+name: Skill Review
+description: Evaluate a Pantheon store skill against a fixed rubric and emit a structured rating + review (per-dimension scores, an overall 0-100, a verdict, and best_for/not_for/caveats) for humans and for the auto-skill-selection mechanism. Use when assessing the quality of a store skill from its content. Do NOT use it to measure task lift — that requires the benchmark harness, not a read of the artifact.
+tags: [meta, evaluation, store, quality, reviewer]
+category: evaluation
+---
+
+# Skill Review
+
+A standard for reviewing **agent skills** — the Markdown playbooks (`SKILL.md` + bundled
+files) an LLM agent loads to do a task better. Apply this rubric to produce a consistent,
+structured review that both humans and the store's auto-skill-selection mechanism can act on.
+
+## Purpose & scope
+
+This is the **cheap, scalable expert-review layer**. It judges the *artifact as written*:
+is the content correct, actionable, well-scoped, safe, and routable? It is a **proxy** for
+how useful a skill is — not a measurement of it.
+
+It deliberately does **not** measure causal task lift (does an agent equipped with the skill
+actually solve more tasks?). That requires running the skill against held-out tasks with a
+deterministic verifier — the benchmark harness's job. When measured lift exists for a skill,
+**trust it over this review**. Treat this rubric's score as the signal you use to decide
+*which* skills are worth the expensive lift evaluation, and as a fallback where lift is absent.
+
+You review from the text only — you cannot execute the skill. Be skeptical and discriminating:
+most real skills land **2–4** on a dimension; reserve **5** for genuinely exemplary and **0–1**
+for broken or misleading.
+
+## The rubric (score each 0–5, with one line of evidence citing specifics)
+
+| Dimension | Weight | 5 looks like | 0 looks like |
+|---|---|---|---|
+| **correctness** & currency | 25 | Tools/APIs/params/methods correct and current; code blocks look runnable | Deprecated APIs, wrong params, factually misleading |
+| **activation** (when to use / not use) | 20 | Description gives precise positive AND negative triggers; a router can decide from it | Vague ("helps with bio analysis") or missing triggers |
+| **actionability** | 20 | Concrete commands/code/exact params/decision rules; an agent follows it without guessing | Prose essay with no executable content |
+| **completeness** & scope | 15 | Covers preconditions, edge cases, failure modes; scope matches the name | A stub, or scope absurdly broad/thin for the name |
+| **safety** & robustness | 12 | Flags destructive/irreversible ops, tells the agent to validate results, handles errors | Runs dangerous ops with no checks or recovery |
+| **efficiency** (signal density) | 8 | Tight, high-signal; every line earns the tokens it costs to load | Padded, repetitive, bloated |
+
+Weights sum to 100. **Freshness is not in the rubric** — it is tracked objectively via the
+package's `source_rev` / `source_committed_at`; cite it, don't score it subjectively.
+
+## Computing overall & verdict (deterministic — do not eyeball it)
+
+```
+overall = round( sum( (score_dim / 5) * weight_dim  for each dimension ) )   # 0–100
+
+verdict:
+  correctness < 2  OR  overall < 50   -> not_recommended
+  safety < 3       OR  overall < 70   -> use_with_caution
+  else                                -> recommended
+```
+
+The reviewer model returns only the six scores + evidence + the structured fields below;
+`overall` and `verdict` are computed from the scores so they never depend on the model doing
+arithmetic or applying thresholds. A 1–5 star rating for display is `max(1, round(overall/20))`.
+
+## Output schema
+
+Return a single JSON object:
+
+```json
+{
+  "scores": { "correctness": 0-5, "activation": 0-5, "actionability": 0-5,
+              "completeness": 0-5, "safety": 0-5, "efficiency": 0-5 },
+  "evidence": { "<dimension>": "one line citing specifics from the skill", ... },
+  "summary": "2-4 sentence human-readable review",
+  "best_for": ["tasks/contexts where this skill genuinely helps"],
+  "not_for":  ["where it does not apply or is known to mismatch"],
+  "caveats":  ["known issues/assumptions a caller must heed (e.g. hardcoded organism)"],
+  "improvements": ["concrete fixes that would raise the score"],
+  "confidence": "low | medium | high"
+}
+```
+
+`best_for` / `not_for` / `caveats` are the **machine-consumable payload**: the auto-skill
+mechanism filters by `verdict`, matches the current task against `best_for`/`not_for`, ranks
+by `overall`, and surfaces `caveats` as load-time warnings — without parsing the prose.
+
+## When to use / not use
+
+- **Use** to: score store skills for quality/routing; gate ingestion; pick candidates for the
+  expensive lift benchmark; feed `improvements` back into skill evolution.
+- **Do not use** to: claim a skill improves task success (use the benchmark harness); judge a
+  skill you can actually execute end-to-end (run it instead); rate non-skill content.
+
+## Notes for the reviewer
+
+- Penalize missing **negative triggers** ("when NOT to use / routes to X") — it is the single
+  best discriminator of well-engineered skills and what the router most needs.
+- If the harness clipped the content, it will say so inline — do **not** penalize completeness
+  for the harness's clipping.
+- Lower `confidence` when you could not verify correctness statically (e.g. external API
+  behavior, exact column names) rather than guessing a high score.
+
+> Canonical machine-readable form of this rubric lives in `pantheon/store/reviewer.py`
+> (`RUBRIC`, `REVIEW_SCHEMA`, `compute_overall`), versioned as `RUBRIC_VERSION`. Keep them in sync.

--- a/pantheon/store/batch_review.py
+++ b/pantheon/store/batch_review.py
@@ -1,0 +1,261 @@
+"""Batch skill reviewer: score store skills with the skill-review rubric and write
+the results back as the `pantheon-reviewer` bot.
+
+Dependency-free (stdlib only). Calls the Anthropic Messages API over raw HTTP with a
+tool-forced schema (so output is always rubric-valid), computes overall/verdict
+deterministically, and writes one review per skill.
+
+Write path:
+  --write api  (default) : POST to the hub API as the pantheon-reviewer bot. Works
+                           against any hub (dev SQLite or prod Postgres) — this is the
+                           path the scheduled/cron reviewer uses.
+  --write db             : write straight into a local SQLite dev_store.db (fast, dev only).
+
+Incremental:
+  --changed-only : skip skills whose content is unchanged since their last review
+                   (current content_hash == the reviewed_content_hash recorded in the
+                   existing pantheon-reviewer evaluation). So a nightly run only re-scores
+                   newly-published or version-bumped skills.
+
+Env:
+  ANTHROPIC_API_KEY            required (the reviewer LLM key)
+  REVIEW_MODEL                 default claude-sonnet-4-6
+  PANTHEON_HUB_URL             default http://localhost:8000
+  PANTHEON_REVIEWER_USER/PASS  bot creds for --write api (default pantheon-reviewer / env pass)
+  DEV_STORE_DB                 sqlite path for --write db
+"""
+import argparse, json, os, sqlite3, sys, time, uuid, datetime, urllib.parse
+import urllib.request as U
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from pantheon.store.reviewer import (
+    REVIEW_SCHEMA, REVIEWER_SYSTEM, RUBRIC_VERSION, build_review_prompt, compute_overall,
+)
+
+HUB = os.environ.get("PANTHEON_HUB_URL", "http://localhost:8000").rstrip("/")
+DB = os.environ.get("DEV_STORE_DB", os.path.expanduser("~/Projects/pantheon-hub/dev_store.db"))
+REVIEWER_USER_ID = "pantheon_reviewer"
+REVIEWER_USERNAME = os.environ.get("PANTHEON_REVIEWER_USER", "pantheon-reviewer")
+REVIEWER_PASSWORD = os.environ.get("PANTHEON_REVIEWER_PASSWORD", "reviewer-bot-dev")
+MODEL = os.environ.get("REVIEW_MODEL", "claude-sonnet-4-6")
+API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+
+
+def _get(path):
+    with U.urlopen(HUB + path, timeout=30) as r:
+        return json.loads(r.read())
+
+
+def _post(path, body, token=None, form=False):
+    if form:
+        data = urllib.parse.urlencode(body).encode()
+        ct = "application/x-www-form-urlencoded"
+    else:
+        data = json.dumps(body).encode()
+        ct = "application/json"
+    req = U.Request(HUB + path, data=data, method="POST")
+    req.add_header("content-type", ct)
+    if token:
+        req.add_header("Authorization", "Bearer " + token)
+    with U.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+
+def login_bot():
+    d = _post("/api/auth/login", {"username": REVIEWER_USERNAME, "password": REVIEWER_PASSWORD}, form=True)
+    tok = d.get("access_token")
+    if not tok:
+        raise SystemExit(f"bot login failed: {str(d)[:120]}")
+    return tok
+
+
+def list_source_skills(source):
+    out, off = [], 0
+    while True:
+        src = "" if source == "all" else f"&source={urllib.parse.quote(source)}"
+        d = _get(f"/api/store/packages?type=skill{src}&limit=100&offset={off}")
+        out.extend(d["packages"])
+        if len(d["packages"]) < 100:
+            break
+        off += 100
+    return out
+
+
+def existing_reviewed_hash(pkg_name):
+    """The content_hash the pantheon-reviewer last scored this skill at, or None."""
+    try:
+        d = _get(f"/api/store/packages/{urllib.parse.quote(pkg_name)}/reviews")
+    except Exception:
+        return None
+    for r in d.get("reviews", []):
+        if r.get("username") == REVIEWER_USERNAME:
+            return (r.get("evaluation") or {}).get("reviewed_content_hash")
+    return None
+
+
+def review_one(pkg):
+    """Call the LLM for one skill; return (pkg, evaluation_dict) or (pkg, None, error)."""
+    try:
+        dl = _get(f"/api/store/packages/{urllib.parse.quote(pkg['name'])}/download")
+    except Exception as e:
+        return pkg, None, f"download failed: {e}"
+    skill = {**pkg, "content": dl.get("content", ""), "files": dl.get("files") or {}}
+    body = json.dumps({
+        "model": MODEL,
+        "max_tokens": 2000,
+        "system": REVIEWER_SYSTEM,
+        "messages": [{"role": "user", "content": build_review_prompt(skill)}],
+        "tools": [{"name": "submit_review",
+                   "description": "Submit the structured skill review.",
+                   "input_schema": REVIEW_SCHEMA}],
+        "tool_choice": {"type": "tool", "name": "submit_review"},
+    }).encode()
+    req = U.Request("https://api.anthropic.com/v1/messages", data=body, method="POST")
+    req.add_header("x-api-key", API_KEY)
+    req.add_header("anthropic-version", "2023-06-01")
+    req.add_header("content-type", "application/json")
+    for attempt in range(4):
+        try:
+            with U.urlopen(req, timeout=120) as r:
+                resp = json.loads(r.read())
+            review = next((c["input"] for c in resp.get("content", []) if c.get("type") == "tool_use"), None)
+            if not review:
+                return pkg, None, "no tool_use in response"
+            overall, verdict = compute_overall(review.get("scores", {}))
+            review["overall"] = overall
+            review["verdict"] = verdict
+            review["rubric_version"] = RUBRIC_VERSION
+            review["model"] = MODEL
+            review["current_version"] = dl.get("version")
+            # Stamp the content fingerprint we reviewed, so --changed-only can later
+            # tell whether this skill needs re-reviewing.
+            review["reviewed_content_hash"] = pkg.get("content_hash")
+            return pkg, review, None
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503, 529) and attempt < 3:
+                time.sleep(2 ** attempt * 3)
+                continue
+            return pkg, None, f"HTTP {e.code}: {e.read()[:200]}"
+        except Exception as e:
+            if attempt < 3:
+                time.sleep(2 ** attempt * 3)
+                continue
+            return pkg, None, f"{type(e).__name__}: {e}"
+    return pkg, None, "exhausted retries"
+
+
+def _rating(evaluation):
+    return max(1, round(evaluation["overall"] / 20))
+
+
+def write_api(token, pkg, evaluation):
+    """Post the review as the pantheon-reviewer bot via the hub API."""
+    comment = (evaluation.get("summary") or "").strip() or None
+    _post(f"/api/store/packages/{pkg['id']}/reviews",
+          {"rating": _rating(evaluation), "comment": comment, "evaluation": evaluation},
+          token=token)
+
+
+def write_db(con, pkg, evaluation):
+    """Write straight into SQLite (dev only) + recompute aggregates."""
+    cur = con.cursor()
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    comment = (evaluation.get("summary") or "").strip() or None
+    pkg_id = pkg["id"]
+    cur.execute("DELETE FROM store_package_reviews WHERE package_id=? AND user_id=?", (pkg_id, REVIEWER_USER_ID))
+    cur.execute("""INSERT INTO store_package_reviews
+        (id,package_id,user_id,rating,comment,version,evaluation,created_at,updated_at)
+        VALUES (?,?,?,?,?,?,?,?,?)""",
+        (str(uuid.uuid4()), pkg_id, REVIEWER_USER_ID, _rating(evaluation), comment,
+         evaluation.get("current_version"), json.dumps(evaluation), now, now))
+    rows = cur.execute("SELECT rating FROM store_package_reviews WHERE package_id=?", (pkg_id,)).fetchall()
+    cur.execute("UPDATE store_packages SET rating_sum=?, rating_count=? WHERE id=?",
+                (sum(r[0] for r in rows), len(rows), pkg_id))
+    con.commit()
+
+
+def run(source="bioSkills", write="api", changed_only=False, limit=0, workers=6,
+        force=False, only=None):
+    """Review skills and write results. Returns (ok, failed). See module docstring."""
+    if not API_KEY:
+        raise SystemExit("ANTHROPIC_API_KEY not set")
+
+    skills = list_source_skills(source)
+    if only:
+        names = set(only.split(",")) if isinstance(only, str) else set(only)
+        skills = [s for s in skills if s["name"] in names]
+
+    # Decide which skills actually need reviewing.
+    if not force:
+        kept = []
+        for s in skills:
+            prev = existing_reviewed_hash(s["name"])
+            if prev is None:
+                kept.append(s)                                   # never reviewed
+            elif changed_only and prev != s.get("content_hash"):
+                kept.append(s)                                   # content changed since last review
+            elif not changed_only:
+                pass                                             # already reviewed, not changed-only -> skip
+        dropped = len(skills) - len(kept)
+        skills = kept
+        if dropped:
+            print(f"Skipping {dropped} already-reviewed/unchanged.")
+    if limit:
+        skills = skills[:limit]
+    print(f"Reviewing {len(skills)} '{source}' skills -> write={write}, model={MODEL}, workers={workers}")
+    if not skills:
+        print("Nothing to review.")
+        return 0, 0
+
+    token = login_bot() if write == "api" else None
+    con = sqlite3.connect(DB) if write == "db" else None
+    ok, fail = 0, 0
+    t0 = time.time()
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futs = {pool.submit(review_one, p): p for p in skills}
+        for i, fut in enumerate(as_completed(futs), 1):
+            pkg, review, *err = fut.result()
+            if review is None:
+                fail += 1
+                print(f"  [{i}/{len(skills)}] FAIL {pkg['name'][:40]}: {err[0] if err else '?'}")
+                continue
+            try:
+                if write == "api":
+                    write_api(token, pkg, review)
+                else:
+                    write_db(con, pkg, review)
+                ok += 1
+            except Exception as e:
+                fail += 1
+                print(f"  [{i}/{len(skills)}] WRITE-FAIL {pkg['name'][:34]}: {type(e).__name__}: {str(e)[:120]}")
+                continue
+            if i % 20 == 0 or i == len(skills):
+                rate = i / max(1e-9, time.time() - t0)
+                print(f"  [{i}/{len(skills)}] ok={ok} fail={fail} ({rate:.1f}/s) last: "
+                      f"{pkg['name'][:34]} -> {review['overall']}/{review['verdict']}")
+    if con:
+        con.close()
+    print(f"\nDone: {ok} reviewed, {fail} failed, {time.time()-t0:.0f}s")
+    return ok, fail
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--source", default="bioSkills", help="source label, or 'all' for every skill")
+    ap.add_argument("--write", choices=["api", "db"], default="api",
+                    help="api: POST as the pantheon-reviewer bot (prod-portable). db: direct SQLite (dev).")
+    ap.add_argument("--changed-only", action="store_true",
+                    help="only review skills whose content changed since their last review")
+    ap.add_argument("--only", default=None, help="comma-separated store names to restrict to")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--force", action="store_true", help="re-review even if unchanged/already reviewed")
+    args = ap.parse_args()
+    run(source=args.source, write=args.write, changed_only=args.changed_only,
+        limit=args.limit, workers=args.workers, force=args.force, only=args.only)
+
+
+if __name__ == "__main__":
+    main()

--- a/pantheon/store/cli.py
+++ b/pantheon/store/cli.py
@@ -372,10 +372,41 @@ class StoreCLI:
             seeder.prepare(output_dir=output_dir)
         elif action == "publish":
             seeder.publish_prepared(input_dir=output_dir, dry_run=dry_run)
+        elif action in ("check-updates", "check_updates"):
+            seeder.check_updates()
         else:
             raise SystemExit(
-                f"Unknown action: {action}. Options: prepare, publish"
+                f"Unknown action: {action}. Options: prepare, publish, check-updates"
             )
+
+    def review(self, source: str = "all", changed_only: bool = True, write: str = "api",
+               only: str = None, limit: int = 0, workers: int = 6, force: bool = False,
+               hub_url: str = None):
+        """Review store skills against the skill-review rubric, writing results as the
+        pantheon-reviewer bot. Intended for scheduled runs after `seed publish`.
+
+        Needs ANTHROPIC_API_KEY (the reviewer LLM key). For `write=api` it logs in as
+        the bot (PANTHEON_REVIEWER_USER / PANTHEON_REVIEWER_PASSWORD).
+
+        Args:
+            source: source label, or "all" for every skill.
+            changed_only: only re-review skills whose content changed since their last
+                review (default True — this is what makes nightly runs cheap).
+            write: "api" (POST as the bot; works against dev or prod) or "db" (direct SQLite; dev).
+            only: comma-separated store names to restrict to (e.g. what `seed publish` just changed).
+            limit: cap the number reviewed (0 = no cap).
+            workers: concurrent reviewers.
+            force: re-review even if unchanged/already reviewed.
+            hub_url: override PANTHEON_HUB_URL.
+        """
+        import os as _os
+        if hub_url:
+            _os.environ["PANTHEON_HUB_URL"] = hub_url
+        from . import batch_review
+        if hub_url:
+            batch_review.HUB = hub_url.rstrip("/")
+        batch_review.run(source=source, write=write, changed_only=changed_only,
+                         only=only, limit=limit, workers=workers, force=force)
 
     def list(self, what: str = "installed", hub_url: str = None):
         """List installed or published packages.

--- a/pantheon/store/client.py
+++ b/pantheon/store/client.py
@@ -119,6 +119,27 @@ class StoreClient:
             resp.raise_for_status()
             return resp.json()
 
+    async def submit_review(self, package_id: str, rating: int, comment: str = None,
+                            evaluation: dict = None) -> dict:
+        """Post a review (rating + optional comment + structured rubric evaluation)
+        for a package as the logged-in user. Used by the automated reviewer to write
+        results as the pantheon-reviewer bot."""
+        self._check_auth()
+        body = {"rating": rating, "comment": comment, "evaluation": evaluation}
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                f"{self.hub_url}/api/store/packages/{package_id}/reviews",
+                json=body, headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def get_reviews(self, package_id: str) -> dict:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(f"{self.hub_url}/api/store/packages/{package_id}/reviews")
+            resp.raise_for_status()
+            return resp.json()
+
     async def transfer_reviews(self, to_package_id: str, from_package_id: str) -> dict:
         """Move reviews from one package onto another (rename/move recovery)."""
         self._check_auth()

--- a/pantheon/store/reviewer.py
+++ b/pantheon/store/reviewer.py
@@ -1,0 +1,141 @@
+"""Skill reviewer: a versioned rubric + a static (read-only) LLM reviewer that
+scores a store skill and emits a structured review for both humans and the
+downstream auto-skill-selection mechanism.
+
+This is the cheap, scalable "expert review" layer. It judges the *artifact*
+(SKILL.md + bundled files + metadata), NOT causal task lift — that needs the
+benchmark harness. When measured lift exists, trust it over this score.
+
+Design notes:
+- The model returns only the 6 dimension scores (0-5) + evidence + the
+  structured routing fields. `overall` (0-100) and `verdict` are computed
+  deterministically from the scores here, so they don't depend on the model
+  doing arithmetic or applying thresholds consistently.
+- RUBRIC_VERSION lets us re-review when the standard itself changes (separate
+  from re-reviewing when a skill's content_hash/version changes).
+"""
+
+RUBRIC_VERSION = "1.0.0"
+
+# (key, label, weight, what 5 looks like, what 0 looks like)
+RUBRIC = [
+    ("correctness", "Correctness & currency", 25,
+     "Tools/APIs/params/methods are correct and current; code blocks look runnable.",
+     "Deprecated APIs, wrong params, or factually misleading guidance."),
+    ("activation", "Activation (when to use / not use)", 20,
+     "Description gives precise positive AND negative triggers; a router can decide from it.",
+     "Vague ('helps with bio analysis') or missing trigger guidance."),
+    ("actionability", "Actionability", 20,
+     "Concrete commands/code/exact params/decision rules; an agent can follow it without guessing.",
+     "Prose essay with no executable content."),
+    ("completeness", "Completeness & scope", 15,
+     "Covers preconditions, edge cases, failure modes; scope matches the name.",
+     "A stub, or scope absurdly broad/thin for the name."),
+    ("safety", "Safety & robustness", 12,
+     "Flags destructive/irreversible ops, tells the agent to validate results, handles errors.",
+     "Runs dangerous operations with no checks or recovery."),
+    ("efficiency", "Efficiency (signal density)", 8,
+     "Tight and high-signal; every line earns the tokens it costs to load.",
+     "Padded, repetitive, or bloated."),
+]
+WEIGHTS = {k: w for k, _, w, _, _ in RUBRIC}  # sums to 100
+
+# Model-facing output schema (overall/verdict are computed, NOT requested here).
+REVIEW_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "scores": {
+            "type": "object",
+            "properties": {k: {"type": "integer", "minimum": 0, "maximum": 5} for k, *_ in RUBRIC},
+            "required": [k for k, *_ in RUBRIC],
+            "additionalProperties": False,
+        },
+        "evidence": {
+            "type": "object",
+            "description": "One short justification per dimension, citing specifics from the skill.",
+            "properties": {k: {"type": "string"} for k, *_ in RUBRIC},
+            "additionalProperties": False,
+        },
+        "summary": {"type": "string", "description": "2-4 sentence human-readable review (becomes the review comment)."},
+        "best_for": {"type": "array", "items": {"type": "string"},
+                     "description": "Tasks/contexts where this skill genuinely helps."},
+        "not_for": {"type": "array", "items": {"type": "string"},
+                    "description": "Where it does not apply or is known to mismatch."},
+        "caveats": {"type": "array", "items": {"type": "string"},
+                    "description": "Known issues/assumptions a caller must heed (e.g. hardcoded organism)."},
+        "improvements": {"type": "array", "items": {"type": "string"},
+                         "description": "Concrete fixes that would raise the score."},
+        "confidence": {"type": "string", "enum": ["low", "medium", "high"],
+                       "description": "Reviewer's confidence; lower it when correctness couldn't be verified statically."},
+    },
+    "required": ["scores", "summary", "best_for", "not_for", "caveats", "confidence"],
+    "additionalProperties": False,
+}
+
+
+def compute_overall(scores: dict) -> tuple:
+    """Deterministically fold the 6 dimension scores into (overall 0-100, verdict).
+
+    Verdict gates (not just the weighted sum):
+      - correctness < 2  OR  overall < 50  -> not_recommended
+      - safety < 3       OR  overall < 70  -> use_with_caution
+      - else                               -> recommended
+    """
+    overall = round(sum((scores.get(k, 0) / 5) * w for k, w in WEIGHTS.items()))
+    if scores.get("correctness", 0) < 2 or overall < 50:
+        verdict = "not_recommended"
+    elif scores.get("safety", 0) < 3 or overall < 70:
+        verdict = "use_with_caution"
+    else:
+        verdict = "recommended"
+    return overall, verdict
+
+
+def _rubric_block() -> str:
+    return "\n".join(
+        f"- **{k}** ({label}, weight {w}): 5 = {hi}  |  0 = {lo}"
+        for k, label, w, hi, lo in RUBRIC
+    )
+
+
+REVIEWER_SYSTEM = """You are a skeptical senior reviewer of *agent skills* — Markdown playbooks an LLM agent loads to do a task better. You judge the artifact as written (you cannot run it). Be discriminating: most real skills land 2-4 on a dimension; reserve 5 for genuinely exemplary and 0-1 for broken/misleading. Reward concrete, executable, correctly-scoped guidance; penalize vague prose, deprecated/wrong calls, missing trigger conditions, unflagged destructive operations, and bloat. Your scores feed an automatic skill-selection mechanism, so your best_for / not_for / caveats must be accurate and specific enough to route on."""
+
+
+def build_review_prompt(skill: dict) -> str:
+    """skill: {name, display_name, description, category, source, source_url,
+    references, content, files: {path: content}}."""
+    files = skill.get("files") or {}
+
+    def _clip(text: str, limit: int) -> str:
+        text = text or ""
+        if len(text) <= limit:
+            return text
+        # Mark our own clipping so the reviewer doesn't penalize completeness for it.
+        return text[:limit] + f"\n\n[... reviewer note: {len(text) - limit} chars clipped HERE by the harness, NOT missing from the skill ...]"
+
+    file_blob = "\n\n".join(
+        f"### bundled file: {p}\n```\n{_clip(c, 16000)}\n```" for p, c in list(files.items())[:12]
+    ) or "(none)"
+    refs = ", ".join(skill.get("references") or []) or "(none)"
+    return f"""Review this store skill against the rubric. Score each dimension 0-5 with one line of evidence citing specifics.
+
+## Rubric
+{_rubric_block()}
+
+## Skill metadata
+- store name: {skill.get('name')}
+- display: {skill.get('display_name')}
+- category: {skill.get('category')}
+- source: {skill.get('source')} ({skill.get('source_url')})
+- declared references: {refs}
+- frontmatter description: {skill.get('description')}
+
+## SKILL.md
+```
+{_clip(skill.get('content') or '', 60000)}
+```
+
+## Bundled files
+{file_blob}
+
+Return ONLY the structured review. overall/verdict are computed downstream — do not include them."""


### PR DESCRIPTION
## What

The **reviewer** half of the store quality loop — so a scheduled job can score new/changed skills after a `seed`. Pairs with the hub's review/`evaluation` support and a forthcoming GitHub Actions workflow.

### New
- **`reviewer.py`** — the versioned skill-review rubric (6 weighted dimensions + anchors, deterministic `overall`/`verdict`, output schema). Pure stdlib.
- **`batch_review.py`** — scores skills via the Anthropic Messages API (tool-forced schema → always rubric-valid), writes results back:
  - `--write api` (default): POST as the **pantheon-reviewer bot** — works against dev SQLite *or* prod Postgres.
  - `--write db`: direct SQLite (dev only).
  - `--changed-only`: only re-review skills whose `content_hash` changed since their last review (stamped as `reviewed_content_hash`) → **nightly runs are near-free**.
  - `--only a,b`: restrict to specific names (e.g. exactly what `seed publish` just changed).
- **`pantheon store review`** CLI command.
- factory skill **`meta/skill_review.md`** — the rubric as a discoverable store skill.

### Fixed
- `seed check-updates` is now reachable from the CLI (the `StoreSeed.check_updates` method shipped in #123 but the `seed()` dispatch only handled prepare/publish).

### Client
- `StoreClient.submit_review()` + `get_reviews()`.

## The loop (each runs an existing CLI command)
```
pantheon store seed check-updates                 # which sources moved
pantheon store seed prepare && ... seed publish   # changed sources: pull, auto-version, reconcile
pantheon store review --changed-only --source all # review only new/changed skills
```

## Testing
Verified end-to-end against a local dev hub: review writes via the bot API with `reviewed_content_hash`; bumping a skill's content makes `--changed-only` re-review **only** that skill and skip the unchanged one.

## Note
No new deps (stdlib + the existing client). The reviewer needs `ANTHROPIC_API_KEY`; `--write api` needs the `pantheon-reviewer` bot creds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)