### PR TITLE
fix(store): repair claude-scientific (0→149) + add DeepMind science-skills (+34)

### DIFF
--- a/pantheon/store/seed.py
+++ b/pantheon/store/seed.py
@@ -74,11 +74,26 @@ EXTERNAL_REPOS = {
         "has_categories": False,
     },
     "claude-scientific": {
+        # K-Dense-AI/claude-scientific-skills (== scientific-agent-skills, same repo)
+        # — 149 SKILL.md. The repo MOVED its skills from scientific-skills/ to
+        # skills/, which silently dropped this source to 0; skills_dir fixed below.
         "url": "https://github.com/K-Dense-AI/claude-scientific-skills.git",
-        "skills_dir": "scientific-skills",
+        "skills_dir": "skills",
         "display_name": "Claude Scientific Skills",
         "source_url": "https://github.com/K-Dense-AI/claude-scientific-skills",
         "has_categories": False,
+    },
+    "science-skills": {
+        # google-deepmind/science-skills (Apache-2.0 / CC-BY) — ~37 SKILL.md
+        # wrapping AlphaGenome, AlphaFold DB, UniProt, ClinVar + 30 databases.
+        # `exclude` drops the 3 non-science infra skills it ships (a uv installer,
+        # a shared-utils common, and a meta skill-creator).
+        "url": "https://github.com/google-deepmind/science-skills.git",
+        "skills_dir": "skills",
+        "display_name": "DeepMind Science Skills",
+        "source_url": "https://github.com/google-deepmind/science-skills",
+        "has_categories": False,
+        "exclude": ["uv", "scienceskillscommon", "workflow_skill_creator"],
     },
     "clawbio": {
         "url": "https://github.com/ClawBio/ClawBio.git",
@@ -654,9 +669,15 @@ class StoreSeed:
 
         skills = []
         has_categories = source_config.get("has_categories", False)
+        # Optional per-source skip list (skill dir-name or rel path), e.g. to drop
+        # non-science meta/infra skills a repo ships alongside its real skills.
+        exclude = set(source_config.get("exclude") or [])
 
         for skill_md in sorted(skills_dir.rglob("SKILL.md")):
             rel = skill_md.relative_to(skills_dir)
+            if skill_md.parent.name in exclude or str(rel.parent).replace("\\", "/") in exclude:
+                logger.info(f"[seed] {source_name}: excluding {rel.parent} (config exclude)")
+                continue
             parts = rel.parts
 
             category_hint = None


### PR DESCRIPTION
## Key finding
`claude-scientific` (K-Dense) was silently contributing **0 skills** — the upstream repo moved skills from `scientific-skills/` → `skills/`, but our `skills_dir` still pointed at the old empty dir (confirmed 0 packages on staging). One-line fix recovers **149** skills.

## Changes
- **Fix `claude-scientific`**: `skills_dir` `scientific-skills` → `skills` → +149.
- **Add `science-skills`** (google-deepmind, Apache-2.0/CC-BY): 37 SKILL.md (AlphaGenome/AlphaFold/UniProt/ClinVar + 30 DBs). New optional per-source `exclude` drops 3 non-science infra skills (uv, scienceskillscommon, workflow_skill_creator) → **34**.
- New reusable `exclude` mechanism in `_discover_external_skills`.

Net **+183**. Verified locally: claude-scientific now discovers 149, science-skills 34 (meta excluded); `py_compile` clean.

Notes: anthropic/life-sciences skipped (6 skills, mostly MCP marketplace). Kept DeepMind's DB-access skills (may be higher quality than existing equivalents; /recommend ranks by reviewer quality) — `exclude` is extendable if specific drops are wanted. Cross-source topical duplication is a known separate curation problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)