### PR TITLE
feat(skills): per-deployment skill denylist (PANTHEON_EXCLUDED_SKILLS)

### DIFF
--- a/pantheon/internal/learning_system/runtime.py
+++ b/pantheon/internal/learning_system/runtime.py
@@ -29,6 +29,8 @@ class LearningRuntime:
 
     def initialize(self, pantheon_dir: Path, global_pantheon_dir: Path | None = None) -> None:
         """Initialize all components."""
+        import os
+
         from pantheon.settings import get_settings
 
         skills_dir = resolve_skills_dir(pantheon_dir)
@@ -36,11 +38,25 @@ class LearningRuntime:
         global_skills_dir = resolve_skills_dir(global_pantheon_dir) if global_pantheon_dir else None
         factory_skills_dir = get_settings().factory_skills_dir
 
+        # Deployment-level skill denylist. A host app (e.g. Virtual Embryo) whose
+        # own agent already reaches that app's data via a dedicated MCP sets
+        # PANTHEON_EXCLUDED_SKILLS so the packaged factory skill for that app is
+        # hidden + unloadable *in this sandbox only* — the skill stays in the
+        # factory tree for every other PantheonOS agent. Comma-separated path keys.
+        excluded_skills = [
+            s.strip()
+            for s in os.environ.get("PANTHEON_EXCLUDED_SKILLS", "").split(",")
+            if s.strip()
+        ]
+        if excluded_skills:
+            logger.info(f"LearningRuntime skill denylist active: {excluded_skills}")
+
         self.store = SkillStore(
             skills_dir,
             runtime_dir,
             global_skills_dir=global_skills_dir,
             factory_skills_dir=factory_skills_dir,
+            excluded_skills=excluded_skills,
         )
         self.injector = SkillInjector(
             self.store,

--- a/pantheon/internal/learning_system/store.py
+++ b/pantheon/internal/learning_system/store.py
@@ -38,13 +38,31 @@ class SkillStore:
         runtime_dir: Path,
         global_skills_dir: Path | None = None,
         factory_skills_dir: Path | None = None,
+        excluded_skills: list[str] | None = None,
     ):
         self.skills_dir = skills_dir
         self.runtime_dir = runtime_dir
         self.global_skills_dir = global_skills_dir
         self.factory_skills_dir = factory_skills_dir
+        # Per-deployment skill denylist (e.g. a host app whose own agent reaches
+        # its data via a dedicated MCP and must NOT also see the packaged factory
+        # skill for that app). Keyed by the skill's path/dir key (e.g.
+        # "virtualembryo"); a name N also hides any nested skill under "N/".
+        # Applied at this choke point so the skill stays in the factory tree for
+        # every other agent while being invisible + unloadable here.
+        self.excluded_skills = set(excluded_skills or [])
         self.skills_dir.mkdir(parents=True, exist_ok=True)
         self.runtime_dir.mkdir(parents=True, exist_ok=True)
+
+    def _is_excluded(self, path_key: str) -> bool:
+        """True if a skill path key is in the deployment denylist (exact dir
+        match, or nested under an excluded dir)."""
+        if not self.excluded_skills:
+            return False
+        return any(
+            path_key == name or path_key.startswith(f"{name}/")
+            for name in self.excluded_skills
+        )
 
     # ── Discovery ──
 
@@ -59,6 +77,8 @@ class SkillStore:
             for skill_md in self._iter_skill_files(base_dir):
                 header = parse_frontmatter_only(skill_md, skills_dir=base_dir)
                 if header and header.path not in seen_paths:
+                    if self._is_excluded(header.path):
+                        continue
                     header.scope = scope
                     headers.append(header)
                     seen_paths.add(header.path)
@@ -84,6 +104,10 @@ class SkillStore:
             return None
         try:
             entry = parse_skill_file(skill_md, skills_dir=base_dir)
+            # Denylisted skills are invisible in scan_headers; also refuse to load
+            # them here so a stale/guessed name can't pull the content back in.
+            if self._is_excluded(entry.path):
+                return None
             entry.scope = scope
             return entry
         except Exception as e:


### PR DESCRIPTION
## What
Adds a per-deployment skill denylist to the learning system. `SkillStore` accepts `excluded_skills`; excluded skills are filtered out of `scan_headers` (so they never reach the injected skill index) and refused by `load_skill` (so a stale/guessed name can't pull the content back in). `LearningRuntime` reads the comma-separated `PANTHEON_EXCLUDED_SKILLS` env var and threads it through.

## Why
A host app whose own agent already reaches that app's data via a dedicated MCP (e.g. Virtual Embryo → `ve_curator`) shouldn't ALSO see the packaged factory skill for that app — the agent ends up flip-flopping between the MCP and the skill's raw-HTTP path. This hides the skill *in that sandbox only*; it stays in the factory tree for every other PantheonOS agent. Parallels the existing per-app `mcp.json` server disable.

The denylist is applied at the `SkillStore` discovery choke point (not at materialization) because the store scans the packaged factory skills dir directly — so skipping materialization alone would not hide the skill.

## Pairs with
pantheon-hub PR that sets `PANTHEON_EXCLUDED_SKILLS=virtualembryo` for the VE app. Inert + harmless until both land.

## Verified (locally)
- **Unit:** against the real factory skills, denylist `["virtualembryo"]` hides exactly that skill, preserves the other 8 (incl `live_view`), and `load_skill("virtualembryo")` returns `None`.
- **Full path:** `LearningRuntime.initialize` → `SkillStore` → `SkillInjector.build_skill_index()` drops `virtualembryo` from the injected index while keeping the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)