### PR TITLE
feat(llm): add Claude Sonnet 5 to the model catalog

### DIFF
--- a/pantheon/utils/llm_catalog.json
+++ b/pantheon/utils/llm_catalog.json
@@ -363,6 +363,22 @@
           "deprecated": true,
           "retirement_date": "2026-06-15"
         },
+        "claude-sonnet-5": {
+          "max_input_tokens": 1000000,
+          "max_output_tokens": 128000,
+          "input_cost_per_million": 3.0,
+          "output_cost_per_million": 15.0,
+          "supports_vision": true,
+          "supports_function_calling": true,
+          "supports_response_schema": true,
+          "supports_reasoning": true,
+          "supports_audio_input": false,
+          "supports_audio_output": false,
+          "supports_web_search": false,
+          "supports_pdf_input": true,
+          "supports_computer_use": true,
+          "supports_assistant_prefill": false
+        },
         "claude-sonnet-4-6": {
           "max_input_tokens": 1000000,
           "max_output_tokens": 64000,

--- a/pantheon/utils/model_selector.py
+++ b/pantheon/utils/model_selector.py
@@ -179,6 +179,7 @@ DEFAULT_PROVIDER_MODELS = {
             "anthropic/claude-opus-4-5-20251101",
         ],
         "normal": [
+            "anthropic/claude-sonnet-5",
             "anthropic/claude-sonnet-4-6",
             "anthropic/claude-sonnet-4-5-20250929",
             "anthropic/claude-sonnet-4-20250514",


### PR DESCRIPTION
## What

Adds **Claude Sonnet 5** (`claude-sonnet-5`) to the model catalog.

- **`pantheon/utils/llm_catalog.json`** — new `claude-sonnet-5` entry under the `anthropic` provider: 1M context, 128K max output, \$3/\$15 per 1M, vision / computer-use / reasoning / pdf all supported. `supports_assistant_prefill: false` to match the 4.6+ Anthropic API surface (assistant prefills 400), consistent with `claude-fable-5`.
- **`pantheon/utils/model_selector.py`** — prepend `anthropic/claude-sonnet-5` to the anthropic `normal` tier so it's reachable by tier routing (high/normal/low).

## Effect

- Surfaces in `list_available_models` → appears in the UI model picker automatically (the frontend fetches the list dynamically; **no frontend change needed**).
- Included in `reasoning_models` via `supports_reasoning`.

## Verification

`get_model_info` / `find_provider_for_model` / `completion_cost` / `list_available_models` all return the model correctly (cost \$18 @ 1M+1M = \$3+\$15). JSON validated; `model_selector.py` syntax-checked.