### PR TITLE
feat(store): path-based install layout + local-skill awareness + uninstall

### DIFF
--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -3890,7 +3890,7 @@ class ChatRoom(ToolSet):
             dl = await client.download(package_id, version)
             installer = PackageInstaller()
             written = installer.install(
-                dl["type"], dl["name"], dl["content"], dl.get("files")
+                dl["type"], dl["name"], dl["content"], dl.get("files"), path=dl.get("path")
             )
             # Record in local manifest
             try:
@@ -3899,6 +3899,7 @@ class ChatRoom(ToolSet):
                     "name": dl["name"],
                     "type": dl["type"],
                     "version": dl["version"],
+                    "path": dl.get("path"),
                     "installed_at": datetime.now().isoformat(),
                 }
                 self._save_store_installs(installs)
@@ -3925,6 +3926,40 @@ class ChatRoom(ToolSet):
             return {"success": False, "error": str(e)}
 
     @tool
+    async def uninstall_store_package(self, package_id: str) -> dict:
+        """Uninstall a previously store-installed package.
+
+        Removes the package's local files (using the recorded original ``path``
+        so the source-folder layout is cleaned up) and drops it from the local
+        install manifest. Built-in (factory) skills are not store-installed and
+        cannot be removed this way.
+
+        Args:
+            package_id: The ID of the installed package to remove.
+        """
+        from pantheon.store.installer import PackageInstaller
+
+        try:
+            installs = self._load_store_installs()
+            info = installs.get(package_id)
+            if not info:
+                return {"success": False, "error": "Package is not installed"}
+            installer = PackageInstaller()
+            removed = installer.uninstall(
+                info.get("type", "skill"), info.get("name", ""), path=info.get("path")
+            )
+            del installs[package_id]
+            self._save_store_installs(installs)
+            return {
+                "success": True,
+                "name": info.get("name"),
+                "removed_files": [str(p) for p in removed],
+            }
+        except Exception as e:
+            logger.error(f"Error uninstalling store package: {e}")
+            return {"success": False, "error": str(e)}
+
+    @tool
     async def get_installed_store_packages(self) -> dict:
         """Get locally installed store packages with their versions.
 
@@ -3945,8 +3980,13 @@ class ChatRoom(ToolSet):
                 exists = False
 
                 if pkg_type == "skill":
+                    from pantheon.store.installer import _skill_install_root
+                    sub = _skill_install_root(name)[len("skills/"):]  # "<slug>/<base>" or "<name>"
+                    rel_path = (info.get("path") or "").strip("/")  # original hierarchical path, if recorded
                     for base in [settings.skills_dir, user_home / "skills"]:
-                        if (base / name / "SKILL.md").exists() or (base / name).exists():
+                        if ((base / name / "SKILL.md").exists() or (base / name).exists()
+                                or (base / sub / "SKILL.md").exists()
+                                or (rel_path and (base / rel_path / "SKILL.md").exists())):
                             exists = True
                             break
                 elif pkg_type == "agent":
@@ -3972,6 +4012,83 @@ class ChatRoom(ToolSet):
         except Exception as e:
             logger.error(f"Error reading store installs: {e}")
             return {"success": False, "installs": {}, "error": str(e)}
+
+    @tool
+    async def get_local_skills(self) -> dict:
+        """List the agent's LOCAL skills (factory built-ins + global + project) so
+        the store UI can show built-ins as already-installed.
+
+        Each entry: {path, name, scope, modified}.
+          - scope: "factory" (built-in, pristine), "global", or "project".
+          - modified: true when a user-layer copy shadows a factory built-in AND
+            its SKILL.md differs from the factory original. Compared LOCALLY
+            (user-layer vs factory), NOT against the store — the store-synced copy
+            has an added Source header, so a store comparison would false-positive.
+
+        Returns: {success, skills: [...]}.
+        """
+        try:
+            import hashlib
+            from pantheon.internal.learning_system import plugin as _lp
+            rt = getattr(_lp, "_learning_runtime", None)
+            store = getattr(rt, "store", None) if rt else None
+            if not store:
+                return {"success": True, "skills": []}
+            factory_dir = getattr(store, "factory_skills_dir", None)
+
+            def _md5(p: Path):
+                try:
+                    return hashlib.md5(p.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+                except Exception:
+                    return None
+
+            out = []
+            for h in store.scan_headers():
+                scope = getattr(h, "scope", "project")
+                modified = False
+                # A factory built-in the user overrode (project/global) — flag if changed.
+                if scope in ("project", "global") and factory_dir:
+                    fac_md = Path(factory_dir) / h.path / "SKILL.md"
+                    if fac_md.exists():
+                        cur = _md5(Path(h.skill_dir) / "SKILL.md")
+                        fac = _md5(fac_md)
+                        modified = bool(cur and fac and cur != fac)
+                out.append({
+                    "name": h.name,
+                    "path": h.path,
+                    "scope": scope,
+                    "modified": modified,
+                })
+
+            # Factory-bundled sub-skills: nested resource ".md" files (e.g.
+            # live_view/cytoscape/cytoscape.md) that ship INSIDE a built-in skill.
+            # The store seeds each as a SEPARATE package, but they're already
+            # present locally — so the UI must show them as built-in, not as
+            # installable. Mirror the seed's path convention (rel-without-suffix,
+            # "_"-flattened name) so the store rows match by path.
+            if factory_dir:
+                fac = Path(factory_dir)
+                seen_paths = {e["path"] for e in out}
+                for md_file in sorted(fac.rglob("*.md")):
+                    if md_file.name in ("SKILL.md", "SKILLS.md"):
+                        continue
+                    rel = md_file.relative_to(fac)
+                    if any(p.startswith(("_", ".")) for p in rel.parts[:-1]):
+                        continue
+                    path = str(rel.with_suffix("")).replace("\\", "/")
+                    if path in seen_paths:
+                        continue
+                    seen_paths.add(path)
+                    out.append({
+                        "name": md_file.stem,
+                        "path": path,
+                        "scope": "factory",
+                        "modified": False,
+                    })
+            return {"success": True, "skills": out}
+        except Exception as e:
+            logger.error(f"Error listing local skills: {e}")
+            return {"success": False, "skills": [], "error": str(e)}
 
     @tool
     async def reload_settings(self) -> dict:

--- a/pantheon/store/installer.py
+++ b/pantheon/store/installer.py
@@ -6,6 +6,21 @@ from typing import Dict, Optional
 from loguru import logger
 
 
+def _skill_install_root(name: str) -> str:
+    """Relative install root for a skill: ``skills/<source-slug>/<base>``.
+
+    External store names are ``<source-slug>_<base>`` (e.g.
+    ``bioskills_bio-clinical-...``). Foldering by source drops the prefix and
+    encodes provenance in the path. Names without a ``_`` fall back to
+    ``skills/<name>`` unchanged.
+    """
+    if "_" in name:
+        slug, base = name.split("_", 1)
+        if slug and base:
+            return f"skills/{slug}/{base}"
+    return f"skills/{name}"
+
+
 class PackageInstaller:
     """Install/uninstall agent, team, and skill packages from the Store.
 
