### PR TITLE
feat(skills): Pantheon Store skill discovery, adoption & usage feedback

### DIFF
--- a/pantheon/internal/learning_system/prompts.py
+++ b/pantheon/internal/learning_system/prompts.py
@@ -27,6 +27,10 @@ Choose by: `best_for` matching your task, a `recommended` verdict and solid rati
 and `not_for` / `caveats` that don't exclude your case. Prefer a local skill when \
 both fit. Adopted store skills are ephemeral — used for this task only, not installed.
 
+After finishing a task in which you adopted a store skill, leave usage feedback with \
+`skill_rate(name, rating, comment)` — did it actually help, was its best_for/caveats \
+accurate? This is how the store learns which skills truly work, beyond the static review.
+
 **Creating and Maintaining Skills:**
 
 After completing a complex task (5+ tool calls), fixing a tricky error, \

--- a/pantheon/internal/learning_system/prompts.py
+++ b/pantheon/internal/learning_system/prompts.py
@@ -29,7 +29,10 @@ both fit. Adopted store skills are ephemeral — used for this task only, not in
 
 After finishing a task in which you adopted a store skill, leave usage feedback with \
 `skill_rate(name, rating, comment)` — did it actually help, was its best_for/caveats \
-accurate? This is how the store learns which skills truly work, beyond the static review.
+accurate? Feedback is posted as the user's OWN review, so it requires the user to be \
+logged in to the store; if they aren't (the tool returns needs_login), tell them they \
+can run `pantheon store login` to enable it rather than silently skipping. This is how \
+the store learns which skills truly work, beyond the static review.
 
 **Creating and Maintaining Skills:**
 

--- a/pantheon/internal/learning_system/prompts.py
+++ b/pantheon/internal/learning_system/prompts.py
@@ -17,6 +17,16 @@ skill defines how it should be done here.
 
 Only proceed without loading a skill if genuinely none are relevant to the task.
 
+**Pantheon Store (marketplace):**
+
+If none of your LOCAL skills above cover a non-trivial task, search the broader \
+marketplace with `skill_search_store(query="<your task>")`. It returns ranked \
+candidates with a quality verdict, rating, and `best_for` / `not_for` / `caveats`. \
+Adopt a good match with `skill_adopt(name=...)` and follow it like a local skill. \
+Choose by: `best_for` matching your task, a `recommended` verdict and solid rating, \
+and `not_for` / `caveats` that don't exclude your case. Prefer a local skill when \
+both fit. Adopted store skills are ephemeral — used for this task only, not installed.
+
 **Creating and Maintaining Skills:**
 
 After completing a complex task (5+ tool calls), fixing a tricky error, \

--- a/pantheon/internal/learning_system/toolset.py
+++ b/pantheon/internal/learning_system/toolset.py
@@ -393,6 +393,61 @@ class SkillToolSet(ToolSet):
             "bundled_files": list(files.keys()),
             "hint": (
                 "EPHEMERAL store skill (not installed). Follow its content as a playbook for "
-                "this task. (Bundled files are listed by name only in v1.)"
+                "this task. When the task is done, leave usage feedback with "
+                "skill_rate(name, rating, comment)."
             ),
+        })
+
+    @tool
+    async def skill_rate(self, name: str, rating: int, comment: str = None) -> str:
+        """Leave usage feedback on a Pantheon Store skill you ADOPTED and used this task.
+
+        Call this AFTER finishing a task in which you used skill_adopt(), to report
+        whether the skill actually helped: did it work, was its best_for accurate, did
+        its caveats hold? Your feedback becomes a real review (rating + comment) — the
+        store's quality signal is usage-validated this way, not just the static AI
+        review. Only rate skills you actually used.
+
+        Args:
+            name: the store name of an adopted skill.
+            rating: 1-5 (1 = useless/wrong/misleading, 5 = exactly what was needed).
+            comment: optional — what worked, what didn't, whether the caveats held.
+        """
+        try:
+            rating = int(rating)
+        except Exception:
+            return self._json({"success": False, "error": "rating must be an integer 1-5"})
+        if not (1 <= rating <= 5):
+            return self._json({"success": False, "error": "rating must be 1-5"})
+        import os as _os
+        import httpx
+        # Feedback is posted as the USER. Token from the store login file, or an
+        # injected PANTHEON_STORE_TOKEN (how the agent runtime would carry the user's).
+        token = _os.environ.get("PANTHEON_STORE_TOKEN")
+        if not token:
+            try:
+                from pantheon.store.client import StoreClient
+                token = StoreClient(hub_url=self._hub_url()).auth.token
+            except Exception:
+                token = None
+        if not token:
+            return self._json({
+                "success": False,
+                "error": "No store credentials — feedback skipped. (`pantheon store login` or set PANTHEON_STORE_TOKEN.)",
+            })
+        try:
+            async with httpx.AsyncClient(timeout=20) as c:
+                r = await c.post(
+                    f"{self._hub_url()}/api/store/packages/{name}/reviews",
+                    json={"rating": rating, "comment": (comment or "").strip() or None},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                if r.status_code == 404:
+                    return self._json({"success": False, "error": f"Skill '{name}' not found in the store"})
+                r.raise_for_status()
+        except Exception as e:
+            return self._json({"success": False, "error": f"feedback failed: {e}"})
+        return self._json({
+            "success": True,
+            "hint": f"Recorded your usage feedback on '{name}' (rating {rating}/5). This improves the store for everyone.",
         })

--- a/pantheon/internal/learning_system/toolset.py
+++ b/pantheon/internal/learning_system/toolset.py
@@ -306,6 +306,29 @@ class SkillToolSet(ToolSet):
             "PANTHEON_HUB_URL", "https://app.pantheonos.stanford.edu"
         ).rstrip("/")
 
