### PR TITLE
fix(store): skill_search_store falls back to lexical when /recommend is unavailable

### DIFF
--- a/pantheon/internal/learning_system/toolset.py
+++ b/pantheon/internal/learning_system/toolset.py
@@ -354,27 +354,64 @@ class SkillToolSet(ToolSet):
                 exclude = [h.path for h in self._runtime.store.scan_headers()]
             except Exception:
                 exclude = []
+        base = self._hub_url()
+        # 1. Semantic recommend (preferred — carries the reviewer verdict/best_for).
         try:
             async with httpx.AsyncClient(timeout=20) as c:
                 r = await c.get(
-                    f"{self._hub_url()}/api/store/recommend",
+                    f"{base}/api/store/recommend",
                     params={"q": query, "limit": limit, "exclude": ",".join(exclude)},
                 )
                 r.raise_for_status()
                 data = r.json()
-        except Exception as e:
-            return self._json({"success": False, "error": f"store search failed: {e}"})
-        results = data.get("results", [])
-        return self._json({
-            "success": True,
-            "count": len(results),
-            "results": results,
-            "hint": (
-                "Adopt one with skill_adopt(name=...). Prefer verdict=recommended with a "
-                "matching best_for and good rating; check not_for/caveats don't exclude your "
-                "task. Skip any that duplicate a local skill from skill_list()."
-            ),
-        })
+            results = data.get("results", [])
+            return self._json({
+                "success": True,
+                "count": len(results),
+                "results": results,
+                "hint": (
+                    "Adopt one with skill_adopt(name=...). Prefer verdict=recommended with a "
+                    "matching best_for and good rating; check not_for/caveats don't exclude your "
+                    "task. Skip any that duplicate a local skill from skill_list()."
+                ),
+            })
+        except Exception as semantic_err:
+            # /recommend may not exist on a store backend without semantic search
+            # (e.g. a 404). Fall back to LEXICAL keyword search so the agent still
+            # gets candidates instead of a hard failure — just without the reviewer
+            # verdict/best_for signals.
+            try:
+                async with httpx.AsyncClient(timeout=20) as c:
+                    r = await c.get(
+                        f"{base}/api/store/packages",
+                        params={"q": query, "type": "skill", "limit": limit},
+                    )
+                    r.raise_for_status()
+                    data = r.json()
+            except Exception as lexical_err:
+                return self._json({"success": False, "error": (
+                    f"store search failed: {semantic_err}; lexical fallback also failed: {lexical_err}"
+                )})
+            results = [{
+                "name": p.get("name"),
+                "display_name": p.get("display_name"),
+                "description": p.get("description"),
+                "category": p.get("category"),
+                "rating_avg": p.get("rating_avg"),
+                "rating_count": p.get("rating_count"),
+            } for p in data.get("packages", [])]
+            return self._json({
+                "success": True,
+                "count": len(results),
+                "results": results,
+                "degraded": "lexical",
+                "hint": (
+                    "Semantic search was unavailable, so these are LEXICAL keyword matches "
+                    "(no reviewer verdict/best_for/caveats) — judge fit from the description. "
+                    "Adopt one with skill_adopt(name=...). Skip any that duplicate a local "
+                    "skill from skill_list()."
+                ),
+            })
 
     @tool
     async def skill_browse_store(self, query: str = None, category: str = None, limit: int = 15) -> str:


### PR DESCRIPTION
## Problem
`skill_search_store` calls `/api/store/recommend` (semantic). If that endpoint is unavailable — e.g. a store backend without pgvector/semantic search returns **404** — it hard-failed and handed the agent a raw error (`store search failed: Client error '404 Not Found' …`) with **zero results**, dead-ending discovery. Observed against the local dev hub (SQLite, no `/recommend`).

## Fix
On **any** `/recommend` failure, fall back to a **lexical keyword search** via `/api/store/packages?q=…&type=skill` and return those candidates — flagged `degraded: "lexical"` with a hint that the reviewer verdict/best_for signals aren't available, so the agent judges fit from the description. Only if the lexical call *also* fails does it return an error (with both causes).

Net effect: store discovery works against **any** store backend (semantic or not) instead of erroring out. No change to the happy path (semantic `/recommend` still preferred and returns the full reviewer payload).

Verified: local `/api/store/packages?q=segmentation` returns 34 skills, so the fallback yields real candidates where `/recommend` 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)