@@ -25,6 +40,7 @@ class PackageInstaller:
         name: str,
         content: str,
         files: Optional[Dict[str, str]] = None,
+        path: Optional[str] = None,
     ) -> list[Path]:
         """Install a package locally.
 
@@ -62,18 +78,31 @@ class PackageInstaller:
                     written.append(file_target)
 
         elif pkg_type == "skill":
-            # Always install as skills/{name}/SKILL.md directory structure
-            # to preserve the original repo layout (even for single-file skills)
-            target = self.settings.skills_dir / name / "SKILL.md"
+            # Install under a SOURCE folder with a clean (un-prefixed) base name:
+            #   skills/<source-slug>/<base>/SKILL.md
+            # External store names are "<source-slug>_<base>" (e.g.
+            # "bioskills_bio-clinical-..."). Foldering by source keeps names clean,
+            # mirrors the factory layout, and encodes provenance in the path instead
+            # of a prefix. (Full original nesting can't be reconstructed until the
+            # store stores the source path; this is the source-folder layout.)
+            # Prefer the original hierarchical source path (restores the exact repo
+            # layout, e.g. skills/omics/database_access/gget). Fall back to the
+            # source-folder layout when the store didn't carry a path.
+            rel_root = f"skills/{path.strip('/')}" if path else _skill_install_root(name)
+            target = self.settings.pantheon_dir / rel_root / "SKILL.md"
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(content, encoding="utf-8")
             written.append(target)
 
-            # Write bundled skill files (for skill groups)
+            # Write bundled skill files, rewriting the old flat "skills/{name}/..."
+            # prefix onto the new source-folder root.
             if files:
+                old_prefix = f"skills/{name}/"
                 for rel_path, file_content in files.items():
-                    # rel_path is like "skills/{name}/subdir/file.py"
-                    file_target = self.settings.pantheon_dir / rel_path
+                    rp = rel_path
+                    if rp.startswith(old_prefix):
+                        rp = f"{rel_root}/" + rp[len(old_prefix):]
+                    file_target = self.settings.pantheon_dir / rp
                     file_target.parent.mkdir(parents=True, exist_ok=True)
                     file_target.write_text(file_content, encoding="utf-8")
                     written.append(file_target)
@@ -86,12 +115,15 @@ class PackageInstaller:
 
         return written
 
-    def uninstall(self, pkg_type: str, name: str) -> list[Path]:
+    def uninstall(self, pkg_type: str, name: str, path: Optional[str] = None) -> list[Path]:
         """Uninstall a package by removing its files.
 
         Args:
             pkg_type: One of "agent", "team", "skill".
             name: Package name.