+    def _store_credentials(self):
+        """Resolve the user's store identity for WRITE ops (feedback) only.
+
+        Read ops (search/adopt) are anonymous; only feedback is posted as the
+        user, so only it requires login. Hosted runtimes inject the logged-in
+        user's store JWT via PANTHEON_STORE_TOKEN (+ optional PANTHEON_STORE_USER
+        for attribution); the local CLI uses the `pantheon store login`
+        credentials file. Returns (token, username), or (None, None) when the
+        user isn't logged in.
+        """
+        import os
+        token = os.environ.get("PANTHEON_STORE_TOKEN")
+        if token:
+            return token, os.environ.get("PANTHEON_STORE_USER")
+        try:
+            from pantheon.store.auth import StoreAuth
+            auth = StoreAuth()
+            if auth.is_logged_in:
+                return auth.token, auth.username
+        except Exception:
+            pass
+        return None, None
+
     @tool
     async def skill_search_store(self, query: str, limit: int = 8) -> str:
         """Search the Pantheon Store MARKETPLACE for skills relevant to your task.
@@ -385,6 +408,14 @@ class SkillToolSet(ToolSet):
         except Exception:
             pass
         files = dl.get("files") or {}
+        token, _user = self._store_credentials()
+        if token:
+            fb = ("When the task is done, leave usage feedback with "
+                  "skill_rate(name, rating, comment) — it's posted as the user's review.")
+        else:
+            fb = ("To leave usage feedback when done (it becomes the user's own review and "
+                  "improves the store), the user must be logged in — mention they can run "
+                  "`pantheon store login`.")
         return self._json({
             "success": True,
             "name": dl.get("name"),
@@ -392,9 +423,8 @@ class SkillToolSet(ToolSet):
             "content": dl.get("content", ""),
             "bundled_files": list(files.keys()),
             "hint": (
-                "EPHEMERAL store skill (not installed). Follow its content as a playbook for "
-                "this task. When the task is done, leave usage feedback with "
-                "skill_rate(name, rating, comment)."
+                "EPHEMERAL store skill (not installed). Follow its content as a playbook "
+                "for this task. " + fb
             ),
         })
 
@@ -419,22 +449,19 @@ class SkillToolSet(ToolSet):
             return self._json({"success": False, "error": "rating must be an integer 1-5"})
         if not (1 <= rating <= 5):
             return self._json({"success": False, "error": "rating must be 1-5"})
-        import os as _os
-        import httpx
-        # Feedback is posted as the USER. Token from the store login file, or an
-        # injected PANTHEON_STORE_TOKEN (how the agent runtime would carry the user's).
-        token = _os.environ.get("PANTHEON_STORE_TOKEN")
-        if not token:
-            try:
-                from pantheon.store.client import StoreClient
-                token = StoreClient(hub_url=self._hub_url()).auth.token
-            except Exception:
-                token = None
+        # Feedback is posted as the USER's own review, so it requires login.
+        token, username = self._store_credentials()
         if not token:
             return self._json({
                 "success": False,
-                "error": "No store credentials — feedback skipped. (`pantheon store login` or set PANTHEON_STORE_TOKEN.)",
+                "needs_login": True,
+                "error": (
+                    "Feedback becomes the user's own review, which requires login. Tell the "
+                    "user they can run `pantheon store login` to enable it — don't silently "
+                    "skip. (Hosted runtimes inject PANTHEON_STORE_TOKEN automatically.)"
+                ),
             })
+        import httpx
         try:
             async with httpx.AsyncClient(timeout=20) as c:
                 r = await c.post(
@@ -442,12 +469,21 @@ class SkillToolSet(ToolSet):
                     json={"rating": rating, "comment": (comment or "").strip() or None},
                     headers={"Authorization": f"Bearer {token}"},
                 )
-                if r.status_code == 404:
-                    return self._json({"success": False, "error": f"Skill '{name}' not found in the store"})
-                r.raise_for_status()
+            if r.status_code == 404:
+                return self._json({"success": False, "error": f"Skill '{name}' not found in the store"})
+            if r.status_code in (401, 403):
+                return self._json({
+                    "success": False,
+                    "needs_login": True,
+                    "error": "Store session expired or invalid — tell the user to run "
+                             "`pantheon store login` again to leave feedback.",
+                })
+            r.raise_for_status()
         except Exception as e:
             return self._json({"success": False, "error": f"feedback failed: {e}"})
+        who = f" as {username}" if username else ""
         return self._json({
             "success": True,
-            "hint": f"Recorded your usage feedback on '{name}' (rating {rating}/5). This improves the store for everyone.",
+            "hint": f"Recorded your usage feedback{who} on '{name}' (rating {rating}/5). "
+                    "This usage-validates the store's quality signal for everyone.",
         })

--- a/pantheon/internal/learning_system/toolset.py
+++ b/pantheon/internal/learning_system/toolset.py
@@ -297,3 +297,102 @@ class SkillToolSet(ToolSet):
                 "error": str(e),
                 "hint": "Use skill_list() to see existing skills.",
             })
+
+    # ---- Pantheon Store marketplace (broader than the local skill set) ----
+
+    def _hub_url(self) -> str:
+        import os
+        return os.environ.get(
+            "PANTHEON_HUB_URL", "https://app.pantheonos.stanford.edu"
+        ).rstrip("/")
+
+    @tool
+    async def skill_search_store(self, query: str, limit: int = 8) -> str:
+        """Search the Pantheon Store MARKETPLACE for skills relevant to your task.
+
+        Your LOCAL skills (skill_list) are the trusted default — use this when the
+        local set doesn't cover the task; the marketplace is broader. Returns ranked
+        candidates with the AI reviewer's decision payload: verdict, rating, best_for,
+        not_for, caveats. Adopt a good one with skill_adopt(name=...).
+
+        Choosing: prefer a candidate whose `best_for` matches your task with a good
+        `verdict`/rating; avoid ones whose `not_for`/`caveats` exclude your case (e.g.
+        a caveat that an organism is hardcoded). Don't adopt one that duplicates a
+        local skill — prefer the local one.
+
+        Args:
+            query: task description / capability keywords.
+            limit: max candidates (default 8).
+        """
+        import httpx
+        exclude = []
+        if self._runtime.store:
+            try:
+                exclude = [h.path for h in self._runtime.store.scan_headers()]
+            except Exception:
+                exclude = []
+        try:
+            async with httpx.AsyncClient(timeout=20) as c:
+                r = await c.get(
+                    f"{self._hub_url()}/api/store/recommend",
+                    params={"q": query, "limit": limit, "exclude": ",".join(exclude)},
+                )
+                r.raise_for_status()
+                data = r.json()
+        except Exception as e:
+            return self._json({"success": False, "error": f"store search failed: {e}"})
+        results = data.get("results", [])
+        return self._json({
+            "success": True,
+            "count": len(results),
+            "results": results,
+            "hint": (
+                "Adopt one with skill_adopt(name=...). Prefer verdict=recommended with a "
+                "matching best_for and good rating; check not_for/caveats don't exclude your "
+                "task. Skip any that duplicate a local skill from skill_list()."
+            ),
+        })
+
+    @tool
+    async def skill_adopt(self, name: str) -> str:
+        """Adopt a Pantheon Store skill for THIS task (ephemeral — NOT installed locally).
+
+        Downloads the skill's content into your context so you can follow it as a
+        playbook for the current task. It is not added to your local skills. Use
+        skill_search_store first to find candidates.
+
+        Args:
+            name: the store `name` of a candidate from skill_search_store.
+        """
+        import httpx
+        try:
+            async with httpx.AsyncClient(timeout=30) as c:
+                r = await c.get(f"{self._hub_url()}/api/store/packages/{name}/download")
+                if r.status_code == 404:
+                    return self._json({"success": False, "error": f"Skill '{name}' not found in the store"})
+                r.raise_for_status()
+                dl = r.json()
+        except Exception as e:
+            return self._json({"success": False, "error": f"adopt failed: {e}"})
+        # Remember which store skills were used this session (for post-task feedback, later).
+        try:
+            adopted = getattr(self._runtime, "adopted_store_skills", None)
+            if adopted is None:
+                adopted = []
+                setattr(self._runtime, "adopted_store_skills", adopted)
+            if name not in adopted:
+                adopted.append(name)
+        except Exception:
+            pass
+        files = dl.get("files") or {}
+        return self._json({
+            "success": True,
+            "name": dl.get("name"),
+            "version": dl.get("version"),
+            "content": dl.get("content", ""),
+            "bundled_files": list(files.keys()),
+            "hint": (
+                "EPHEMERAL store skill (not installed). Follow its content as a playbook for "
+                "this task. (Bundled files are listed by name only in v1.)"
+            ),
+        })


### PR DESCRIPTION
Gives the agent **store-awareness**: before a task it can search the marketplace for the most relevant skill, decide whether to adopt it from the quality signal, use it ephemerally, and — once done — feed back whether it actually worked. Closes the quality loop between the static AI review and real usage.

Reuses the existing `SkillToolSet` (`pantheon/internal/learning_system/`) — no new toolset. Local skills always take precedence; the store is the fallback when nothing local fits.

### Scope 1 — discovery + adoption (read path)
- **`skill_search_store(query, limit=8)`** → GET hub `/api/store/recommend`. Lexical (FTS) ranking over name/display/description/category + the reviewer's `best_for`, joined with the `pantheon-reviewer` AI evaluation. Returns ranked candidates with `verdict` / `overall` / `rating` / `best_for` / `not_for` / `caveats`, excluding skills already installed locally and any `not_recommended`. The agent decides from this payload.
- **`skill_adopt(name)`** → GET `/api/store/packages/{name}/download`. Loads content **ephemerally** into the task context (not installed to `~/.pantheon`); followed like a local skill for this task only.

### Scope 2 — post-task usage feedback (write path)
- **`skill_rate(name, rating, comment)`** → POST `/api/store/packages/{name}/reviews` as the **user's real review**. Token resolves from `PANTHEON_STORE_TOKEN` (runtime-carried session token) or the `pantheon store login` file; no-ops with a clear hint if neither is present, so it never fails the task. This makes the store's quality signal **usage-validated**, layered on top of the static rubric.

`SKILLS_GUIDANCE` (prompts.py) is extended with a marketplace section (when to search/adopt, how to choose) and a nudge to rate adopted skills after the task.

### Validated e2e (against staging)
- **Scope 1:** agent searched "molecular docking", correctly **rejected** the highest-rated candidate (a SPR/BLI-kinetics skill whose `best_for` didn't match docking) and adopted `diffdock` instead — proves the decision payload drives real choices.
- **Scope 2:** agent adopted `openclaw-medical_diffdock`, summarized it, then `skill_rate(rating=4, comment=…)` — the review **landed on staging** attributed to the real user, ★4 alongside `pantheon-reviewer`'s static ★3 (avg 3.5/2). Closed loop confirmed live.

Hub `/recommend` endpoint is already merged (#24) and deployed to staging. Lexical retrieval is v1; semantic-embedding ranking is a deferred v2.

**Draft — not for merge to main yet.**

---

### Auth model (who can give feedback)
Read ops (search/adopt) are **anonymous**; only feedback (`skill_rate`) is posted as the user, so only it requires login — same split as the existing `install_store_package` (anonymous download, login-gated record).

`_store_credentials()` is the single source of truth for the user's store identity:
| Mode | "logged in" = | token source |
|---|---|---|
| Local CLI | ran `pantheon store login` | `~/.pantheon/store_auth.json` |
| Hosted | platform session | `PANTHEON_STORE_TOKEN` (+ `PANTHEON_STORE_USER`) injected at agent launch |

No password handling in the agent loop. Unauthenticated `skill_rate` returns `needs_login` (no network) and the agent is told to prompt the user to log in rather than silently skip; 401/403 (expired) is distinguished from 404 (not found); the success hint is attributed to the username.

### Follow-ups (NOT in this PR)
- **Hub/server side:** when the hosted platform launches an agent session for a logged-in user, mint/forward that user's store JWT into the agent env as `PANTHEON_STORE_TOKEN`. This is the only missing piece for hosted feedback; the agent side already consumes it.
- **`/recommend` v2:** semantic-embedding ranking (current v1 is lexical FTS).