### PR TITLE
feat: platform-budget force-proxy + budget-aware quality tiers

### DIFF
--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -3933,6 +3933,51 @@ class ChatRoom(ToolSet):
             }
 
     @tool(exclude=True)
+    async def set_llm_proxy(
+        self, enabled: bool, base_url: str = "", api_key: str = ""
+    ) -> dict:
+        """Toggle 'platform budget' mode for THIS local backend (frontend-only).
+
+        enabled=True: route every LLM call through the platform LiteLLM proxy
+        (base_url) using the user's per-user virtual key (api_key) — usage spends
+        against the user's platform budget — bypassing (NOT deleting) the user's own
+        provider keys. enabled=False: go back to the user's own keys.
+
+        Sets the env in this process so it takes effect immediately. The frontend
+        re-pushes this on every connect, so it survives backend restarts without
+        persisting the virtual key to disk.
+        """
+        import os
+
+        try:
+            if enabled:
+                if not base_url or not api_key:
+                    return {
+                        "success": False,
+                        "message": "base_url and api_key are required when enabling platform budget",
+                    }
+                # Dedicated env so the user's own LLM_API_BASE/KEY are never touched.
+                os.environ["PANTHEON_PLATFORM_PROXY_BASE"] = base_url
+                os.environ["PANTHEON_PLATFORM_PROXY_KEY"] = api_key
+                os.environ["LLM_FORCE_PROXY"] = "true"
+            else:
+                os.environ.pop("LLM_FORCE_PROXY", None)
+                os.environ.pop("PANTHEON_PLATFORM_PROXY_BASE", None)
+                os.environ.pop("PANTHEON_PLATFORM_PROXY_KEY", None)
+            return {
+                "success": True,
+                "enabled": bool(enabled),
+                "message": (
+                    "Platform budget enabled — LLM calls now use the platform proxy."
+                    if enabled
+                    else "Platform budget disabled — using your own API keys."
+                ),
+            }
+        except Exception as e:
+            logger.error(f"set_llm_proxy failed: {e}")
+            return {"success": False, "message": str(e)}
+
+    @tool(exclude=True)
     async def check_api_keys(self) -> dict:
         """Check the configuration status of LLM API keys.
 

--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -3964,6 +3964,14 @@ class ChatRoom(ToolSet):
                 os.environ.pop("LLM_FORCE_PROXY", None)
                 os.environ.pop("PANTHEON_PLATFORM_PROXY_BASE", None)
                 os.environ.pop("PANTHEON_PLATFORM_PROXY_KEY", None)
+            # Rebuild the model selector so quality-tier chains (high/normal/low)
+            # re-resolve under the new mode — under budget they must use only the
+            # platform's providers, not a cached local one.
+            try:
+                from pantheon.utils.model_selector import reset_model_selector
+                reset_model_selector()
+            except Exception as e:
+                logger.warning(f"set_llm_proxy: model selector reset failed: {e}")
             return {
                 "success": True,
                 "enabled": bool(enabled),

--- a/pantheon/utils/llm.py
+++ b/pantheon/utils/llm.py
@@ -865,6 +865,21 @@ async def acompletion(
         if _fp_base and _fp_key:
             effective_base_url = _fp_base
             effective_api_key = _fp_key
+            _mk = f"{_fp_key[:7]}…({len(_fp_key)}c)" if _fp_key else "—"
+            logger.info(
+                f"[PLATFORM-BUDGET-ROUTE] model={model!r} sdk={sdk_type} → platform proxy "
+                f"{_fp_base} (vkey {_mk}) — spending platform budget"
+            )
+    else:
+        # force-proxy can't apply to OAuth/CLI providers — flag if budget is on yet a
+        # local-auth model still got picked (the budget-aware selector should prevent this).
+        from .llm_providers import is_force_proxy_enabled
+        if is_force_proxy_enabled():
+            logger.warning(
+                f"[PLATFORM-BUDGET-ROUTE] model={model!r} sdk={sdk_type} is a LOCAL OAuth/CLI "
+                f"provider → NOT routed through the platform proxy (uses local auth). A budget "
+                f"quality tier should not resolve to this."
+            )
 
     adapter = get_adapter(sdk_type)
 

--- a/pantheon/utils/llm.py
+++ b/pantheon/utils/llm.py
@@ -734,6 +734,7 @@ async def acompletion(
     )
     from .adapters import get_adapter
     from .llm_providers import (
+        get_force_proxy_config,
         get_openai_effective_config,
         get_openai_fallback_config,
         get_provider_api_key,
@@ -854,6 +855,16 @@ async def acompletion(
         if not effective_api_key and provider_config.get("local"):
             effective_api_key = "ollama"
         effective_model = model_name  # use bare model name with native SDK
+
+    # Platform-budget (force-proxy) mode: route every non-OAuth provider through the
+    # platform LiteLLM proxy (LLM_API_BASE + the user's virtual key), bypassing the
+    # user's own provider keys WITHOUT deleting them. Adapter/model selection stays,
+    # so claude-* still uses the Anthropic adapter against the proxy (as in hub mode).
+    if sdk_type not in ("codex", "gemini-cli"):
+        _fp_base, _fp_key = get_force_proxy_config()
+        if _fp_base and _fp_key:
+            effective_base_url = _fp_base
+            effective_api_key = _fp_key
 
     adapter = get_adapter(sdk_type)
 

--- a/pantheon/utils/llm_providers.py
+++ b/pantheon/utils/llm_providers.py
@@ -274,6 +274,32 @@ def get_global_fallback_base_url() -> str:
     return get_settings().get_api_key("LLM_API_BASE") or ""
 
 
+def is_force_proxy_enabled() -> bool:
+    """True when this backend is in 'platform budget' mode: every LLM call is routed
+    through the platform LiteLLM proxy + the user's virtual key, bypassing the user's
+    own provider keys (without deleting them). Toggled at runtime via the
+    ``set_llm_proxy`` RPC, which sets ``LLM_FORCE_PROXY`` +
+    ``PANTHEON_PLATFORM_PROXY_BASE`` / ``PANTHEON_PLATFORM_PROXY_KEY`` (dedicated env
+    so the user's own ``LLM_API_BASE`` is never touched)."""
+    import os
+
+    val = os.environ.get("LLM_FORCE_PROXY", "")
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+def get_force_proxy_config() -> tuple[Optional[str], Optional[str]]:
+    """``(base_url, api_key)`` to force every provider through the platform proxy when
+    force-proxy is on, else ``(None, None)``."""
+    if not is_force_proxy_enabled():
+        return None, None
+    import os
+
+    return (
+        os.environ.get("PANTHEON_PLATFORM_PROXY_BASE") or None,
+        os.environ.get("PANTHEON_PLATFORM_PROXY_KEY") or None,
+    )
+
+
 def resolve_provider_base_url(
     provider_key: str,
     default_base_url: str | None = None,

--- a/pantheon/utils/model_selector.py
+++ b/pantheon/utils/model_selector.py
@@ -151,6 +151,13 @@ def prefix_saved_models(provider: str, model_names: list[str]) -> list[str]:
 
 DEFAULT_PROVIDER_PRIORITY = ["anthropic", "openai", "gemini", "gemini-cli", "zai", "deepseek", "minimax", "moonshot", "qwen", "groq", "mistral", "together_ai", "openrouter", "codex", "ollama"]
 
+# Providers the platform LiteLLM proxy serves. When platform budget (force-proxy)
+# is on, model resolution is restricted to these so quality-tier chains (high/
+# normal/low) never fall through to a local-only provider (gemini-cli / ollama /
+# zai / minimax / …) the proxy can't run. The budget supplies these keys, so they
+# are usable even without the user configuring their own.
+PLATFORM_PROXY_PROVIDERS = ["anthropic", "openai", "gemini"]
+
 # Quality levels map to MODEL LISTS (not single models) for fallback chains
 # Models within each level are ordered by preference
 DEFAULT_PROVIDER_MODELS = {
@@ -397,6 +404,23 @@ class ModelSelector:
 
         return self._available_providers
 
+    def _effective_providers(self) -> set[str]:
+        """Providers usable for model resolution *right now*.
+
+        Under platform budget (force-proxy), only the proxy's providers are usable
+        regardless of what the user configured locally: the budget supplies the
+        keys, and local-only providers (gemini-cli / ollama / zai / …) aren't
+        reachable through the proxy. Read fresh each call (not cached) so a runtime
+        budget toggle is reflected.
+        """
+        try:
+            from pantheon.utils.llm_providers import is_force_proxy_enabled
+            if is_force_proxy_enabled():
+                return set(PLATFORM_PROXY_PROVIDERS)
+        except Exception:
+            pass
+        return self._get_available_providers()
+
     def detect_available_provider(self) -> str | None:
         """Detect first available provider based on API keys.
 
@@ -412,7 +436,7 @@ class ModelSelector:
             return self._detected_provider
 
         # Get available providers from environment
-        available = self._get_available_providers()
+        available = self._effective_providers()
         if not available:
             logger.warning("No LLM providers detected from environment API keys")
             return None
@@ -715,7 +739,7 @@ class ModelSelector:
             return []
 
         tier_order = tier_order or ["normal", "high", "low"]
-        available = self._get_available_providers()
+        available = self._effective_providers()
         if not available:
             return []
 
@@ -802,7 +826,7 @@ class ModelSelector:
         Returns:
             List of image generation models as fallback chain
         """
-        available = self._get_available_providers()
+        available = self._effective_providers()
         
         # Priority order for image generation providers
         priority = ["openai", "gemini"]


### PR DESCRIPTION
Backend for the local/desktop platform-budget feature. All opt-in + inert unless a client turns it on via the `set_llm_proxy` RPC.

- `acompletion` force-proxy mode (utils/llm.py): when LLM_FORCE_PROXY is set, route non-OAuth providers through the platform proxy (PANTHEON_PLATFORM_PROXY_BASE/KEY), keeping adapter/model selection.
- `set_llm_proxy(enabled, base_url, api_key)` RPC (chatroom/room.py) — frontend-only; resets the model selector on toggle.
- Budget-aware quality tiers (utils/model_selector.py): under force-proxy, high/normal/low resolve only to platform providers (anthropic/openai/gemini), never a local-only one.
- `[PLATFORM-BUDGET-ROUTE]` log when a call routes through the proxy.