+            path: Original hierarchical source path the skill was installed under
+                  (e.g. "omics/database_access/gget"). When recorded at install
+                  time, it pins the exact dir to remove.
 
         Returns:
             List of paths that were removed.
@@ -113,16 +145,27 @@ class PackageInstaller:
             # as they may be shared with other teams.
 
         elif pkg_type == "skill":
-            # Check directory format first (skills/{name}/SKILL.md)
-            dir_target = self.settings.skills_dir / name
-            if dir_target.is_dir():
-                import shutil
-                removed_files = list(dir_target.rglob("*"))
-                shutil.rmtree(dir_target)
-                removed.extend(removed_files)
-                removed.append(dir_target)
-            else:
-                # Fallback: legacy flat file format
+            # Try the recorded original path first (matches the path-based install
+            # layout), then the source-folder layout, then the legacy flat-prefixed
+            # dir, then the legacy single-file form.
+            candidates = []
+            if path:
+                candidates.append(self.settings.pantheon_dir / "skills" / path.strip("/"))
+            candidates += [
+                self.settings.pantheon_dir / _skill_install_root(name),  # skills/<slug>/<base>
+                self.settings.skills_dir / name,                          # legacy skills/<name>
+            ]
+            removed_dir = False
+            for dir_target in candidates:
+                if dir_target.is_dir():
+                    import shutil
+                    removed_files = list(dir_target.rglob("*"))
+                    shutil.rmtree(dir_target)
+                    removed.extend(removed_files)
+                    removed.append(dir_target)
+                    removed_dir = True
+                    break
+            if not removed_dir:
                 flat_target = self.settings.skills_dir / f"{name}.md"
                 if flat_target.exists():
                     flat_target.unlink()

--- a/pantheon/store/seed.py
+++ b/pantheon/store/seed.py
@@ -393,6 +393,7 @@ class StoreSeed:
                 if r and r != s["store_name"]:
                     refs.append(r)
             s["references"] = list(dict.fromkeys(refs))
+            s["path"] = s.get("_relkey")  # preserve the original hierarchical source path
             for k in ("_relkey", "_basedir", "_is_group"):
                 s.pop(k, None)
 
@@ -613,6 +614,8 @@ class StoreSeed:
             )
             if converted:
                 converted["_dirname"] = skill_md.parent.name
+                # Original hierarchical source path (skill dir relative to skills_dir).
+                converted["path"] = str(rel.parent).replace("\\", "/")
                 skills.append(converted)
 
         # Resolve "Related Skills" names (= sibling directory names) to store names
@@ -678,6 +681,7 @@ class StoreSeed:
                 "display_name": skill["display_name"],
                 "description": skill["description"],
                 "category": skill["category"],
+                "path": skill.get("path"),
                 "tags": skill.get("tags", []),
                 "references": skill.get("references", []),
                 "source": "Pantheon",
@@ -788,6 +792,7 @@ class StoreSeed:
                         "display_name": skill["display_name"],
                         "description": skill["description"],
                         "category": skill["category"],
+                        "path": skill.get("path"),
                         "tags": skill.get("tags", []),
                         "references": skill.get("references", []),
                         "source": config["display_name"],
