### PR TITLE
fix(file): bound read_file and take it off the event loop

### DIFF
--- a/pantheon/toolsets/file/file_manager.py
+++ b/pantheon/toolsets/file/file_manager.py
@@ -16,6 +16,42 @@ from pantheon.utils.log import logger
 from .apply_patch import execute_patch_operations
 from .grep_glob import grep_search, glob_search
 
+# Hard ceiling on how much text read_file will pull off disk in one call,
+# in characters (the file is opened in text mode). Nothing larger can be
+# returned in a single reply anyway — the caller must page with
+# start_line/end_line, or stream via open_file_for_read + read_chunk_at.
+# See _read_lines_bounded for why this exists.
+MAX_READ_CHARS = 8 * 1024 * 1024
+
+
+def _read_lines_bounded(
+    path: Path, max_chars: int
+) -> tuple[list[str], int, bool]:
+    """Read at most `max_chars` of `path` as text, split into lines.
+
+    This replaces a plain ``f.readlines()``, which read the *entire* file into
+    memory before any of read_file's line/char limits were applied. A 100 MB
+    file therefore became a single multi-hundred-megabyte string — and because
+    NUL bytes are valid UTF-8, even binaries decoded cleanly instead of failing
+    fast. Done on the event loop thread, that was enough to stop the agent
+    answering NATS ``_ping``, so the Hub declared it dead and recycled the
+    sandbox (observed on staging 2026-08-04).
+
+    Returns (lines, total_lines, truncated_by_size). When truncated_by_size is
+    True the file was cut at `max_chars`, so total_lines is a lower bound and
+    the last line may be partial.
+
+    Runs synchronously; call it via asyncio.to_thread so file I/O and UTF-8
+    decoding stay off the event loop.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        data = f.read(max_chars)
+        # One extra char tells us whether anything was left behind, without
+        # pulling in the rest of the file.
+        truncated_by_size = f.read(1) != ""
+    lines = data.splitlines(keepends=True)
+    return lines, len(lines), truncated_by_size
+
 
 def _replace_in_content(
     content: str,
@@ -811,10 +847,37 @@ class FileManagerToolSet(FileManagerToolSetBase):
             return {"success": False, "error": "Path is not a file"}
 
         try:
-            with open(target_path, "r", encoding="utf-8") as f:
-                lines = f.readlines()
+            # Bounded + off-thread: never pull an unbounded amount off disk,
+            # and never do the read or the UTF-8 decode on the event loop.
+            # (See _read_lines_bounded — an unbounded readlines() here is what
+            # let a single large file stop the agent answering health checks.)
+            lines, total_lines, truncated_by_size = await asyncio.to_thread(
+                _read_lines_bounded, target_path, MAX_READ_CHARS
+            )
 
-            total_lines = len(lines)
+            if truncated_by_size:
+                # Too big to serve in one reply. Return the prefix we already
+                # have rather than a bare error, so callers reading the head of
+                # a big log still get something useful.
+                from pantheon.settings import get_settings
+                char_limit = (
+                    max_chars if max_chars is not None
+                    else get_settings().max_file_read_chars
+                )
+                content = "".join(lines)[:char_limit]
+                return {
+                    "success": True,
+                    "content": content,
+                    "total_lines": total_lines,
+                    "format": target_path.suffix.lower(),
+                    "truncated": True,
+                    "hint": (
+                        f"⚠️ File is too large to return in one reply; "
+                        f"showing the first {len(content):,} chars of its first "
+                        f"{total_lines:,}+ lines. Page with start_line/end_line, "
+                        f"or stream it with open_file_for_read + read_chunk_at."
+                    ),
+                }
 
             # Empty file - return early
             if total_lines == 0:

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -614,3 +614,77 @@ async def test_max_tokens_live_openai():
     assert isinstance(message, dict)
     content = message.get("content", "")
     assert len(content) > 0, "Expected non-empty response"
+
+
+# --- read_file must stay bounded (staging incident 2026-08-04) -------------
+#
+# read_file used to do a plain f.readlines(), pulling the whole file into memory
+# before any line/char limit applied. A 100 MB file became one huge string on
+# the event loop thread; the agent stopped answering NATS _ping and the Hub
+# recycled the sandbox. These pin the two properties that prevent that:
+# the read is bounded, and it happens off the event loop.
+
+from pantheon.toolsets.file.file_manager import (  # noqa: E402
+    MAX_READ_CHARS,
+    _read_lines_bounded,
+)
+
+
+def test_read_lines_bounded_stops_at_the_ceiling(tmp_path):
+    """A file past the ceiling is cut, and reports that it was cut."""
+    big = tmp_path / "big.txt"
+    big.write_text("x" * (MAX_READ_CHARS + 5000))
+
+    lines, total_lines, truncated = _read_lines_bounded(big, MAX_READ_CHARS)
+
+    assert truncated is True
+    assert sum(len(x) for x in lines) == MAX_READ_CHARS
+    assert total_lines >= 1
+
+
+def test_read_lines_bounded_reads_small_files_whole(tmp_path):
+    small = tmp_path / "small.txt"
+    small.write_text("a\nb\nc\n")
+
+    lines, total_lines, truncated = _read_lines_bounded(small, MAX_READ_CHARS)
+
+    assert truncated is False
+    assert total_lines == 3
+    assert "".join(lines) == "a\nb\nc\n"
+
+
+def test_read_lines_bounded_keeps_line_endings(tmp_path):
+    """read_file joins these back together, so endings must survive."""
+    f = tmp_path / "e.txt"
+    f.write_text("one\ntwo\n")
+
+    lines, _, _ = _read_lines_bounded(f, MAX_READ_CHARS)
+
+    assert lines == ["one\n", "two\n"]
+
+
+async def test_read_file_truncates_a_huge_file_instead_of_hanging(temp_toolset):
+    """The whole point: a file far past the ceiling returns promptly, marked
+    truncated, rather than materialising in full."""
+    root = temp_toolset._get_root()
+    huge = root / "huge.txt"
+    huge.write_text("y" * (MAX_READ_CHARS + 100_000))
+
+    result = await temp_toolset.read_file("huge.txt")
+
+    assert result["success"] is True
+    assert result["truncated"] is True
+    assert len(result["content"]) < MAX_READ_CHARS
+    assert "too large" in result["hint"]
+
+
+async def test_read_file_still_returns_small_files_untruncated(temp_toolset):
+    root = temp_toolset._get_root()
+    (root / "ok.txt").write_text("hello\nworld\n")
+
+    result = await temp_toolset.read_file("ok.txt")
+
+    assert result["success"] is True
+    assert result["truncated"] is False
+    assert result["content"] == "hello\nworld\n"
+    assert result["total_lines"] == 2


### PR DESCRIPTION
Agent-side half of the large-file problem. Frontend half is [pantheon-ui#29](https://github.com/Nanguage/pantheon-ui/pull/29).

## What happened

Opening a 100 MB file in the UI's file panel made the agent stop answering NATS health checks, and the Hub recycled the whole sandbox. Staging, 2026-08-04:

```
00:55:07  Pod admin_001 health check timeout
00:55:40  Pod admin_001 health check timeout
00:56:03  Creating Modal Sandbox   ← Hub gave up on the agent
```

## Cause

`read_file` did this:

```python
with open(target_path, "r", encoding="utf-8") as f:
    lines = f.readlines()
```

Synchronous, unbounded, **on the event loop thread**, and — the part that makes the existing guards useless — *before* any limit is applied. `max_file_read_lines`, `max_file_read_chars` and `start_line`/`end_line` all filter a list that has already been fully materialised.

So a 100 MB file became one multi-hundred-megabyte string inline. NUL bytes are valid UTF-8, so a binary didn't even fail fast on decode — it sailed through and became 100M characters.

Request dispatch was never the problem: `NATSRemoteWorker._handle_request` already spawns each request with `asyncio.create_task`. The **event loop itself** was blocked, which is why even `_ping` — whose handler is documented as *"Must not block"* — couldn't answer.

## Fix

The read is bounded at `MAX_READ_CHARS` and runs via `asyncio.to_thread`, so neither the file I/O nor the UTF-8 decode touches the event loop.

Past the ceiling the caller still gets the file's head, marked `truncated`, with a hint to page via `start_line`/`end_line` or stream with `open_file_for_read` + `read_chunk_at`. That's more useful than a bare error for the common *"show me the top of this log"* case. Files under the ceiling behave exactly as before.

Detecting the overflow costs one extra character, not another pass over the file:

```python
data = f.read(max_chars)
truncated_by_size = f.read(1) != ""
```

## Tests

5 new tests: the ceiling cuts and reports it, small files read whole and untruncated, line endings survive the split (`read_file` joins them back), a huge file returns promptly marked truncated, and normal files are unaffected.

`tests/test_file_manager.py` + `tests/test_file_manager_broken_symlink.py`: 17 passed, 1 skipped on this branch. The 2 pre-existing failures in `test_think_plugin.py` fail on `main` too and are unrelated.

## Why both halves

pantheon-ui#29 stops the file panel from requesting an unbounded read. This makes the agent resilient when something still does — a user running `cat` on a big file by hand, a skill that reads a BAM, anything not routed through the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)