### PR TITLE
feat(skills): skill_browse_store — keyword/category lookup

### DIFF
--- a/pantheon/internal/learning_system/prompts.py
+++ b/pantheon/internal/learning_system/prompts.py
@@ -27,6 +27,11 @@ Choose by: `best_for` matching your task, a `recommended` verdict and solid rati
 and `not_for` / `caveats` that don't exclude your case. Prefer a local skill when \
 both fit. Adopted store skills are ephemeral — used for this task only, not installed.
 
+`skill_search_store` is semantic + quality-ranked (best for fuzzy "find something \
+for task X"). When you instead know a name/keyword or want to see what's in a \
+category, use `skill_browse_store(query=..., category=...)` — an exact keyword/\
+category lookup (no semantic ranking). Both feed `skill_adopt`.
+
 After finishing a task in which you adopted a store skill, leave usage feedback with \
 `skill_rate(name, rating, comment)` — did it actually help, was its best_for/caveats \
 accurate? Feedback is posted as the user's OWN review, so it requires the user to be \

--- a/pantheon/internal/learning_system/toolset.py
+++ b/pantheon/internal/learning_system/toolset.py
@@ -377,6 +377,54 @@ class SkillToolSet(ToolSet):
         })
 
     @tool
+    async def skill_browse_store(self, query: str = None, category: str = None, limit: int = 15) -> str:
+        """Look up Pantheon Store skills by KEYWORD or CATEGORY — exact/filter
+        search, NOT semantic ranking.
+
+        Use this when you know a name, a keyword, or a category and want precise
+        matches or to see what exists in a category. For a fuzzy "find me something
+        for task X" with quality signals, use skill_search_store instead (semantic
+        + reviewer verdict/best_for). Adopt any result with skill_adopt(name=...).
+
+        Args:
+            query: keyword matched in name/display/description (optional).
+            category: restrict to one category, e.g. "bioinformatics" (optional).
+            limit: max results (default 15).
+        """
+        import httpx
+        params = {"type": "skill", "limit": limit}
+        if query:
+            params["q"] = query
+        if category:
+            params["category"] = category
+        try:
+            async with httpx.AsyncClient(timeout=20) as c:
+                r = await c.get(f"{self._hub_url()}/api/store/packages", params=params)
+                r.raise_for_status()
+                data = r.json()
+        except Exception as e:
+            return self._json({"success": False, "error": f"store browse failed: {e}"})
+        results = [{
+            "name": p.get("name"),
+            "display_name": p.get("display_name"),
+            "description": p.get("description"),
+            "category": p.get("category"),
+            "rating_avg": p.get("rating_avg"),
+            "rating_count": p.get("rating_count"),
+        } for p in data.get("packages", [])]
+        return self._json({
+            "success": True,
+            "count": len(results),
+            "total": data.get("total"),
+            "results": results,
+            "hint": (
+                "Exact keyword/category matches (no semantic ranking, no reviewer verdict). "
+                "Adopt one with skill_adopt(name=...). For task-intent discovery with quality "
+                "signals use skill_search_store. Prefer a local skill from skill_list() if it fits."
+            ),
+        })
+
+    @tool
     async def skill_adopt(self, name: str) -> str:
         """Adopt a Pantheon Store skill for THIS task (ephemeral — NOT installed locally).
 


### PR DESCRIPTION
Adds a precise-lookup counterpart to the semantic `skill_search_store`. `skill_browse_store(query=, category=)` hits `GET /api/store/packages` (exact keyword/category filter, no semantic ranking) — for when the agent knows a name/keyword or wants to browse a category. The prompt tells it which to use. Keyword search was never lost (it's also fused into `/recommend`); this gives the agent explicit choice. Unit-tested against staging (keyword 'docking'→18, category 'bioinformatics'→94). Draft.