@@ -897,6 +902,7 @@ class StoreSeed:
                     references=entry.get("references", []),
                     source_rev=entry.get("source_rev"),
                     source_committed_at=entry.get("source_committed_at"),
+                    path=entry.get("path"),
                     dry_run=dry_run,
                 )
                 progress.advance(task)
@@ -925,7 +931,8 @@ class StoreSeed:
                      files: dict = None, version: str = "1.0.0",
                      source: str = "Pantheon", source_url: str = None,
                      references: list = None, source_rev: str = None,
-                     source_committed_at: str = None, dry_run: bool = False) -> bool:
+                     source_committed_at: str = None, path: str = None,
+                     dry_run: bool = False) -> bool:
         """Publish a package. If it already exists, publish a NEW VERSION when the
         content changed (auto-bumped patch), else skip. This makes re-seeding a
         real content sync instead of a no-op, with version history."""
@@ -946,6 +953,8 @@ class StoreSeed:
             payload["source_rev"] = source_rev
         if source_committed_at:
             payload["source_committed_at"] = source_committed_at
+        if path:
+            payload["path"] = path
 
         # 1. Try to create as a brand-new package.
         try:
@@ -968,25 +977,36 @@ class StoreSeed:
                 return False
             pkg_id = existing["id"]
             next_ver = _bump_patch(existing.get("latest_version") or "1.0.0")
+            # Package-level metadata to sync (refs/desc/path/source rev). Computed
+            # once so it can be applied whether or not the content changed.
+            meta_update = {
+                "references": references or [], "description": description or "",
+                "display_name": display_name, "category": category,
+            }
+            if path:
+                meta_update["path"] = path
+            if source_rev:
+                meta_update["source_rev"] = source_rev
+            if source_committed_at:
+                meta_update["source_committed_at"] = source_committed_at
             try:
                 _run(self.client.publish_version(pkg_id, {
                     "version": next_ver, "content": content, "files": files or {},
                     "changelog": "Synced from source",
                 }))
             except SystemExit:
-                # content identical (or version clash) -> no update needed
-                self.stats["skipped"] += 1
-                return False
-            # version published -> sync package-level metadata (refs/desc/tags/source rev)
+                # Content identical (or version clash) -> no new version. Still sync
+                # package-level metadata so re-seeds can backfill path/refs WITHOUT
+                # republishing content (preserves reviews, costs no review tokens).
+                try:
+                    _run(self.client.update_package(pkg_id, meta_update))
+                    self.stats["updated"] += 1
+                    return True
+                except Exception:
+                    self.stats["skipped"] += 1
+                    return False
+            # version published -> sync package-level metadata
             try:
-                meta_update = {
-                    "references": references or [], "description": description or "",
-                    "display_name": display_name, "category": category,
-                }
-                if source_rev:
-                    meta_update["source_rev"] = source_rev
-                if source_committed_at:
-                    meta_update["source_committed_at"] = source_committed_at
                 _run(self.client.update_package(pkg_id, meta_update))
             except Exception:
                 pass  # version is published; metadata sync is best-effort


### PR DESCRIPTION
Part of the in-app Pantheon Store hierarchy/install work (agent side).

## What
- **installer.py** — install skills under their original hierarchical source path (`skills/<path>/SKILL.md`) instead of a flat prefixed dir; `uninstall()` gained a `path` param so it cleans up that layout.
- **room.py** — `get_local_skills` now also reports factory-bundled sub-skills (nested resource `.md` files like `live_view/cytoscape/cytoscape.md`) so the store UI shows them as built-in (already shipped), not installable; new `uninstall_store_package` tool; install records + uses the original `path` in the local install manifest; installed-check is path-aware.
- **seed.py** — thread the original source path end-to-end (factory + external discovery → manifest → `_publish_one`) so each package carries an accurate `path`; backfills it on content-unchanged re-seeds (so reviews are preserved, no re-review tokens).

## Test
- Re-ran the seed locally against the dev hub: 2105 updated / 9 new / 0 failed, reviews preserved (2102), 2107/2107 skills with accurate paths.
- Verified in the local UI: built-in detection, path-restore install, subtree install, cascade uninstall.

Pairs with pantheon-hub (package `path` + descendants endpoint) and pantheon-ui (Installed hierarchy + detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)