### PR TITLE
fix(chatroom): single-flight lock for per-chat team creation (port 3100 race / ve_curator tool loss)

### DIFF
--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -190,6 +190,10 @@ class ChatRoom(ToolSet):
 
         # Per-chat team management
         self.chat_teams: dict[str, PantheonTeam] = {}  # Per-chat teams cache
+        # Per-chat single-flight locks: serialize concurrent first-time team
+        # creation for the same chat so the team — and its endpoint + MCP
+        # gateway — is built exactly once. Mirrors _project_endpoint_locks.
+        self._team_init_locks: dict[str, asyncio.Lock] = {}
 
         self.speech_to_text_model = speech_to_text_model
         self.threads: dict[str, Thread] = {}
@@ -813,11 +817,27 @@ class ChatRoom(ToolSet):
         if chat_id in self.chat_teams:
             return self.chat_teams[chat_id]
 
-        # 2. Try to load team from persistent memory
-        team = await self._load_team_from_memory(chat_id, save_to_memory=save_to_memory)
-        self.chat_teams[chat_id] = team  # Cache it
+        # 2. Serialize concurrent first-time creation for this chat. Without
+        # this single-flight lock, parallel requests (e.g. the first message
+        # racing a session restore) both miss the cache, both build the team,
+        # and the duplicate endpoint / MCP gateway fight over port 3100 —
+        # either crashing the sandbox ("bind: address already in use") or
+        # mis-registering MCP tools so ve_curator drops out of the agent's
+        # active toolset. Mirrors _ensure_project_endpoint's per-project lock.
+        lock = self._team_init_locks.get(chat_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._team_init_locks[chat_id] = lock
+        async with lock:
+            # Double-check: another caller may have built it while we waited.
+            if chat_id in self.chat_teams:
+                return self.chat_teams[chat_id]
 
-        return team
+            # 3. Try to load (or create) the team from persistent memory.
+            team = await self._load_team_from_memory(chat_id, save_to_memory=save_to_memory)
+            self.chat_teams[chat_id] = team  # Cache it
+
+            return team
 
     async def _load_team_from_memory(self, chat_id: str, save_to_memory: bool = True) -> PantheonTeam:
         """Load team from chat's persistent memory.


### PR DESCRIPTION
## Problem
On Virtual Embryo sandboxes the curator intermittently either crashed at startup or reported its `ve_curator` KG tools as unavailable (`Tool 've_curator__kg_search' not found`). 

Root cause: `ChatRoom.get_team_for_chat()` is **check-then-act with no concurrency guard**. Two near-simultaneous first-time requests for the same chat (e.g. the first user message racing a session restore) both miss the `chat_teams` cache and both run `_load_team_from_memory` → `_create_team_from_template`, each starting the team's endpoint + MCP gateway. The duplicate gateway races to bind `127.0.0.1:3100`:

- **hard failure**: `OSError: [Errno 98] address already in use` → `gateway.py` `SystemExit(1)` → sandbox `exit 1` → "no responders" → hub reaps the pod.
- **soft failure**: gateway comes up but `ve_curator` tools register on the losing instance, so the agent's active toolset lacks them → `ValueError: Tool 've_curator__kg_search' not found`.

(The default Pantheon app doesn't hit this — it has no MCP gateway competing for 3100, which is why only VE-app sessions broke.)

Sandbox log evidence: `_create_team_from_template 'Virtual Embryo Expert'` runs twice, `"Team ... created"` ×2, `"MCP server 've_curator' started successfully"` ×4.

## Fix
Wrap the cache-miss branch of `get_team_for_chat()` in a **per-chat `asyncio.Lock` with a double-check**, mirroring the existing `_ensure_project_endpoint` per-project lock. The team — and its endpoint/MCP gateway — is now built exactly once per chat; concurrent callers wait and reuse the cached team.

## Verified
- New concurrency check: 8 concurrent `get_team_for_chat` calls for the same chat → `_load_team_from_memory` runs **once**, all 8 get the same team; different chats still build independently.
- chatroom/team suite: **39 passed, 10 skipped**. (The 3 `test_chatroom_resilience::list_chats` failures are pre-existing on `main` — unrelated `project_manager` attribute, not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)