### PR TITLE
fix(agent): keep MCP tools foreground-only (fixes ve_curator 'tool not found' in background_task)

### DIFF
--- a/pantheon/agent.py
+++ b/pantheon/agent.py
@@ -999,7 +999,16 @@ class Agent:
         # Providers return ToolInfo with pre-generated inputSchema (the "function" part)
         logger.debug(f"get tools for llm: {self.providers} ")
         provider_tools = []
+        # MCP provider tools are task-bound: the MCP client session lives on the
+        # endpoint's main asyncio task, so they cannot be run via background_task
+        # (a separate asyncio.Task) — cross-task access makes list_tools()/call_tool()
+        # fail with "tool not found". Collect their fully-qualified names so step 3
+        # does NOT advertise a `_background` option for them (foreground-only).
+        from .providers import MCPProvider
+
+        mcp_tool_names: set[str] = set()
         for provider_name, provider in self.providers.items():
+            is_mcp_provider = isinstance(provider, MCPProvider)
             try:
                 # Get tools from provider (uses cached list if available)
                 tools = await provider.list_tools()
@@ -1015,7 +1024,10 @@ class Agent:
                     function_schema = tool_info.inputSchema.copy()
 
                     # Add provider prefix to tool name (using __ as separator to support provider names with _)
-                    function_schema["name"] = f"{provider_name}__{tool_info.name}"
+                    full_name = f"{provider_name}__{tool_info.name}"
+                    function_schema["name"] = full_name
+                    if is_mcp_provider:
+                        mcp_tool_names.add(full_name)
 
                     # Build complete OpenAI tool dict
                     provider_tools.append(
@@ -1041,8 +1053,10 @@ class Agent:
         all_tools = base_tools + provider_tools
         for tool_dict in all_tools:
             name = tool_dict["function"]["name"]
-            if name in _BG_PARAM_SKIP or any(
-                name.startswith(p) for p in _BG_PARAM_SKIP_PREFIXES
+            if (
+                name in _BG_PARAM_SKIP
+                or name in mcp_tool_names
+                or any(name.startswith(p) for p in _BG_PARAM_SKIP_PREFIXES)
             ):
                 continue
 


### PR DESCRIPTION
## Problem
On VE sandboxes, after the team-init race fix (#134) the curator correctly saw `ve_curator__*` tools but every KG call still failed with:
`Tool 've_curator__kg_search' not found. Available tools: ['background_task','think','file_manager__*',...]` — note **no `ve_curator__*` in the list**, but `file_manager__*` (local toolset) **was** present.

**Root cause:** the LLM set `_background: true` on the MCP tool calls, so they ran inside `background_task()` — a **separate `asyncio.Task`** (`background.py: asyncio.create_task`). MCP provider sessions are **task-bound** (the MCP client lives on the endpoint's main task). Cross-task access makes `provider.list_tools()` raise, which `call_tool` swallows in its `except` (`agent.py:1211`), so MCP tools drop out of the resolved tool table → "not found". Local toolsets aren't task-bound, so they stayed visible — exactly matching the symptom.

`get_tools_for_llm` injects a `_background` param into **every** eligible tool schema (`agent.py:1037`), so the LLM was free to choose background execution for MCP tools too.

## Fix
`get_tools_for_llm()` now detects `MCPProvider` instances and **omits `_background` from their tool schemas**. The LLM can no longer request background execution for MCP tools, so they run foreground on the main task where the session is valid. Mirrors the existing `_BG_PARAM_SKIP` (`background_task`/`think`/`call_agent`). Local + base tools keep `_background`.

Schema-layer change (not execution-layer) — there's no risk of the agent believing a tool is backgrounded when it isn't.

## Verified (locally)
- **Unit:** MCP provider tools (`ve_curator__*`) have **no** `_background`; local provider tools (`file_manager__*`) and normal base tools (`list_agents`) **keep** it; `_BG_PARAM_SKIP` tools (`think`) unchanged.
- **Regression:** `152 passed, 65 skipped`. The failures are pre-existing on `main` (model-selector / provider-adapter config + a `test_unified_mcp` E2E env RecursionError) — confirmed identical on a clean `origin/main` via stash check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)