### PR TITLE
Web/Desktop App Tutorials Page

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -455,6 +455,81 @@ html[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
     }
 }
 
+/* ===== Sidebar Quick-Nav (Platforms / Functions) ===== */
+.sidebar-quicknav {
+    padding: 0 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.sidebar-quicknav-header {
+    font-size: 0.68rem !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.09em !important;
+    text-transform: uppercase !important;
+    color: var(--text-tertiary, #888) !important;
+    margin: 1rem 0 0.35rem 0 !important;
+    padding: 0 !important;
+    line-height: 1 !important;
+}
+
+.sidebar-quicknav-list {
+    list-style: none !important;
+    padding: 0 !important;
+    margin: 0 0 0.25rem 0 !important;
+}
+
+.sidebar-quicknav-list li {
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+.sidebar-quicknav-list li a {
+    display: block !important;
+    padding: 0.28rem 0.6rem !important;
+    border-radius: 5px !important;
+    font-size: 0.82rem !important;
+    font-weight: 400 !important;
+    color: var(--pst-color-text-muted, #555) !important;
+    text-decoration: none !important;
+    transition: background 0.15s, color 0.15s !important;
+    border-left: 2px solid transparent !important;
+}
+
+.sidebar-quicknav-list li a:hover {
+    background: rgba(91, 95, 199, 0.08) !important;
+    color: var(--primary, #5b5fc7) !important;
+    text-decoration: none !important;
+}
+
+.sidebar-quicknav-list li.quicknav-active a {
+    background: rgba(91, 95, 199, 0.1) !important;
+    color: var(--primary, #5b5fc7) !important;
+    font-weight: 600 !important;
+    border-left-color: var(--primary, #5b5fc7) !important;
+}
+
+.sidebar-quicknav-divider {
+    border: none !important;
+    border-top: 1px solid var(--border, #e2e8f0) !important;
+    margin: 0.75rem 0.25rem 0.25rem !important;
+}
+
+/* Dark mode adjustments for quick-nav */
+html[data-theme="dark"] .sidebar-quicknav-header {
+    color: #888 !important;
+}
+html[data-theme="dark"] .sidebar-quicknav-list li a {
+    color: #aaa !important;
+}
+html[data-theme="dark"] .sidebar-quicknav-list li a:hover,
+html[data-theme="dark"] .sidebar-quicknav-list li.quicknav-active a {
+    background: rgba(91, 95, 199, 0.15) !important;
+    color: #a5a8e6 !important;
+}
+html[data-theme="dark"] .sidebar-quicknav-divider {
+    border-top-color: #334155 !important;
+}
+
 /* ===== Tutorial Video Cards ===== */
 .tutorial-card {
     transition: all 0.2s ease !important;

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -455,6 +455,29 @@ html[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
     }
 }
 
+/* ===== Tutorial Video Cards ===== */
+.tutorial-card {
+    transition: all 0.2s ease !important;
+}
+
+.tutorial-card:hover {
+    transform: translateY(-3px) !important;
+    box-shadow: var(--shadow-lg) !important;
+    border-color: var(--primary) !important;
+}
+
+.tutorial-card .sd-card-body {
+    padding: 0.75rem !important;
+}
+
+.tutorial-card .sd-card-title {
+    font-size: 0.9rem !important;
+    font-weight: 600 !important;
+    line-height: 1.4 !important;
+    letter-spacing: -0.01em !important;
+    margin-bottom: 0.75rem !important;
+}
+
 /* ===== Misc ===== */
 html { scroll-behavior: smooth; }
 

--- a/docs/source/_templates/sidebar-platforms-functions.html
+++ b/docs/source/_templates/sidebar-platforms-functions.html
@@ -1,0 +1,38 @@
+<div class="sidebar-quicknav">
+  <p class="sidebar-quicknav-header">Platforms</p>
+  <ul class="sidebar-quicknav-list">
+    <li class="{% if pagename.startswith('interfaces/ui') %}quicknav-active{% endif %}">
+      <a href="{{ pathto('interfaces/ui/index') }}">Web / Desktop App</a>
+    </li>
+    <li class="{% if pagename.startswith('interfaces/repl') %}quicknav-active{% endif %}">
+      <a href="{{ pathto('interfaces/repl/index') }}">CLI (REPL)</a>
+    </li>
+    <li class="{% if pagename.startswith('interfaces/api') %}quicknav-active{% endif %}">
+      <a href="{{ pathto('interfaces/api/index') }}">Python API</a>
+    </li>
+  </ul>
+
+  <p class="sidebar-quicknav-header">Functions</p>
+  <ul class="sidebar-quicknav-list">
+    <li class="{% if pagename.startswith('team') %}quicknav-active{% endif %}">
+      <a href="{{ pathto('team/index') }}">Multi-Agent Teams</a>
+    </li>
+    <li class="{% if pagename.startswith('toolsets') and not pagename.startswith('toolsets/fleet') and not pagename.startswith('toolsets/live') and not pagename.startswith('toolsets/scfm') and not pagename.startswith('toolsets/evolution') %}quicknav-active{% endif %}">
+      <a href="{{ pathto('toolsets/index') }}">Toolsets</a>
+    </li>
+    <li class="{% if pagename == 'toolsets/fleet' or pagename.startswith('interfaces/ui/fleet') %}quicknav-active{% endif %}">
+      <a href="{{ pathto('toolsets/fleet') }}">Pantheon Fleet</a>
+    </li>
+    <li class="{% if pagename == 'toolsets/live_view' or pagename.startswith('interfaces/ui/live') %}quicknav-active{% endif %}">
+      <a href="{{ pathto('toolsets/live_view') }}">Live View</a>
+    </li>
+    <li class="{% if pagename == 'advanced/evolution' or pagename == 'toolsets/evolution' %}quicknav-active{% endif %}">
+      <a href="{{ pathto('advanced/evolution') }}">Evolution</a>
+    </li>
+    <li class="{% if pagename == 'interfaces/ui/store-skills' %}quicknav-active{% endif %}">
+      <a href="{{ pathto('interfaces/ui/store-skills') }}">Store &amp; Skills</a>
+    </li>
+  </ul>
+
+  <hr class="sidebar-quicknav-divider" />
+</div>

--- a/docs/source/_toc.yml
+++ b/docs/source/_toc.yml
@@ -33,6 +33,8 @@ chapters:
     - file: interfaces/api/team
     - file: interfaces/api/toolsets
     - file: interfaces/api/advanced
+  - title: Web/Desktop App Tutorials
+    file: interfaces/tutorials
 
 # Configuration (Shared Foundation)
 - file: configuration/index

--- a/docs/source/_toc.yml
+++ b/docs/source/_toc.yml
@@ -3,40 +3,54 @@ root: index
 title: Home
 
 chapters:
-# Getting Started (Easy)
+
+# ── Getting Started ──────────────────────────────────────────────────────────
 - file: getting-started/index
   sections:
   - file: getting-started/installation
   - file: getting-started/first-steps
   - file: getting-started/5min-tutorial
 
-# Interfaces (Three Entry Points)
-- file: interfaces/index
+# ── Web / Desktop App ────────────────────────────────────────────────────────
+- title: Web / Desktop App
+  file: interfaces/ui/index
   sections:
-  - title: REPL
-    file: interfaces/repl/index
-    sections:
-    - file: interfaces/repl/commands
-    - file: interfaces/repl/file-viewer
-    - file: interfaces/repl/advanced
-  - title: Web UI
-    file: interfaces/ui/index
-    sections:
-    - file: interfaces/ui/quickstart
-    - file: interfaces/ui/web-interface
-    - file: interfaces/ui/advanced
-  - title: Python API
-    file: interfaces/api/index
-    sections:
-    - file: interfaces/api/quickstart
-    - file: interfaces/api/agent
-    - file: interfaces/api/team
-    - file: interfaces/api/toolsets
-    - file: interfaces/api/advanced
-  - title: Web/Desktop App Tutorials
+  - file: interfaces/ui/quickstart
+  - file: interfaces/ui/core-features
+  - file: interfaces/ui/projects
+  - file: interfaces/ui/teams-agents
+  - file: interfaces/ui/models-providers
+  - file: interfaces/ui/store-skills
+  - file: interfaces/ui/fleet
+  - file: interfaces/ui/live-view
+  - file: interfaces/ui/terminal
+  - file: interfaces/ui/gateway
+  - file: interfaces/ui/advanced
+  - title: Video Tutorials
     file: interfaces/tutorials
 
-# Configuration (Shared Foundation)
+# ── CLI (REPL) ────────────────────────────────────────────────────────────────
+- title: CLI (REPL)
+  file: interfaces/repl/index
+  sections:
+  - file: interfaces/repl/quickstart
+  - file: interfaces/repl/commands
+  - file: interfaces/repl/session-management
+  - file: interfaces/repl/file-viewer
+  - file: interfaces/repl/mcp-servers
+  - file: interfaces/repl/advanced
+
+# ── Python API ────────────────────────────────────────────────────────────────
+- title: Python API
+  file: interfaces/api/index
+  sections:
+  - file: interfaces/api/quickstart
+  - file: interfaces/api/agent
+  - file: interfaces/api/team
+  - file: interfaces/api/toolsets
+  - file: interfaces/api/advanced
+
+# ── Configuration ─────────────────────────────────────────────────────────────
 - file: configuration/index
   sections:
   - file: configuration/settings
@@ -48,59 +62,60 @@ chapters:
   - file: configuration/mcp
   - file: configuration/models
 
-# Core Components (Deep Dive)
-- file: components/index
+# ── Toolsets Reference ────────────────────────────────────────────────────────
+- file: toolsets/index
   sections:
-  - file: components/agents
-  - file: components/teams
-  - file: components/toolsets
-  - file: components/memory
-  - file: components/providers
-  # Legacy detailed docs
-  - title: Teams
-    file: team/index
+  - file: toolsets/builtin_toolsets
+  - title: Code Execution
+    file: toolsets/python_interpreter
     sections:
-    - file: team/pantheon_team
-    - file: team/sequential_team
-    - file: team/moa_team
-    - file: team/swarm_team
-    - file: team/swarm_center_team
-  - title: Toolsets
-    file: toolsets/index
-    sections:
-    - file: toolsets/builtin_toolsets
-    - file: toolsets/python_interpreter
-    - file: toolsets/notebook
+    - file: toolsets/r_interpreter
+    - file: toolsets/julia_interpreter
     - file: toolsets/shell
-    - file: toolsets/web_browse
-    - file: toolsets/file_editor
-    - file: toolsets/custom_toolsets
+    - file: toolsets/notebook
+  - file: toolsets/file_editor
+  - file: toolsets/web_browse
+  - file: toolsets/fleet
+  - file: toolsets/live_view
+  - file: toolsets/scfm
+  - file: toolsets/evolution
+  - file: toolsets/evaluator
+  - file: toolsets/knowledge
+  - file: toolsets/vector_rag
+  - file: toolsets/database_api
+  - file: toolsets/scraper_api
+  - file: toolsets/image_generation
+  - file: toolsets/task
+  - file: toolsets/skillbook
+  - file: toolsets/code_toolset
+  - file: toolsets/file_transfer
+  - file: toolsets/package
+  - file: toolsets/custom_toolsets
 
-# Advanced Topics
+# ── Teams & Agents ────────────────────────────────────────────────────────────
+- file: team/index
+  sections:
+  - file: team/pantheon_team
+  - file: team/sequential_team
+  - file: team/moa_team
+  - file: team/swarm_team
+  - file: team/swarm_center_team
+  - file: team/custom_team
+
+# ── Advanced Topics ───────────────────────────────────────────────────────────
 - file: advanced/index
   sections:
-  - file: advanced/learning
   - file: advanced/evolution
   - file: advanced/distributed
+  - file: advanced/learning
   - file: advanced/extending
 
-# Reference
-- file: examples/index
-  sections:
-  - file: examples/shell_bot
-  - file: examples/search_bot
-  - file: examples/coderun_bot
-  - file: examples/reasoning_bot
-  - file: examples/sequential_team
-  - file: examples/swarm_team
-  - file: examples/moa_team
-  - file: examples/paper_reporter
+# ── Reference ─────────────────────────────────────────────────────────────────
 - file: api/index
   sections:
   - file: api/agent
   - file: api/team
   - file: api/memory
-  - file: api/chatroom
   - file: api/repl
 - file: concepts
 - file: architecture

--- a/docs/source/advanced/index.rst
+++ b/docs/source/advanced/index.rst
@@ -1,62 +1,63 @@
 Advanced Topics
 ===============
 
-Advanced features and patterns for power users.
-
-Overview
---------
-
-These topics cover advanced Pantheon capabilities:
-
-**Learning System**
-   Agents that improve over time by recording and learning from successful task completions.
-
-**Evolution System**
-   Automatic code optimization through LLM-guided mutations and evaluation.
-
-**Distributed Deployment**
-   Running Pantheon across multiple machines with NATS backend.
-
-**Extending Pantheon**
-   Creating custom components, providers, and integrations.
-
-Prerequisites
--------------
-
-Before diving into advanced topics, ensure you're comfortable with:
-
-- Basic agent creation and usage
-- Team configurations
-- Toolset usage
-- Configuration system (``.pantheon/`` structure)
-
-Difficulty Levels
------------------
+Deep-dive guides for power users and developers who want to push Pantheon beyond the defaults.
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 20 50
+   :widths: 25 15 60
 
    * - Topic
-     - Difficulty
-     - Prerequisites
-   * - Learning System
+     - Level
+     - What You Will Learn
+   * - :doc:`evolution`
+     - Advanced
+     - LLM-guided MAP-Elites optimization; ``EvolutionTeam``; custom evaluators; multi-island search; visualizing results
+   * - :doc:`distributed`
+     - Advanced
+     - NATS hub topology; multi-worker HA; remote endpoints; Docker/K8s deployment
+   * - :doc:`learning`
      - Intermediate
-     - Agent basics, toolsets
-   * - Evolution System
+     - Skillbook system; automatic skill recording; retrieval and refinement; sharing skills across a team
+   * - :doc:`extending`
      - Advanced
-     - Learning system, teams
-   * - Distributed Deployment
-     - Advanced
-     - System administration, NATS
-   * - Extending Pantheon
-     - Advanced
-     - Python, async programming
+     - Custom toolsets, team patterns, providers, and plugins
 
-Quick Links
------------
+Evolution System
+----------------
 
-- :doc:`learning` - Agent skill acquisition and memory
-- :doc:`evolution` - Automatic code optimization
-- :doc:`distributed` - Multi-machine deployment
-- :doc:`extending` - Custom development
+The Evolution system runs MAP-Elites + LLM mutation to automatically improve code.
+See :doc:`evolution` for the full guide.
+
+See also :doc:`/toolsets/evolution` for using the EvolutionToolSet inside an agent,
+and the ``examples/evolution_*/`` directories in the repository for runnable examples.
+
+Distributed Deployment
+----------------------
+
+Pantheon's NATS backend supports multi-machine deployments where agents, toolsets, and
+endpoints run on separate processes or machines. See :doc:`distributed`.
+
+For multi-machine agent control via the Fleet system, see :doc:`/toolsets/fleet`
+and :doc:`/interfaces/ui/fleet`.
+
+Learning System
+---------------
+
+Agents can record successful strategies as reusable skills and retrieve them in future
+sessions. See :doc:`learning`.
+
+Extending Pantheon
+------------------
+
+Build custom toolsets, register new team patterns, or add third-party providers.
+See :doc:`extending`.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   evolution
+   distributed
+   learning
+   extending

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,14 +70,24 @@ html_theme_options = {
     "use_download_button": True,
     "path_to_docs": "docs/source",
     "repository_branch": "main",
-    "home_page_in_toc": True,
-    "show_navbar_depth": 1,  # Show 2 levels, deeper levels collapsed
+    "home_page_in_toc": False,
+    "show_navbar_depth": 2,
     "logo": {
         "image_light": "_static/pantheon.png",
         "image_dark": "_static/pantheon.png",
         "text": "Pantheon",
     },
     "navigation_with_keys": True,
+    "primary_sidebar_end": [],
+}
+
+# Custom primary sidebar: Platforms + Functions quick-nav above the TOC
+html_sidebars = {
+    "**": [
+        "navbar-logo.html",
+        "sidebar-platforms-functions.html",
+        "sbt-sidebar-nav.html",
+    ]
 }
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -63,9 +63,54 @@
 
 ---
 
-## Key Features
+## Use PantheonOS
 
-::::{grid} 1 1 2 2
+::::{grid} 1 1 3 3
+:gutter: 3
+
+:::{grid-item-card}
+:link: interfaces/ui/index
+:link-type: doc
+:text-align: center
+
+<svg class="card-icon-sm icon-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0H3" /></svg>
+
+**Web / Desktop App**
+
+Full graphical interface with chat, projects, fleet, live view, store, and terminal.
+:::
+
+:::{grid-item-card}
+:link: interfaces/repl/index
+:link-type: doc
+:text-align: center
+
+<svg class="card-icon-sm icon-green" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" /></svg>
+
+**CLI (REPL)**
+
+Terminal interface with slash commands, session management, file viewer, and MCP support.
+:::
+
+:::{grid-item-card}
+:link: interfaces/api/index
+:link-type: doc
+:text-align: center
+
+<svg class="card-icon-sm icon-orange" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" /></svg>
+
+**Python API**
+
+Full programmatic control — agents, teams, toolsets, and streaming from code.
+:::
+
+::::
+
+---
+
+## Platform Capabilities
+
+::::{grid} 2 2 3 3
 :gutter: 3
 
 :::{grid-item-card}
@@ -77,7 +122,7 @@
 
 **Multi-Agent Teams**
 
-PantheonTeam, Sequential, Swarm, MoA patterns for complex workflows.
+PantheonTeam, Sequential, Swarm, MoA — delegate and parallelize complex tasks.
 :::
 
 :::{grid-item-card}
@@ -87,125 +132,57 @@ PantheonTeam, Sequential, Swarm, MoA patterns for complex workflows.
 
 <svg class="card-icon-sm icon-orange" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" /></svg>
 
-**Rich Toolsets**
+**25+ Toolsets**
 
-Python, Jupyter, Shell, Web, File operations, Knowledge bases.
+Python, R, Julia, Shell, Jupyter, Files, Web, Fleet, Live View, SCFM, RAG, and more.
 :::
 
 :::{grid-item-card}
-:link: interfaces/repl/index
+:link: toolsets/fleet
 :link-type: doc
 :text-align: center
 
-<svg class="card-icon-sm icon-green" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 0 1-.825-.242m9.345-8.334a2.126 2.126 0 0 0-.476-.095 48.64 48.64 0 0 0-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0 0 11.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155" /></svg>
+<svg class="card-icon-sm icon-cyan" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 6 0m-6 0H3m16.5 0a3 3 0 0 0 3-3m-3 3a3 3 0 1 1-6 0m6 0h1.5m-7.5 0v-1.5m0 1.5v1.5m-7.5-7.5V9m0 0a3 3 0 0 1 3-3h9a3 3 0 0 1 3 3m-15 0h-1.5m16.5 0h1.5" /></svg>
 
-**Interactive REPL**
+**Pantheon Fleet**
 
-Full-screen file viewer, syntax highlighting, interactive approvals.
+Control multiple machines from one session — run code, transfer files, manage nodes.
 :::
 
 :::{grid-item-card}
-:link: configuration/mcp
+:link: toolsets/live_view
 :link-type: doc
 :text-align: center
 
-<svg class="card-icon-sm icon-purple" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" /></svg>
+<svg class="card-icon-sm icon-purple" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5m.75-9 3-3 2.148 2.148A12.061 12.061 0 0 1 16.5 7.605" /></svg>
 
-**MCP Integration**
+**Live View**
 
-Connect to external MCP servers and expose tools as endpoints.
+Interactive visualizations in the browser: IGV, Mol*, Vitessce, Cytoscape, and 7 more.
 :::
 
 :::{grid-item-card}
-:link: advanced/index
+:link: advanced/evolution
 :link-type: doc
 :text-align: center
 
-<svg class="card-icon-sm icon-pink" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5" /></svg>
+<svg class="card-icon-sm icon-pink" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z" /></svg>
 
-**Learning System**
+**Evolution**
 
-Skillbook-based learning for agents to improve over time.
+LLM-guided MAP-Elites optimization to automatically improve algorithms and code.
 :::
 
 :::{grid-item-card}
-:link: advanced/index
+:link: interfaces/ui/store-skills
 :link-type: doc
 :text-align: center
 
-<svg class="card-icon-sm icon-cyan" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5a17.92 17.92 0 0 1-8.716-2.247m0 0A8.966 8.966 0 0 1 3 12c0-1.97.633-3.794 1.707-5.274" /></svg>
+<svg class="card-icon-sm icon-green" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 21v-7.5a.75.75 0 0 1 .75-.75h3a.75.75 0 0 1 .75.75V21m-4.5 0H2.36m11.14 0H18m0 0h3.64m-1.39 0V9.349M3.75 21V9.349m0 0a3.001 3.001 0 0 0 3.75-.615A2.993 2.993 0 0 0 9.75 9.75c.896 0 1.7-.393 2.25-1.016a2.993 2.993 0 0 0 2.25 1.016c.896 0 1.7-.393 2.25-1.015a3.001 3.001 0 0 0 3.75.614m-16.5 0a3.004 3.004 0 0 1-.621-4.72l1.189-1.19A1.5 1.5 0 0 1 5.378 3h13.243a1.5 1.5 0 0 1 1.06.44l1.19 1.189a3 3 0 0 1-.621 4.72M6.75 18h3.75a.75.75 0 0 0 .75-.75V13.5a.75.75 0 0 0-.75-.75H6.75a.75.75 0 0 0-.75.75v3.75c0 .414.336.75.75.75Z" /></svg>
 
-**Distributed**
+**Store & Skills**
 
-NATS-based distributed execution across multiple machines.
+Install agent skill packs — omics, paper writing, bioimaging, structural biology, and more.
 :::
 
 ::::
-
-```{toctree}
-:hidden:
-:maxdepth: 2
-:caption: Getting Started
-
-getting-started/index
-getting-started/installation
-getting-started/first-steps
-getting-started/5min-tutorial
-```
-
-```{toctree}
-:hidden:
-:maxdepth: 2
-:caption: Interfaces
-
-interfaces/index
-interfaces/repl/index
-interfaces/ui/index
-interfaces/api/index
-```
-
-```{toctree}
-:hidden:
-:maxdepth: 2
-:caption: Configuration
-
-configuration/index
-configuration/settings
-configuration/templates/index
-configuration/mcp
-configuration/models
-```
-
-```{toctree}
-:hidden:
-:maxdepth: 2
-:caption: Components
-
-components/index
-team/index
-toolsets/index
-```
-
-```{toctree}
-:hidden:
-:maxdepth: 2
-:caption: Advanced
-
-advanced/index
-advanced/learning
-advanced/evolution
-advanced/distributed
-advanced/extending
-```
-
-```{toctree}
-:hidden:
-:maxdepth: 2
-:caption: Reference
-
-examples/index
-api/index
-concepts
-architecture
-contributing
-```

--- a/docs/source/interfaces/repl/commands.rst
+++ b/docs/source/interfaces/repl/commands.rst
@@ -1,186 +1,309 @@
-REPL Commands
-=============
+Command Reference
+=================
 
-Complete reference for REPL slash commands.
+Complete reference for the Pantheon CLI — startup options, slash commands, file input
+syntax, and keyboard shortcuts.
 
-Built-in Commands
------------------
+Starting Pantheon CLI
+---------------------
 
-/help
-~~~~~
+.. code-block:: bash
 
-Display available commands.
+   pantheon cli [OPTIONS] [--] [MESSAGE]
 
-.. code-block:: text
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
 
-   > /help
+   * - Option
+     - Default
+     - Description
+   * - ``--template <name>``
+     -
+     - Team template to load. Uses a built-in template name or a filename from
+       ``.pantheon/teams/`` (without the ``.md`` extension).
+   * - ``--memory-dir <path>``
+     - ``.pantheon/memory``
+     - Directory where session files are stored and read from.
+   * - ``--workspace <path>``
+     - current directory
+     - Workspace root that agents operate in when workspace mode is active.
+   * - ``--chat-id <id>``
+     -
+     - Resume a specific session by its exact ID.
+   * - ``--resume <id\|name\|last>``
+     -
+     - Resume a session by partial name, full ID, or the keyword ``last`` to
+       resume the most recently active session.
+   * - ``-r <id\|name\|last>``
+     -
+     - Shorthand for ``--resume``.
+   * - ``--log-level <level>``
+     - ``ERROR``
+     - Logging verbosity: ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``.
+   * - ``--quiet``
+     - ``False``
+     - Suppress status messages and decorative output. Useful for scripted use.
+   * - ``--resync``
+     - ``False``
+     - Force a re-index of the workspace knowledge base on startup.
+   * - ``-i <message>``
+     -
+     - Send a single non-interactive query and exit. Accepts ``@path`` file
+       attachments. Output is printed to stdout.
+   * - ``--model <name\|tag>``
+     -
+     - Override the model for all agents in this session. Accepts a full model
+       identifier (e.g., ``openai/gpt-4o``) or a quality tag (``high``,
+       ``normal``, ``fast``).
 
-/view <filepath>
-~~~~~~~~~~~~~~~~
+Slash Commands — Complete Reference
+-------------------------------------
 
-Open full-screen file viewer with syntax highlighting.
+Session & Navigation
+~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: text
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
 
-   > /view src/main.py
-   > /view README.md
+   * - Command
+     - Description
+   * - ``/help``
+     - Show all available slash commands with brief descriptions.
+   * - ``/status``
+     - Show current session information: active model, team template name, chat ID,
+       and approximate token count for the current context.
+   * - ``/new``
+     - Start a new chat session. The current session is saved automatically. The
+       new session starts with an empty conversation.
+   * - ``/clear``
+     - Clear the current conversation history. Prompts for confirmation before
+       deleting. The session ID is preserved but all turns are removed.
+   * - ``/exit``, ``/quit``, ``/q``
+     - Exit Pantheon CLI. The current session is saved before exiting.
 
-See :doc:`file-viewer` for navigation keys.
+Chat History
+~~~~~~~~~~~~
 
-/clear
-~~~~~~
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
 
-Clear conversation context. Starts a fresh conversation while keeping the same session.
+   * - Command
+     - Description
+   * - ``/history``
+     - Show the input history for the current CLI session (commands and messages
+       sent since startup). Not the same as conversation history.
+   * - ``/list`` (or ``/chats``)
+     - List all saved chat sessions. Displays session ID, name, creation date,
+       last modified date, and message count.
+   * - ``/resume [id\|name\|last]``
+     - Resume a previous chat. Accepts a full session ID, a partial session name
+       (case-insensitive substring match), or ``last`` for the most recent session.
+       If no argument is provided, shows an interactive session picker.
+   * - ``/save [file]``
+     - Save the current conversation to a JSON file. If no filename is provided,
+       saves to ``<session-id>.json`` in the current directory.
+   * - ``/load <file>``
+     - Load a conversation from a JSON file exported by ``/save``. The loaded
+       conversation replaces the current context; all history from the file is
+       available to the agent.
+   * - ``/revert [index]``
+     - Revert the conversation to an earlier user turn. If ``index`` is provided,
+       reverts to that turn number (0-indexed). If omitted, shows a numbered list
+       of user turns to pick from.
 
-.. code-block:: text
-
-   > /clear
-
-/compress
-~~~~~~~~~
-
-Compress conversation history to reduce token usage. Useful for long conversations approaching context limits.
-
-.. code-block:: text
-
-   > /compress
-
-The agent will summarize the conversation to preserve key information while reducing tokens.
-
-/model [model_name]
-~~~~~~~~~~~~~~~~~~~
-
-View or change the model for the current agent.
-
-.. code-block:: text
-
-   # Show current model and available models
-   > /model
-
-   # Set model by name
-   > /model openai/gpt-4o
-   > /model kimi-for-coding
-
-   # Set model by quality tag
-   > /model high
-   > /model normal,vision
-
-Model changes are **persisted** to the team template file so they survive restarts.
-
-/new
-~~~~
-
-Create a new chat session within the same REPL.
-
-.. code-block:: text
-
-   > /new
-
-/exit or /quit
+Agents & Teams
 ~~~~~~~~~~~~~~
 
-Exit the REPL.
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
 
-.. code-block:: text
+   * - Command
+     - Description
+   * - ``/agents``
+     - List all agents in the current team: name, role, model, and available
+       toolsets.
+   * - ``/agent <name\|n>``
+     - Switch the active agent. Accepts an agent name (partial match) or a
+       1-based agent number from the ``/agents`` list.
+   * - ``/team [list\|id\|path]``
+     - With no argument: show the current team name and template path. With
+       ``list``: show available templates. With a template ID or file path:
+       switch to that template immediately.
 
-   > /exit
-   > /quit
+Models & Keys
+~~~~~~~~~~~~~
 
-Shell Commands
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Command
+     - Description
+   * - ``/model [name\|tag]``
+     - With no argument: show the current model. With a model name or quality
+       tag: switch the model for the active agent. Model changes are persisted
+       to the team template file and survive restarts.
+   * - ``/keys [show\|set <provider>]``
+     - With no argument or ``show``: display configured provider API keys
+       (values are masked). With ``set <provider>``: prompt for and store a new
+       key for the given provider name.
+   * - ``/tokens``
+     - Show a token usage breakdown for the current conversation: total tokens,
+       tokens per turn, estimated cost at current model pricing.
+
+Context & Display
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Command
+     - Description
+   * - ``/compress``
+     - Immediately trigger context compression. The agent summarizes the earlier
+       conversation to reduce token usage. Use when approaching the context limit.
+   * - ``/verbose``, ``/v``
+     - Switch to verbose display mode. All tool calls, tool results, and agent
+       reasoning steps are shown in full.
+   * - ``/compact``, ``/c``
+     - Switch to compact display mode. Tool calls and results are collapsed to
+       one-line summaries. This is the default mode.
+
+Files
+~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Command
+     - Description
+   * - ``/view <path>``
+     - Open the file at ``<path>`` in the full-screen file viewer with syntax
+       highlighting, line numbers, and Vim-style navigation. Press ``q`` or
+       ``Esc`` to exit the viewer.
+   * - ``/edit [path]``
+     - Open a file in ``$EDITOR`` (falls back to ``nvim``, then ``vim``). After
+       you save and close the editor, you are returned to the REPL prompt.
+
+MCP Servers
+~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Command
+     - Description
+   * - ``/mcp list``
+     - List all configured MCP servers, their start commands, and current status
+       (running / stopped / error).
+   * - ``/mcp start <name>``
+     - Start a stopped MCP server. The server's tools become available to agents
+       immediately after startup.
+   * - ``/mcp stop <name>``
+     - Stop a running MCP server. Its tools are removed from the agent's toolset
+       without requiring a restart.
+   * - ``/mcp restart <name>``
+     - Stop and restart an MCP server. Useful after updating the server binary or
+       when a server has entered an error state.
+   * - ``/mcp add <name> <cmd>``
+     - Add a new MCP server for this session. ``<cmd>`` is the full shell command
+       to start the server (e.g., ``npx @modelcontextprotocol/server-filesystem``).
+       The server starts immediately and its tools become available.
+   * - ``/mcp remove <name>``
+     - Remove an MCP server from the current session. The server is stopped and
+       its tools are unregistered. Does not modify ``mcp.json``.
+
+Shell Pass-Through
+~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Syntax
+     - Description
+   * - ``!<cmd>``
+     - Run a shell command directly without involving the LLM. The command runs
+       in a subprocess using the current shell. Output is printed to the terminal.
+       Example: ``!ls -la``, ``!git status``, ``!python train.py``.
+
+Input Features
 --------------
 
-Run shell commands directly by prefixing with ``!``:
+**File attachment with** ``@``
+
+Attach a file as context by typing ``@<path>`` anywhere in your message:
 
 .. code-block:: text
 
-   > !ls -la
-   > !git status
-   > !python script.py
+   > Summarize the key findings in @results/analysis_report.pdf
 
-Output is displayed and can be referenced in the conversation.
+Tab completion is supported for ``@path`` attachments — press Tab after ``@`` to
+autocomplete file paths relative to the current workspace.
 
-Multi-line Input
-----------------
+**Image attachment with** ``@image:``
 
-For multi-line messages, wrap in triple backticks:
+Attach an image for vision models:
 
 .. code-block:: text
 
-   > ```
-   Please review this code:
+   > What cell types are shown in @image:figures/umap_by_celltype.png
 
-   def hello():
-       print("Hello")
-   ```
+Images are base64-encoded and sent as vision input. Requires a model that supports
+image input (look for the ``vision`` capability tag in ``/model``).
 
-The entire block is sent as one message.
+**Multi-line input**
+
+Press **Alt+Enter** or **Ctrl+J** to insert a newline without sending. Press **Enter**
+on its own to submit the complete multi-line message:
+
+.. code-block:: text
+
+   > Please review this function:
+     [Alt+Enter]
+     def calculate_gc(seq):
+         return (seq.count('G') + seq.count('C')) / len(seq)
+     [Enter to send]
+
+**History navigation**
+
+Press **Up Arrow** to scroll backward through previous messages and commands you have
+entered in this session. **Down Arrow** scrolls forward. History persists across
+sessions and is stored in ``~/.pantheon/cli_history``.
 
 Keyboard Shortcuts
 ------------------
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 70
 
    * - Key
      - Action
-   * - ``↑`` / ``↓``
-     - Navigate command history
-   * - ``Tab``
-     - Auto-complete
-   * - ``Ctrl+C``
-     - Cancel current operation
-   * - ``Ctrl+D``
-     - Exit REPL
-   * - ``Ctrl+L``
-     - Clear screen
-
-File Viewer Keys
-----------------
-
-When in the file viewer (``/view``):
-
-.. list-table::
-   :header-rows: 1
-
-   * - Key
-     - Action
-   * - ``j`` / ``↓``
-     - Scroll down
-   * - ``k`` / ``↑``
-     - Scroll up
-   * - ``Space`` / ``Ctrl+F``
-     - Page down
-   * - ``Ctrl+B``
-     - Page up
-   * - ``g``
-     - Go to top
-   * - ``G``
-     - Go to bottom
-   * - ``q`` / ``Esc``
-     - Exit viewer
-
-Interactive Dialogs
--------------------
-
-When agents request approval (via ``notify_user``), an interactive dialog appears:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Key
-     - Action
-   * - ``a``
-     - Approve
-   * - ``c``
-     - Continue planning
-   * - ``1-9``
-     - Switch between file previews
-   * - ``Tab``
-     - Next file
-   * - ``Esc``
-     - Cancel/Reject
-
-Custom Commands
----------------
-
-You can add custom commands by creating command handlers. See :doc:`advanced` for details.
+   * - **Enter**
+     - Send the current message to the active agent
+   * - **Shift+Enter**
+     - Insert a newline (same as Alt+Enter in most terminals)
+   * - **Alt+Enter**
+     - Insert a newline without sending (for multi-line messages)
+   * - **Ctrl+C**
+     - Cancel the currently streaming generation; returns to the prompt
+   * - **Ctrl+D**
+     - Exit Pantheon CLI (equivalent to ``/exit``)
+   * - **Ctrl+T**
+     - Toggle between compact and verbose display modes
+   * - **Esc**
+     - Cancel generation (alternative to Ctrl+C)
+   * - **Up Arrow**
+     - Navigate to the previous message/command in input history
+   * - **Down Arrow**
+     - Navigate to the next message/command in input history
+   * - **Tab**
+     - Autocomplete slash commands and ``@path`` file references

--- a/docs/source/interfaces/repl/index.rst
+++ b/docs/source/interfaces/repl/index.rst
@@ -1,155 +1,102 @@
-REPL Interface
-==============
+CLI (REPL)
+==========
 
-The REPL (Read-Eval-Print Loop) provides a feature-rich command-line interface for interacting with Pantheon agents and teams.
-
-Quick Start
------------
-
-Start the REPL with default settings:
+The Pantheon CLI provides a full-featured terminal interface for working with agents and
+teams. It supports streaming responses, rich syntax highlighting, slash commands, session
+persistence, and all the same teams and toolsets as the web app.
 
 .. code-block:: bash
 
    pantheon cli
 
-You'll see a welcome message and prompt. Type your message and press Enter to chat with the agent.
+You are dropped into an interactive prompt immediately. No additional setup is required
+beyond having an API key configured.
 
-.. code-block:: text
-
-   ╭─ Pantheon REPL ─╮
-   │ Type /help for commands │
-   ╰──────────────────────────╯
-
-   > Hello! What can you help me with?
-
-Starting Options
+Feature Overview
 ----------------
-
-.. code-block:: bash
-
-   # Use a specific team template
-   pantheon cli --template data_research_team
-
-   # Set memory directory
-   pantheon cli --memory-dir ./my_chats
-
-   # Resume a previous chat
-   pantheon cli --chat-id abc123
-
-   # Quiet mode (less output)
-   pantheon cli --quiet
-
-Key Features
-------------
-
-Syntax Highlighting
-~~~~~~~~~~~~~~~~~~~
-
-Code in responses is automatically highlighted:
-
-.. code-block:: text
-
-   > Write a Python hello world
-
-   Here's the code:
-
-   ```python
-   print("Hello, World!")
-   ```
-
-File Viewer
-~~~~~~~~~~~
-
-View files with syntax highlighting using ``/view``:
-
-.. code-block:: text
-
-   > /view src/main.py
-
-This opens a full-screen viewer with:
-
-- Line numbers
-- Syntax highlighting
-- Vim-style navigation (j/k, g/G)
-- Page navigation (Space, Ctrl-F/B)
-
-See :doc:`file-viewer` for details.
-
-Command History
-~~~~~~~~~~~~~~~
-
-- Use arrow keys to navigate previous commands
-- History persists across sessions
-- Stored in ``~/.pantheon/cli_history``
-
-Auto-Completion
-~~~~~~~~~~~~~~~
-
-- Tab completion for commands
-- File path completion
-
-Multi-line Input
-~~~~~~~~~~~~~~~~
-
-For multi-line messages, use triple backticks:
-
-.. code-block:: text
-
-   > ```
-   This is a
-   multi-line
-   message
-   ```
-
-Common Commands
----------------
 
 .. list-table::
    :header-rows: 1
+   :widths: 35 65
 
-   * - Command
+   * - Feature
+     - Details
+   * - **Streaming responses**
+     - Tokens stream to the terminal in real time; no waiting for the full response.
+   * - **Syntax highlighting**
+     - Code blocks in responses are automatically highlighted by language. File
+       viewer (``/view``) provides full syntax highlighting with line numbers.
+   * - **Slash commands**
+     - ~25 built-in commands covering sessions, agents, models, files, MCP servers,
+       and display modes. See :doc:`commands`.
+   * - **Session persistence & resume**
+     - Every conversation is saved automatically. Resume any session by name, ID,
+       or ``last`` on startup or mid-session.
+   * - **File viewer**
+     - ``/view <path>`` opens a full-screen file viewer with Vim-style navigation
+       (j/k, g/G, Space/Ctrl-B, q to exit).
+   * - **Shell pass-through**
+     - Prefix a command with ``!`` to run it directly in the shell without the LLM
+       (e.g., ``!git status``, ``!ls -la``).
+   * - **MCP server management**
+     - Start, stop, restart, add, and remove MCP tool servers live without restarting
+       the CLI session.
+   * - **Model switching**
+     - ``/model <name>`` changes the active model mid-session; change persists across
+       restarts.
+   * - **Multi-agent teams**
+     - All team templates available in the web app work identically in the CLI.
+       Switch agents mid-conversation with ``/agent``.
+   * - **Context compression**
+     - ``/compress`` triggers context summarization when approaching the model's
+       context limit.
+   * - **Speech input**
+     - Not available in the CLI. Use the web or desktop app for speech-to-text input.
+
+Command-Line Options
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Option
      - Description
-   * - ``/help``
-     - Show available commands
-   * - ``/view <file>``
-     - View file with syntax highlighting
-   * - ``/clear``
-     - Clear conversation context
-   * - ``/compress``
-     - Compress conversation to save tokens
-   * - ``/exit``
-     - Exit the REPL
+   * - ``--template <name>``
+     - Load a specific team template on startup.
+   * - ``--resume <id\|name\|last>``
+     - Resume a saved session immediately on startup.
+   * - ``-i <message>``
+     - Non-interactive mode: send one message and exit. Useful for scripting.
+   * - ``--model <name\|tag>``
+     - Override the model for all agents in this session.
+   * - ``--quiet``
+     - Suppress decorative output; useful when piping CLI output to other tools.
 
-See :doc:`commands` for the complete reference.
+See :doc:`commands` for the complete options reference.
 
-Configuration
--------------
+When to Use the CLI
+-------------------
 
-REPL settings are stored in ``.pantheon/settings.json``:
+Prefer the Pantheon CLI when:
 
-.. code-block:: json
+- Working on a remote server over SSH without a browser.
+- Scripting or automating one-shot queries with ``-i``.
+- Integrating Pantheon into shell pipelines or Makefiles.
+- Preferring a minimal, keyboard-driven interface.
+- Running on a headless machine or inside a container.
+- You want the fastest possible startup time (the CLI starts in under a second).
 
-   {
-     "repl": {
-       "quiet": false,
-       "default_template": "default",
-       "log_level": "ERROR"
-     }
-   }
-
-See :doc:`/configuration/settings` for all options.
-
-Next Steps
-----------
-
-- :doc:`commands` - Full command reference
-- :doc:`file-viewer` - File viewer features
-- :doc:`advanced` - Custom handlers and extensions
+Use the web or desktop app when you need Live View visualizations, the Fleet panel,
+the integrated PTY terminal, or the Gateway configuration UI.
 
 .. toctree::
    :hidden:
    :maxdepth: 1
 
+   quickstart
    commands
+   session-management
    file-viewer
+   mcp-servers
    advanced

--- a/docs/source/interfaces/repl/mcp-servers.rst
+++ b/docs/source/interfaces/repl/mcp-servers.rst
@@ -1,0 +1,197 @@
+MCP Servers
+===========
+
+MCP (Model Context Protocol) servers extend your agents with additional tools — databases,
+APIs, file systems, and specialized capabilities. The Pantheon CLI lets you manage MCP
+servers live without restarting the session.
+
+Overview
+--------
+
+MCP is an open protocol for exposing tools to LLM agents. An MCP server is a process that
+implements the protocol and responds to tool calls from the agent. Once an MCP server is
+running, its tools appear alongside Pantheon's built-in toolsets — the agent can call them
+interchangeably.
+
+Pantheon supports any spec-compliant MCP server, including:
+
+- The official ``@modelcontextprotocol`` reference servers (filesystem, GitHub, Slack, etc.)
+- Third-party servers from the MCP ecosystem
+- Custom servers you build with any MCP SDK
+
+Configuration
+-------------
+
+MCP servers are defined in ``.pantheon/mcp.json``. Each entry specifies a name, the
+command to start the server, optional arguments, and environment variables:
+
+.. code-block:: json
+
+   {
+     "servers": {
+       "filesystem": {
+         "command": "npx",
+         "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/data"],
+         "env": {}
+       },
+       "github": {
+         "command": "npx",
+         "args": ["-y", "@modelcontextprotocol/server-github"],
+         "env": {
+           "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+         }
+       },
+       "my-db-server": {
+         "command": "python",
+         "args": ["-m", "my_mcp_server"],
+         "env": {
+           "DB_URL": "postgresql://localhost/mydb"
+         }
+       }
+     }
+   }
+
+See :doc:`/configuration/mcp` for the complete configuration format including transport
+options and startup timeouts.
+
+Listing Servers
+---------------
+
+.. code-block:: text
+
+   > /mcp list
+
+   Name           Command                                     Status
+   ─────────────  ──────────────────────────────────────────  ───────
+   filesystem     npx @modelcontextprotocol/server-filesystem  Running
+   github         npx @modelcontextprotocol/server-github      Stopped
+   my-db-server   python -m my_mcp_server                      Error
+
+The status column shows:
+
+- **Running** — server is connected and its tools are available.
+- **Stopped** — server is configured but not currently running.
+- **Error** — server failed to start or crashed. See troubleshooting below.
+
+Starting & Stopping Servers
+----------------------------
+
+Start a stopped server without restarting the CLI:
+
+.. code-block:: text
+
+   > /mcp start github
+
+   Starting "github"... done
+   Tools registered: create_issue, list_repos, get_pr, ...
+
+Stop a running server:
+
+.. code-block:: text
+
+   > /mcp stop filesystem
+
+   Stopped "filesystem". Tools unregistered.
+
+Tool registration and unregistration happen immediately — no agent restart is needed.
+
+Restarting a Server
+-------------------
+
+Restart a server that has hung, crashed, or whose binary has been updated:
+
+.. code-block:: text
+
+   > /mcp restart my-db-server
+
+   Stopping "my-db-server"... done
+   Starting "my-db-server"... done
+   Tools registered: query_db, list_tables, describe_table
+
+Adding a Server at Runtime
+---------------------------
+
+Add a new MCP server for the current session without editing ``mcp.json``:
+
+.. code-block:: text
+
+   > /mcp add notes npx @modelcontextprotocol/server-memory
+
+   Starting "notes"... done
+   Tools registered: store_memory, retrieve_memory, list_memories
+
+The server is active for this session only. To make it permanent, add it to
+``.pantheon/mcp.json`` manually.
+
+For servers requiring arguments:
+
+.. code-block:: text
+
+   > /mcp add myfs npx @modelcontextprotocol/server-filesystem /tmp/workspace
+
+Removing a Server
+-----------------
+
+Remove an MCP server from the current session:
+
+.. code-block:: text
+
+   > /mcp remove notes
+
+   Stopped "notes". Tools unregistered and server removed from session.
+
+This does not modify ``mcp.json`` — the server remains configured for future sessions.
+
+Tools from MCP
+--------------
+
+Once an MCP server is running, its tools are available to the agent without any
+additional configuration. The agent discovers available tools automatically and can
+use them in responses.
+
+For example, after starting the ``filesystem`` server:
+
+.. code-block:: text
+
+   > List all CSV files in the /home/user/data directory
+
+   I'll use the filesystem tool to list the files...
+   [filesystem: list_directory /home/user/data *.csv]
+   Found 12 CSV files: ...
+
+MCP tools are shown in verbose mode (``/verbose`` or ``Ctrl+T``) with their server name
+as a prefix so you can distinguish them from built-in toolset calls.
+
+Troubleshooting
+---------------
+
+**Server fails to start**
+
+Run the CLI with ``--log-level DEBUG`` to see the full MCP server stderr output:
+
+.. code-block:: bash
+
+   pantheon cli --log-level DEBUG
+
+The debug output includes the server's startup command, environment, and any error
+messages printed to stderr.
+
+**Server shows Error status**
+
+Check the error message with ``/mcp list`` — a brief error summary is shown for servers
+in the Error state. Common causes:
+
+- Missing executable (e.g., ``npx`` not on PATH, Python module not installed)
+- Missing environment variable (e.g., API token not set)
+- Port conflict if the server uses a fixed port
+
+**Tools not appearing after start**
+
+If ``/mcp start`` completes but no tools are listed, the server started but returned an
+empty tool list. This usually means the server requires additional configuration (e.g.,
+a missing API key in the ``env`` block) that prevents it from registering its tools.
+
+.. tip::
+
+   Most official MCP servers print useful startup messages to stderr. Use
+   ``--log-level DEBUG`` to see them.

--- a/docs/source/interfaces/repl/quickstart.rst
+++ b/docs/source/interfaces/repl/quickstart.rst
@@ -1,0 +1,114 @@
+CLI Quick Start
+===============
+
+Get up and running with the Pantheon CLI in under two minutes.
+
+Prerequisites
+-------------
+
+- Python 3.10 or later
+- Install the package:
+
+  .. code-block:: bash
+
+     pip install pantheon-agents
+
+- At least one provider API key (e.g., ``OPENROUTER_API_KEY``, ``OPENAI_API_KEY``, or
+  ``ANTHROPIC_API_KEY``) set as an environment variable or configured via
+  ``pantheon cli`` on first run.
+
+Starting the REPL
+-----------------
+
+.. code-block:: bash
+
+   pantheon cli
+
+You are dropped into an interactive prompt. Type a message and press **Enter** to send it
+to the agent. Responses stream in real time.
+
+.. code-block:: text
+
+   ╭─ Pantheon CLI ────────────────────────────────╮
+   │  Model: anthropic/claude-opus-4-5              │
+   │  Team:  default                                │
+   │  Chat:  new-session-8f3a                       │
+   ╰────────────────────────────────────────────────╯
+
+   > Hello! What can you help me with?
+
+Starting with a Specific Team Template
+---------------------------------------
+
+.. code-block:: bash
+
+   pantheon cli --template single_cell
+
+Replace ``single_cell`` with any template name from ``.pantheon/teams/`` or a built-in
+template. The CLI loads the team configuration before the first prompt.
+
+Resuming a Previous Session
+----------------------------
+
+.. code-block:: bash
+
+   # Resume the most recent session
+   pantheon cli --resume last
+
+   # Resume by partial session name
+   pantheon cli --resume rna-seq-analysis
+
+   # Resume by exact session ID
+   pantheon cli --resume abc1234def
+
+The full conversation history is loaded and you can continue from where you left off.
+
+One-Shot Query (No Interactive Session)
+----------------------------------------
+
+Use ``-i`` to send a single query and exit. Useful for scripting or quick lookups:
+
+.. code-block:: bash
+
+   # Text query
+   pantheon cli -i "Summarize the methods section of this paper" @report.pdf
+
+   # Pipe output to a file
+   pantheon cli -i "Write a bash script to rename files by date" > rename.sh
+
+   # Non-interactive with a specific model
+   pantheon cli -i "What is the GC content of this sequence?" --model openai/gpt-4o
+
+The ``@path`` syntax attaches a file as context. Tab completion works for file paths.
+
+Key Shortcuts
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Key
+     - Action
+   * - **Enter**
+     - Send the current message
+   * - **Ctrl+C**
+     - Cancel the currently streaming generation
+   * - **Ctrl+D**
+     - Exit Pantheon CLI
+   * - **Esc**
+     - Cancel generation (alternative to Ctrl+C)
+   * - **Ctrl+T**
+     - Toggle between compact and verbose display modes
+   * - **Alt+Enter**
+     - Insert a newline (multi-line input without sending)
+   * - **Up / Down Arrow**
+     - Navigate input history
+
+Next Steps
+----------
+
+- :doc:`commands` — complete slash command and option reference
+- :doc:`session-management` — listing, resuming, and exporting sessions
+- :doc:`mcp-servers` — adding MCP tool servers to your CLI session
+- :doc:`file-viewer` — keyboard navigation in the ``/view`` file viewer

--- a/docs/source/interfaces/repl/session-management.rst
+++ b/docs/source/interfaces/repl/session-management.rst
@@ -1,0 +1,198 @@
+Session Management
+==================
+
+Pantheon CLI automatically saves every conversation as a named session. Sessions persist
+across restarts and can be resumed, exported, branched, or recovered after a crash.
+
+Overview
+--------
+
+Every time you start a new chat with ``pantheon cli`` (or type ``/new``), Pantheon creates
+a session with:
+
+- A unique **session ID** — a short alphanumeric identifier (e.g., ``8f3a2b1c``).
+- An auto-generated **name** derived from the first few words of your first message
+  (e.g., ``rna-seq-quality-control``).
+- A **timestamp** and message count that update with each turn.
+
+Sessions are written to the memory directory after every turn. If the process crashes or
+you close the terminal mid-response, the session is recoverable from disk.
+
+How Sessions Work
+-----------------
+
+Sessions are stored as JSONL files in the memory directory:
+
+.. code-block:: text
+
+   .pantheon/memory/
+   ├── 8f3a2b1c_rna-seq-quality-control.jsonl
+   ├── d2e4f6a8_protein-structure-prediction.jsonl
+   └── MEMORY.md
+
+Each line in the JSONL file is a JSON object representing one conversation turn (user
+message, assistant message, or tool call/result). The file is append-only during normal
+operation.
+
+The memory directory defaults to ``.pantheon/memory/`` relative to the workspace. Change
+it with ``--memory-dir``:
+
+.. code-block:: bash
+
+   pantheon cli --memory-dir ~/pantheon-sessions
+
+Listing Sessions
+----------------
+
+Use ``/list`` or its alias ``/chats`` to see all saved sessions:
+
+.. code-block:: text
+
+   > /list
+
+   ID        Name                          Date          Messages
+   ────────  ────────────────────────────  ────────────  ────────
+   8f3a2b1c  rna-seq-quality-control       2026-08-10    47
+   d2e4f6a8  protein-structure-prediction  2026-08-09    23
+   c1b9e7f2  variant-annotation-pipeline   2026-08-07    91
+
+Sessions are listed in reverse chronological order (most recent first). The most recent
+session is marked with an arrow indicator.
+
+Resuming a Session
+------------------
+
+There are three ways to resume a session:
+
+**Most recent session**
+
+.. code-block:: bash
+
+   # From the command line before starting
+   pantheon cli --resume last
+
+   # Or from inside the REPL
+   /resume last
+
+**By partial name**
+
+.. code-block:: bash
+
+   pantheon cli --resume rna-seq
+
+   # Matches the first session whose name contains "rna-seq" (case-insensitive)
+
+**By session ID**
+
+.. code-block:: bash
+
+   pantheon cli --resume 8f3a2b1c
+
+   # Exact ID match
+   /resume 8f3a2b1c
+
+After resuming, the full conversation history is displayed and you can continue from
+where you left off. The agent receives the complete prior context.
+
+Renaming a Session
+------------------
+
+Session names are currently set automatically from the first message. To rename a
+session, export it, delete the original, and reimport under a new name:
+
+.. code-block:: text
+
+   > /save my-rna-analysis.json
+   > /new
+   > /load my-rna-analysis.json
+
+The loaded session inherits the filename as its display name. This workflow also serves
+as a manual backup mechanism.
+
+Forking a Session
+-----------------
+
+To branch the conversation from a specific point:
+
+1. Export the conversation up to the desired point: ``/save branch-point.json``.
+2. Start a new session: ``/new``.
+3. Load the exported file: ``/load branch-point.json``.
+4. Continue from the branch point in a new direction.
+
+Both sessions (original and fork) are now independent and evolve separately.
+
+Exporting Sessions
+------------------
+
+.. code-block:: text
+
+   > /save
+   Saved to: 8f3a2b1c_rna-seq-quality-control.json
+
+   > /save /tmp/analysis-backup.json
+   Saved to: /tmp/analysis-backup.json
+
+The exported file is a JSON array of conversation turns. It can be shared with colleagues,
+imported on another machine, or used as input to a downstream script.
+
+Importing Sessions
+------------------
+
+.. code-block:: text
+
+   > /load /tmp/analysis-backup.json
+
+The conversation from the file is loaded into the current session. All prior turns
+are available in the agent's context. You can continue the conversation or use
+``/revert`` to go back to a specific earlier point.
+
+.. note::
+
+   Loading a file into a session that already has conversation history **appends** the
+   loaded turns after the existing history. If you want a clean import, start a new
+   session with ``/new`` first.
+
+Auto-Recovery
+-------------
+
+If Pantheon CLI exits unexpectedly mid-response (crash, OOM, SIGKILL), the partial
+response may not be written cleanly to the session file. On the next startup, Pantheon
+detects incomplete sessions and offers to recover:
+
+.. code-block:: text
+
+   ╭─ Recovery ─────────────────────────────────────────────╮
+   │ Session "rna-seq-quality-control" has an incomplete     │
+   │ last response. Recover and continue? [y/N]              │
+   ╰────────────────────────────────────────────────────────╯
+
+- **y** — the partial response is trimmed to the last complete sentence and the
+  session is resumed.
+- **N** — the session is loaded without the incomplete turn; you can re-send the
+  last message.
+
+Session Storage Format
+----------------------
+
+Each JSONL file stores turns sequentially. Each turn object contains:
+
+.. code-block:: json
+
+   {
+     "role": "user",
+     "content": "Explain the QC metrics in this plot",
+     "timestamp": "2026-08-10T14:32:01Z",
+     "attachments": [{"type": "file", "path": "figures/qc_violin.png"}]
+   }
+
+Tool calls and results are stored as additional turn objects with ``"role": "tool"``.
+MEMORY.md is a plain Markdown file written and read by the agent to persist facts across
+sessions.
+
+.. tip::
+
+   To inspect a session file directly, use any JSONL viewer or:
+
+   .. code-block:: bash
+
+      cat .pantheon/memory/8f3a2b1c_rna-seq-quality-control.jsonl | python -m json.tool

--- a/docs/source/interfaces/tutorials.rst
+++ b/docs/source/interfaces/tutorials.rst
@@ -1,0 +1,177 @@
+Web/Desktop App Tutorials
+=========================
+
+A curated collection of video tutorials covering the PantheonOS platform — from initial setup through advanced workflows.
+
+.. grid:: 1 2 2 2
+   :gutter: 4
+
+   .. grid-item-card:: PantheonOS Intro Tutorial: Features and Basic Capabilities
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/Wv7baDlnxCA"
+             title="PantheonOS Intro Tutorial: Features and Basic Capabilities"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 2a: The PantheonOS Online Platform
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/qqxctVj8_dY"
+             title="PantheonOS Tutorial 2a: The PantheonOS Online Platform"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 2b: Installing and Using the PantheonOS Desktop App
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/ahTDeJTyqkQ"
+             title="PantheonOS Tutorial 2b: Installing and Using the PantheonOS Desktop App"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 3a: Using Pantheon to Analyze Single-Cell Data
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/f2gNAFI213A"
+             title="PantheonOS Tutorial 3a: Using Pantheon to Analyze Single-Cell Data"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 3b: Using Pantheon for Image Analysis
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/S96qItfIamo"
+             title="PantheonOS Tutorial 3b: Using Pantheon for Image Analysis"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 3c: Using Pantheon for Structural Biology Analysis
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/yuB-npMfxBY"
+             title="PantheonOS Tutorial 3c: Using Pantheon for Structural Biology Analysis"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 4: Pantheon-Store and Customization
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/f4OC12ggUxY"
+             title="PantheonOS Tutorial 4: Pantheon-Store and Customization"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 5: Live-View
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/SiK0-ZUl3sA"
+             title="PantheonOS Tutorial 5: Live-View"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 6: Using Pantheon-Fleet to Control Multiple Computers
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/OkJFy5PY-2s"
+             title="PantheonOS Tutorial 6: Using Pantheon-Fleet to Control Multiple Computers"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>
+
+   .. grid-item-card:: PantheonOS Tutorial 7: Using Pantheon-Evolve For Evolution of Algorithms
+      :text-align: center
+      :class-card: tutorial-card
+
+      .. raw:: html
+
+         <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:8px;">
+           <iframe
+             src="https://www.youtube.com/embed/NujLYOMlOEQ"
+             title="PantheonOS Tutorial 7: Using Pantheon-Evolve For Evolution of Algorithms"
+             frameborder="0"
+             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+             allowfullscreen
+             style="position:absolute;top:0;left:0;width:100%;height:100%;">
+           </iframe>
+         </div>

--- a/docs/source/interfaces/tutorials.rst
+++ b/docs/source/interfaces/tutorials.rst
@@ -1,7 +1,7 @@
 Web/Desktop App Tutorials
 =========================
 
-A curated collection of video tutorials covering the PantheonOS platform — from initial setup through advanced workflows.
+A curated collection of video tutorials covering the PantheonOS Web/Desktop App — from initial setup through advanced workflows.
 
 .. grid:: 1 2 2 2
    :gutter: 4

--- a/docs/source/interfaces/ui/core-features.rst
+++ b/docs/source/interfaces/ui/core-features.rst
@@ -1,0 +1,163 @@
+Core Chat & Session Features
+============================
+
+This page covers the primary chat and session capabilities of the Pantheon web and desktop app.
+
+Chat Interface
+--------------
+
+The chat panel is the central surface for communicating with agents.
+
+**Sending messages**
+
+Type your message in the input box and press **Enter** to send. Responses stream token-by-token
+as the agent generates them; a blinking cursor indicates active generation.
+
+**Multi-agent attribution**
+
+When a team has more than one agent, each agent's name is displayed above its response in a
+distinct color. This makes it easy to follow which agent produced which output in long
+multi-turn conversations.
+
+**File and image attachments**
+
+Click the attachment icon (or drag and drop) to attach files to a message. Any text-readable
+file format is sent as context. Images are sent as vision input when the active model supports
+it. Multiple files can be attached to a single message.
+
+**Speech-to-text**
+
+Click the microphone icon in the input bar to record a voice message. Pantheon transcribes the
+audio using the configured speech-to-text model and inserts the transcript into the input box
+for review before sending.
+
+.. tip::
+
+   Speech-to-text requires a speech model to be configured in ``.pantheon/settings.json``.
+   See :doc:`/configuration/settings` for the ``speech_to_text_model`` option.
+
+Sessions
+--------
+
+Each conversation is stored as a named session that persists across restarts.
+
+**Create a new session**
+
+Click **New Chat** in the sidebar or use the ``/new`` slash command in the input bar. A new
+session starts immediately with a fresh conversation history.
+
+**Rename a session**
+
+Double-click the session name in the sidebar to rename it inline. Names are stored in the
+session metadata and appear in resume prompts.
+
+**Delete a session**
+
+Right-click a session in the sidebar and select **Delete**. Deletion is permanent — the
+conversation history is removed from the memory store.
+
+**Fork a session**
+
+Right-click a session and select **Fork**. A new session is created that starts from the
+same conversation history up to the current point. Both sessions evolve independently from
+that point forward.
+
+**Session persistence**
+
+Sessions are written to the memory directory (default: ``.pantheon/memory/``) after every
+turn. If the app or server restarts, sessions are automatically reloaded and available in
+the sidebar.
+
+**Resume a session**
+
+Click any session in the sidebar to open it and resume the conversation. The full history
+is displayed and you can continue from where you left off.
+
+Context Management
+------------------
+
+**Token usage display**
+
+The token counter in the input bar shows the approximate number of tokens in the current
+context window. The counter updates after each turn.
+
+**Context compression**
+
+When the conversation approaches the model's context limit, click **Compress** or type
+``/compress`` to trigger summarization. The agent condenses the earlier conversation into a
+compact summary, freeing context space while preserving key information.
+
+.. note::
+
+   Compression is destructive — the verbatim earlier turns are replaced by a summary.
+   The raw session file is preserved on disk so you can reload it if needed.
+
+**Revert to an earlier point**
+
+Hover over any user message in the chat and click **Revert here**. The conversation is
+truncated to that point and you can continue from a different direction. The reverted turns
+are not deleted from the session file — they are marked inactive so you can revert the
+revert if needed.
+
+Keyboard Shortcuts
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Key
+     - Action
+   * - **Enter**
+     - Send the current message
+   * - **Shift+Enter**
+     - Insert a newline (multi-line input)
+   * - **Esc**
+     - Cancel the currently streaming generation
+   * - **Ctrl+/** (or **Cmd+/**)
+     - Focus the input box from anywhere in the UI
+   * - **Up Arrow** (in empty input)
+     - Load the previous message you sent (edit and resend)
+   * - **Ctrl+K**
+     - Open the command palette / quick-switch
+   * - **Ctrl+Shift+N**
+     - Open a new chat session
+   * - **Ctrl+Shift+F**
+     - Search across all sessions
+
+Background Tasks
+----------------
+
+Some agent operations run asynchronously (file indexing, long-running analyses, batch jobs).
+These appear as **background tasks** rather than blocking the chat.
+
+**Task list panel**
+
+Click the **Tasks** icon in the sidebar to open the task list. Each task shows its name,
+the agent that started it, current status (queued / running / complete / error), and
+elapsed time.
+
+**Cancel a task**
+
+Click the **Cancel** button next to a running task. The agent receives a cancellation
+signal and stops at the next safe checkpoint.
+
+**Monitoring**
+
+Progress updates from background tasks appear as streaming status messages in the chat.
+When a task completes, a notification badge appears on the Tasks icon and a brief
+summary message is posted to the conversation.
+
+.. tip::
+
+   Use background tasks for operations that take more than a few seconds — for example,
+   running a full analysis pipeline while continuing to chat with a different agent.
+
+Theme & Display
+---------------
+
+Click the **Sun / Moon** icon in the top navigation bar to toggle between light and dark mode.
+The preference is saved in local browser storage and persists across sessions.
+
+The sidebar can be collapsed with the **←** button to give the chat panel more horizontal
+space. On narrow viewports the sidebar auto-collapses.

--- a/docs/source/interfaces/ui/fleet.rst
+++ b/docs/source/interfaces/ui/fleet.rst
@@ -1,0 +1,179 @@
+Pantheon Fleet (Web App)
+========================
+
+Pantheon Fleet allows you to connect and control multiple machines from a single UI session.
+The web app includes a Fleet panel for node management, remote command execution, and token
+lifecycle management.
+
+Overview
+--------
+
+Fleet is a distributed control layer built on the NATS messaging hub. Each machine that
+joins the fleet registers as a **node** and receives a unique identity. From the Fleet panel
+in the UI you can:
+
+- See all connected nodes and their status.
+- Run shell commands or Python snippets on any node.
+- Mint one-time join tokens for new machines.
+- Revoke access for a node that is no longer trusted.
+
+.. note::
+
+   Fleet requires the NATS hub to be running (``--auto-start-nats`` or an external NATS
+   cluster). All fleet traffic is routed through NATS — nodes do not need to be directly
+   network-accessible from the UI host.
+
+Starting a Local Fleet Node
+---------------------------
+
+To include the machine running the UI in the fleet, enable the fleet node alongside the
+backend. There are two ways:
+
+**Via settings**
+
+In **Settings → Fleet**, toggle **Enable local fleet node** on. The node starts
+automatically the next time you run ``pantheon ui``.
+
+**Via the fleet toolset**
+
+Include the ``FleetToolSet`` in your team template. When the backend starts, the fleet
+node is registered automatically:
+
+.. code-block:: bash
+
+   pantheon ui --auto-start-nats --auto-ui --template fleet_team
+
+The local node appears in the Fleet panel under the hostname of the current machine with
+status **Connected**.
+
+Joining the Fleet from Another Machine
+----------------------------------------
+
+Any machine that has ``pantheon-agents`` installed can join the fleet using a join token.
+
+**Mint a join token**
+
+In the Fleet panel, click **Mint Join Token**. A one-time token is generated and displayed.
+The token expires after 24 hours or first use, whichever comes first. Copy the token or
+use the QR code option to share it.
+
+**Join from the remote machine**
+
+On the remote machine, run:
+
+.. code-block:: bash
+
+   fleet join --token <token> --hub wss://your-nats-hub.example.com/nats
+
+Replace ``<token>`` with the token from the UI and the ``--hub`` URL with your NATS
+WebSocket endpoint. The remote machine connects to the hub, validates the token, and
+registers as a fleet node.
+
+After a few seconds the remote node appears in the Fleet panel with its hostname and
+system information.
+
+.. tip::
+
+   If the UI and remote machine are both on the same local network using
+   ``--auto-start-nats``, use ``ws://127.0.0.1:8080`` as the hub URL (accessible from
+   within the local network when the NATS server is configured to bind to all interfaces).
+
+Node List
+---------
+
+The Fleet panel displays a table of all connected nodes:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 20 20
+
+   * - Column
+     - Example
+     - Description
+     - -
+     - -
+   * - **Hostname**
+     - ``gpu-server-01``
+     - The machine's hostname
+     - -
+     - -
+   * - **OS**
+     - ``Linux x86_64``
+     - Operating system and architecture
+     - -
+     - -
+   * - **Label**
+     - ``GPU Server``
+     - Optional friendly label set at join time
+     - -
+     - -
+   * - **Status**
+     - ``Connected``
+     - Connection state (Connected / Disconnected / Error)
+     - -
+     - -
+   * - **Last Seen**
+     - ``2 seconds ago``
+     - Timestamp of the most recent heartbeat
+     - -
+     - -
+
+Click a row to expand it and see available actions for that node.
+
+Running Commands on Nodes
+--------------------------
+
+Select a node from the Fleet panel and use the command runner at the bottom of the node
+detail view.
+
+**Shell command**
+
+Enter a shell command (e.g., ``nvidia-smi``, ``df -h``, ``ps aux``) and click **Run**.
+Output streams back to the Fleet panel in real time. Commands time out after 60 seconds
+by default.
+
+**Python snippet**
+
+Switch to the **Python** tab, enter a Python snippet, and click **Run**. The snippet runs
+in a subprocess on the remote node using the system Python interpreter. ``stdout`` and
+``stderr`` are streamed back.
+
+.. note::
+
+   Commands run as the OS user that started the fleet agent on the remote machine.
+   Ensure that user has appropriate permissions for the operations you intend to perform.
+
+Revoking a Node
+---------------
+
+To disconnect a node and prevent it from reconnecting:
+
+1. Click the node's row in the Fleet panel.
+2. Click **Revoke**.
+3. Confirm the prompt.
+
+The node's token is invalidated on the hub. The node receives a disconnection message and
+cannot rejoin with the same token. A new token must be minted to re-add the machine.
+
+Fleet Down
+----------
+
+To stop the local fleet node (the node running on the same machine as the UI):
+
+Go to **Settings → Fleet** and click **Stop Local Node**, or toggle **Enable local fleet
+node** off.
+
+For remote nodes, stopping fleet requires running ``fleet down`` on the remote machine:
+
+.. code-block:: bash
+
+   fleet down
+
+This gracefully disconnects the node from the NATS hub.
+
+Further Reading
+---------------
+
+- For the full fleet toolset API (available to agents): :doc:`/toolsets/fleet`
+- For the fleet CLI and Go binary documentation: see ``docs/pantheon-fleet.md`` in the
+  repository.

--- a/docs/source/interfaces/ui/gateway.rst
+++ b/docs/source/interfaces/ui/gateway.rst
@@ -1,0 +1,130 @@
+Messaging Gateway
+=================
+
+The Pantheon Gateway connects your agents to external messaging platforms. Once configured,
+users can interact with your Pantheon agents through third-party channels — the same agents,
+same memory, same toolsets.
+
+Overview
+--------
+
+The gateway acts as a bridge between Pantheon's internal NATS messaging layer and external
+chat platforms. When a user sends a message on Discord or WeChat, the gateway receives it,
+routes it to the configured agent or team, waits for the response, and delivers the reply
+back on the originating platform.
+
+Each configured channel operates independently. Channels can target different agents or
+teams, and each channel maintains its own conversation routing. The same user's messages
+from different channels are correlated by their platform user ID and mapped into Pantheon's
+conversation memory.
+
+Supported Channels
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Platform
+     - Support
+   * - **Discord**
+     - Full message support including direct messages, server channels, and slash
+       commands. Bot token authentication. Markdown formatting is preserved in Discord's
+       rendering.
+   * - **WeChat**
+     - QR-code-based session login (WeChat personal accounts). Messages are routed to
+       the configured agent; responses are sent as WeChat text messages.
+   * - **Plugin**
+     - Additional platforms can be added via the gateway plugin interface. See
+       ``docs/gateway-plugins.md`` in the repository.
+
+Configuring a Channel
+---------------------
+
+Open the **Gateway** panel from the sidebar (the plug icon).
+
+1. Click **Add Channel**.
+2. Fill in the channel configuration form:
+
+   - **Platform** — select Discord, WeChat, or a plugin provider.
+   - **Channel name** — a friendly label for this connection (e.g., ``lab-discord-bot``).
+   - **Credentials / Token** — paste the bot token (Discord) or leave blank to trigger
+     QR login (WeChat).
+   - **Target agent or team** — select which agent or team handles messages from this
+     channel. If a team is selected, the team's routing logic determines which agent
+     responds.
+   - **Memory namespace** (optional) — by default, each platform user maps to their own
+     Pantheon memory namespace. Override this to share memory across channels.
+
+3. Click **Save**. The channel configuration is written to ``.pantheon/gateway.json``.
+
+4. Click **Start** to activate the channel.
+
+Starting & Stopping Channels
+-----------------------------
+
+Each configured channel has an on/off toggle in the Gateway panel.
+
+- **Start** — the gateway process connects to the external platform and begins routing
+  messages. A green indicator shows when the channel is connected.
+- **Stop** — the gateway disconnects cleanly. In-flight messages complete before the
+  connection closes.
+- **Status** — the status indicator shows: Connecting / Connected / Disconnected /
+  Error. Click the status badge to see a brief error message if the connection failed.
+
+**Recent logs**
+
+Click **Logs** on a channel row to tail the most recent gateway log entries for that
+channel. Logs show incoming messages, routing decisions, response delivery, and any
+errors.
+
+WeChat QR Login
+---------------
+
+WeChat uses a QR-code session login rather than a static API token.
+
+1. Add a WeChat channel and leave the token field blank.
+2. Click **Start**. The Gateway panel displays a scannable QR code.
+3. Open WeChat on your phone, go to **Discover → Scan**, and scan the code.
+4. The gateway logs confirm the session is authenticated (``WeChat session active``).
+5. The QR panel disappears and the channel shows **Connected**.
+
+The session token is persisted to disk and refreshed automatically. Scanning is
+required only once unless the session expires or is revoked on the WeChat side.
+
+.. note::
+
+   WeChat gateway uses personal account sessions, not the official WeChat Work or
+   official account APIs. Session stability depends on WeChat's platform behavior.
+
+Per-Channel Logs
+----------------
+
+Each channel maintains an in-memory rolling log of recent gateway events:
+
+- Incoming message received (platform user ID, message preview, timestamp)
+- Routing decision (target agent)
+- Response delivered (character count, delivery status)
+- Errors (API errors, timeouts, delivery failures)
+
+Access logs from the **Logs** button in the channel row. Use **Download** to save the
+full log to a file for debugging.
+
+Scoping
+-------
+
+Each channel maps to a specific agent or team. Messages arriving on that channel are
+processed exactly as if they arrived through the chat UI:
+
+- They enter the same conversation memory as other chat sessions (scoped by platform
+  user ID as the session namespace).
+- The agent has access to all its configured toolsets.
+- File attachments sent on Discord are downloaded and made available as context.
+- Responses are streamed back to the platform as they are generated (Discord shows a
+  typing indicator; WeChat delivers the complete response when generation finishes).
+
+.. tip::
+
+   To give a Discord bot access to files in your workspace, configure the target agent
+   with the ``FileEditorToolSet``. Discord users can then ask the bot to read or create
+   files and the agent will operate on the configured workspace.

--- a/docs/source/interfaces/ui/index.rst
+++ b/docs/source/interfaces/ui/index.rst
@@ -1,172 +1,138 @@
-Web UI (ChatRoom)
+Web / Desktop App
 =================
 
-The ChatRoom provides a web-based interface for interacting with Pantheon agents and teams.
+The Pantheon web and desktop app is the full graphical interface for PantheonOS. It provides every
+capability of the platform in a visual, multi-user environment accessible from a browser or the
+native desktop application.
 
-Overview
---------
+Feature Overview
+----------------
 
-ChatRoom is a service that exposes your agents through a web interface. It starts a local NATS messaging server and automatically opens the Pantheon UI in your browser.
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
 
-Quick Start
------------
+   * - Feature
+     - Description
+   * - **Chat Interface**
+     - Stream messages to one or more agents; colored agent names for multi-agent attribution;
+       file and image attachments; speech-to-text via microphone.
+   * - **Projects & Workspaces**
+     - Organize work into isolated projects, each with its own file workspace, memory store,
+       and running endpoint subprocess.
+   * - **Team Management**
+     - Browse and apply team templates; switch the active agent mid-conversation; configure
+       per-agent model overrides interactively.
+   * - **Model Selection**
+     - Full model browser with OpenRouter catalog (300+ models), local Ollama models, saved
+       favorites, and inline API-key management.
+   * - **Store & Skills**
+     - Install agent skills, team templates, and toolset configurations from the Pantheon Store
+       or load local skills from ``.pantheon/skills/``.
+   * - **Pantheon Fleet**
+     - Connect and control multiple machines from a single UI session; mint join tokens;
+       run commands on remote nodes.
+   * - **Live View**
+     - Open interactive in-browser visualizations (genome browsers, 3D structure viewers,
+       spatial maps, network graphs) alongside the chat — no external tool required.
+   * - **Integrated Terminal**
+     - Full PTY terminal backed by a real shell process on the server; output streams live;
+       sessions survive reconnects.
+   * - **Messaging Gateway**
+     - Connect agents to external messaging platforms (Discord, WeChat) so users can
+       interact through third-party channels.
+   * - **App Backends**
+     - Each project runs its own endpoint subprocess; attach to remote endpoints or switch
+       between multiple running backends from the UI.
+
+Starting the App
+----------------
 
 .. code-block:: bash
 
    pantheon ui --auto-start-nats --auto-ui
 
-This single command will:
-
-1. Start a local NATS server (for messaging between frontend and backend)
-2. Start the ChatRoom backend with your configured agents
-3. Automatically open the web UI in your browser and connect
-
-That's it — start chatting!
-
-Features
---------
-
-- **Visual Interface**: Clean, modern chat UI
-- **File Uploads**: Attach files to conversations
-- **Multi-User**: Multiple users can connect simultaneously
-- **Session Persistence**: Conversations are saved and can be resumed
-- **Team Support**: Use any team configuration
-- **Auto-Connect**: ``--auto-ui`` opens the browser with connection pre-configured
-- **WSL Friendly**: On WSL, ``--auto-ui`` attempts to launch your Windows default browser instead of relying on Linux desktop browser handlers
-
-Command Reference
------------------
-
-.. code-block:: bash
-
-   pantheon ui [OPTIONS]
-
-**Core Options:**
+This single command starts the full stack:
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 15 55
+   :widths: 30 70
 
-   * - Option
-     - Default
-     - Description
+   * - Flag
+     - Effect
    * - ``--auto-start-nats``
-     - ``False``
-     - Start a local NATS server automatically. Required for local usage.
+     - Starts a local NATS server (WebSocket on port 8080, TCP on 4222) that the
+       frontend and backend use to communicate. Required for local usage without an
+       external NATS cluster.
    * - ``--auto-ui``
-     - ``False``
-     - Open browser with auto-connect config. Requires ``--auto-start-nats``. Can optionally specify a custom frontend URL (e.g., ``--auto-ui "http://localhost:5173"``).
-   * - ``--template``
-     -
-     - Team template name from ``.pantheon/teams/``.
-   * - ``--nats-servers``
-     -
-     - NATS server URL(s). Supports WebSocket (``wss://``) and TCP (``nats://``). Multiple servers separated by ``|``.
-   * - ``--endpoint-mode``
-     - ``embedded``
-     - How to start the endpoint: ``embedded`` (same event loop) or ``process`` (subprocess).
+     - Opens the Pantheon web UI in your default browser with the connection URL
+       pre-configured so you can start chatting immediately. On WSL, Pantheon
+       attempts to launch the Windows default browser.
 
-**Advanced Options:**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 15 55
-
-   * - Option
-     - Default
-     - Description
-   * - ``--service-name``
-     - from settings
-     - Service name for the ChatRoom instance.
-   * - ``--memory-dir``
-     - from settings
-     - Directory to store conversation memory.
-   * - ``--workspace-path``
-     - from settings
-     - Workspace directory for the endpoint.
-   * - ``--log-level``
-     - ``INFO``
-     - Log level (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``).
-   * - ``--id-hash``
-     -
-     - Hash string for stable service ID (e.g., ``"alice"``). Generates UUID if not provided.
-   * - ``--endpoint-service-id``
-     -
-     - Connect to an existing remote endpoint instead of starting a new one.
-   * - ``--speech-to-text-model``
-     - from settings
-     - Model for speech-to-text transcription.
-
-**Examples:**
+Additional options:
 
 .. code-block:: bash
-
-   # Quick local start (recommended)
-   pantheon ui --auto-start-nats --auto-ui
 
    # Use a specific team template
    pantheon ui --auto-start-nats --auto-ui --template data_research_team
 
-   # Custom frontend URL (for local development)
-   pantheon ui --auto-start-nats --auto-ui "http://localhost:5173"
-
    # Connect to a remote NATS server
-   pantheon ui --nats-servers "wss://your-server.com/nats"
+   pantheon ui --nats-servers "wss://your-server.example.com/nats"
 
-   # Set a stable service ID
-   pantheon ui --auto-start-nats --auto-ui --id-hash alice
+   # Stable service ID (useful for reconnects from the same URL)
+   pantheon ui --auto-start-nats --auto-ui --id-hash mylab
 
-   # Debug mode
+   # Debug logging
    pantheon ui --auto-start-nats --auto-ui --log-level DEBUG
 
-Configuration
--------------
+See the full option reference in :doc:`quickstart`.
 
-ChatRoom reads configuration from ``.pantheon/``:
+Web vs Desktop
+--------------
 
-- ``settings.json`` - General settings
-- ``teams/*.md`` - Team templates
-- ``mcp.json`` - MCP server configuration
+The same backend powers both delivery modes:
 
-Architecture
-------------
+- **Web app** — open ``http://localhost:8080`` (or the URL shown in the terminal) in any
+  modern browser. Supports multiple simultaneous users connecting to the same backend.
+- **Desktop app** — a downloadable installer that embeds the same web UI in an Electron
+  shell. No separate browser session required. The desktop app connects to the same
+  local or remote backend using the standard NATS transport.
 
-.. code-block:: text
+There is no functional difference between the two; use whichever fits your workflow. The
+desktop app is convenient for single-user local setups; the web app is preferred for
+shared lab or team deployments.
 
-   ┌─────────────────┐     ┌─────────────────┐
-   │  Web Browser    │◀───▶│  NATS Server    │
-   │  (Pantheon UI)  │ WS  │  (local:8080)   │
-   └─────────────────┘     └────────┬────────┘
-                                    │ TCP
-                           ┌────────┴────────┐
-                           │  ChatRoom       │
-                           │  (Backend)      │
-                           └────────┬────────┘
-                                    │
-                           ┌────────┴────────┐
-                           ▼                 ▼
-                    ┌──────────┐      ┌──────────┐
-                    │  Agents  │      │ Toolsets │
-                    └──────────┘      └──────────┘
+.. note::
 
-With ``--auto-start-nats``, a local NATS server is started that provides:
-
-- **WebSocket** (``ws://127.0.0.1:8080``) for browser connections
-- **TCP** (``nats://localhost:4222``) for backend communication
-
-The ChatRoom backend connects to NATS and manages your agents, toolsets, and MCP servers.
+   The desktop installer is available from the PantheonOS releases page. On first launch it
+   prompts for a NATS server URL or can start one automatically.
 
 Next Steps
 ----------
 
-- :doc:`quickstart` - Step-by-step setup
-- :doc:`web-interface` - UI features
-- :doc:`advanced` - Programmatic usage and customization
+- :doc:`quickstart` — step-by-step first-use guide
+- :doc:`core-features` — chat, sessions, context management, and keyboard shortcuts
+- :doc:`projects` — organizing workspaces and per-project isolation
+- :doc:`teams-agents` — team templates and agent configuration
+- :doc:`models-providers` — model browser, OpenRouter, and Ollama
+- :doc:`store-skills` — installing skills and browsing the Pantheon Store
+- :doc:`fleet` — controlling multiple machines from the UI
+- :doc:`live-view` — interactive in-browser visualizations
+- :doc:`terminal` — integrated PTY terminal
+- :doc:`gateway` — connecting agents to Discord, WeChat, and other platforms
 
 .. toctree::
    :hidden:
    :maxdepth: 1
 
    quickstart
-   web-interface
+   core-features
+   projects
+   teams-agents
+   models-providers
+   store-skills
+   fleet
+   live-view
+   terminal
+   gateway
    advanced

--- a/docs/source/interfaces/ui/index.rst
+++ b/docs/source/interfaces/ui/index.rst
@@ -107,6 +107,17 @@ shared lab or team deployments.
    The desktop installer is available from the PantheonOS releases page. On first launch it
    prompts for a NATS server URL or can start one automatically.
 
+Video Tutorials
+---------------
+
+New to PantheonOS? The video tutorials below walk you through the web and desktop app entirely through the graphical interface — no command line required. They cover downloading and launching the desktop app, navigating the UI, running analyses, using the store, Fleet, Live View, and more.
+
+.. card:: Watch the Web/Desktop App Tutorials
+   :link: /interfaces/tutorials
+   :link-type: doc
+
+   Ten step-by-step video tutorials showing how to access and use PantheonOS through the web and desktop interface without relying on any terminal commands. Covers the online platform, the desktop app installer, single-cell analysis, image analysis, structural biology, the Store, Live View, Fleet, and the Evolution system.
+
 Next Steps
 ----------
 

--- a/docs/source/interfaces/ui/live-view.rst
+++ b/docs/source/interfaces/ui/live-view.rst
@@ -1,0 +1,145 @@
+Live View
+=========
+
+Live View lets agents open interactive, in-browser visualizations alongside the chat —
+genomics browsers, 3D structure viewers, spatial maps, network graphs, and more. No external
+tool or separate application is required.
+
+Overview
+--------
+
+When an agent calls the Live View API, a visualization panel opens in the UI next to the
+chat. The panel renders domain-specific viewers that update in real time as the agent
+provides data. Users can interact with the viewers (zoom, pan, select, query) while the
+conversation continues.
+
+Live View is designed for scientific and analytical workflows where visual inspection of
+data is an integral part of the analysis — not an afterthought that requires switching
+to a separate application.
+
+How It Works
+------------
+
+1. The agent receives a task that requires visualization (e.g., "show the coverage at this
+   locus").
+2. The agent calls ``open_live_view`` via the ``LiveViewToolSet``, specifying the viewer
+   type and data.
+3. The backend serializes the data and publishes it to the NATS hub.
+4. The UI receives the message and renders the appropriate viewer component in the Live
+   View side panel.
+5. Data updates stream in real time as the agent runs — for example, as sequences are
+   aligned or as a simulation progresses.
+
+The viewer remains open until the user closes it or the agent closes it programmatically.
+Multiple views can be open simultaneously in separate tabs within the Live View panel.
+
+Available Viewers
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 25 55
+
+   * - Viewer
+     - Type tag
+     - Description
+   * - **IGV**
+     - ``igv``
+     - Integrative Genomics Viewer — genome browser with track support for BAM, VCF,
+       BED, BigWig, and GFF formats.
+   * - **Vitessce**
+     - ``vitessce``
+     - Single-cell spatial data explorer supporting AnnData/Zarr datasets, UMAP
+       embeddings, spatial coordinates, and image layers.
+   * - **Viv**
+     - ``viv``
+     - High-resolution microscopy image viewer supporting OME-TIFF and OME-Zarr
+       formats with multi-channel rendering and z-stack navigation.
+   * - **Mol***
+     - ``molstar``
+     - 3D molecular structure viewer supporting PDB, mmCIF, SDF, and MOL2 formats.
+       Full rotation, selection, and measurement tools.
+   * - **Gosling**
+     - ``gosling``
+     - Scalable genomics visualization grammar for tracks, circular layouts, and
+       linked multi-track displays.
+   * - **Cytoscape**
+     - ``cytoscape``
+     - Network and graph viewer for biological networks, interaction graphs, and
+       pathway maps.
+   * - **MSA**
+     - ``msa``
+     - Multiple sequence alignment viewer with color schemes for nucleotide and amino
+       acid conservation.
+   * - **Phylotree**
+     - ``phylotree``
+     - Phylogenetic tree renderer supporting Newick and Nexus formats with node
+       annotation and clade highlighting.
+   * - **RDKit**
+     - ``rdkit``
+     - Chemical structure viewer for small molecules using RDKit SMILES and SDF
+       rendering.
+   * - **Spatial3D**
+     - ``spatial3d``
+     - 3D spatial transcriptomics viewer for point clouds with cell-type color
+       mapping.
+   * - **Volume3D**
+     - ``volume3d``
+     - Volumetric rendering for 3D microscopy datasets and medical imaging volumes
+       (NIfTI, HDF5).
+
+Opening a Live View Manually
+-----------------------------
+
+The Live View panel is available in the UI even without an agent actively pushing data.
+
+1. Click the **Live View** icon in the sidebar (the waveform icon).
+2. The panel opens showing any active views.
+3. Use **+ New View** to open a viewer manually by selecting the type and optionally
+   providing a data file from the workspace.
+4. To close a view, click the **×** on its tab.
+5. To refresh a view (e.g., if data on disk has changed), click the **↻** button on the
+   tab.
+
+Live View in Agent Workflows
+-----------------------------
+
+Agents use the ``LiveViewToolSet`` to open and update views programmatically.
+
+.. code-block:: python
+
+   from pantheon.toolsets.live_view import LiveViewToolSet
+
+   toolset = LiveViewToolSet()
+
+   # Open an IGV genome browser at a specific locus
+   await toolset.open_live_view(
+       view_type="igv",
+       view_id="coverage_track",
+       data={
+           "genome": "hg38",
+           "locus": "chr7:117,120,016-117,308,718",
+           "tracks": [
+               {"type": "bam", "url": "s3://my-bucket/sample.bam"},
+               {"type": "vcf", "url": "s3://my-bucket/variants.vcf.gz"},
+           ],
+       },
+   )
+
+   # Update the view with new data (the panel refreshes in place)
+   await toolset.update_live_view(
+       view_id="coverage_track",
+       data={"locus": "chr7:117,500,000-117,600,000"},
+   )
+
+   # Close a view when analysis is complete
+   await toolset.close_live_view(view_id="coverage_track")
+
+.. note::
+
+   Live View data is transferred over NATS. Very large data files (>100 MB) should be
+   served from a URL (HTTP, S3, GCS) rather than inlined in the tool call payload.
+   Viewer components that support URL-based data (IGV, Viv, Vitessce) fetch data
+   directly from the source.
+
+See also: :doc:`/toolsets/live_view` for the complete ``LiveViewToolSet`` API reference.

--- a/docs/source/interfaces/ui/models-providers.rst
+++ b/docs/source/interfaces/ui/models-providers.rst
@@ -1,0 +1,177 @@
+Models & Providers
+==================
+
+The web app provides a full model browser and provider management panel. You can search,
+filter, and switch models without restarting the backend, and manage API keys directly from
+the settings panel.
+
+Overview
+--------
+
+Pantheon supports multiple model sources:
+
+- **OpenRouter** — a unified API aggregating 300+ models from dozens of providers.
+- **Ollama** — locally hosted models running on your machine or a local server.
+- **Direct providers** — OpenAI, Anthropic, Google, Mistral, and others via their native
+  APIs, configured with provider API keys.
+- **OAuth providers** — providers such as Codex that require browser-based authentication.
+
+All of these are accessible from the same model browser in the UI.
+
+Browsing & Selecting Models
+----------------------------
+
+Open the model browser by clicking the model tag in the input bar or in the **Agents**
+panel next to any agent.
+
+**Search and filter**
+
+Type in the search box to filter by model name, provider, or capability tag
+(e.g., ``vision``, ``coding``, ``128k``). The list updates in real time.
+
+**OpenRouter catalog**
+
+Models sourced from OpenRouter are marked with the OpenRouter badge. Each entry shows:
+
+- Provider and model name (e.g., ``anthropic/claude-opus-4-5``)
+- Context window size
+- Input and output cost per million tokens
+- Capability tags (vision, tool-use, JSON mode, etc.)
+
+**Local Ollama models**
+
+Ollama models are listed under the **Local** section. They show the model name and size on
+disk. If Ollama is not running, the section displays a warning with a link to the Ollama
+status panel.
+
+**Saved / favorite models**
+
+Click the star icon next to any model to add it to your **Favorites** list. Favorites
+appear at the top of the model browser for quick access.
+
+**Selecting a model**
+
+Click a model row to select it. The model is applied to the active agent immediately. The
+model tag in the input bar updates to reflect the new selection.
+
+OpenRouter Integration
+-----------------------
+
+OpenRouter provides a single API key that gives access to models from Anthropic, OpenAI,
+Google, Mistral, Meta, and many other providers.
+
+**Setting the OpenRouter API key**
+
+Go to **Settings → API Keys** and enter your OpenRouter key in the **OpenRouter** field.
+The key is stored in ``.pantheon/settings.json`` (or the system keychain, depending on
+your OS) and used for all OpenRouter-sourced models.
+
+**Automatic catalog**
+
+When an OpenRouter key is configured, Pantheon fetches the live model catalog from the
+OpenRouter API and displays it in the browser. The catalog includes pricing, context
+window, and capability information that is kept current.
+
+**Usage and billing**
+
+OpenRouter usage appears on your OpenRouter dashboard. Pantheon does not aggregate or
+modify OpenRouter billing — costs are passed through directly at the rates published in
+the catalog.
+
+Ollama
+------
+
+Ollama runs open-weight models locally, with no API key required.
+
+**Checking Ollama status**
+
+The model browser's **Local** section shows a green or red indicator for the Ollama
+service. Click **Ollama Status** to open a detail panel showing the Ollama version,
+running models, and the URL Pantheon is configured to use (default:
+``http://localhost:11434``).
+
+**Pulling and selecting Ollama models**
+
+If a model is not yet downloaded, click **Pull** next to its name. The download progress
+is shown in real time. Once the download is complete, the model appears as available and
+can be selected.
+
+**Configuring the Ollama URL**
+
+If Ollama is running on a different host (e.g., a GPU server), update the URL in
+**Settings → Providers → Ollama URL**. Pantheon will connect to that host for all Ollama
+model operations.
+
+OAuth Providers
+---------------
+
+Some providers (such as Codex) use browser-based OAuth rather than a static API key.
+
+**Authenticating**
+
+Go to **Settings → Providers** and click **Connect** next to the provider. A new browser
+tab opens with the provider's OAuth login page. After you authorize, the tab closes and
+Pantheon stores the token.
+
+**Token refresh**
+
+Pantheon automatically refreshes OAuth tokens before they expire. If a token expires
+unexpectedly (e.g., due to a revocation), the **Connect** button reappears in the
+settings panel. Re-authenticate without restarting the backend.
+
+API Key Management
+------------------
+
+API keys for all providers can be entered and updated from **Settings → API Keys**. Keys
+are stored encrypted in ``.pantheon/settings.json`` and never logged.
+
+Supported providers:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Provider
+     - Key setting
+   * - OpenRouter
+     - ``OPENROUTER_API_KEY``
+   * - OpenAI
+     - ``OPENAI_API_KEY``
+   * - Anthropic
+     - ``ANTHROPIC_API_KEY``
+   * - Google (Gemini)
+     - ``GOOGLE_API_KEY``
+   * - Mistral
+     - ``MISTRAL_API_KEY``
+   * - Together AI
+     - ``TOGETHER_API_KEY``
+   * - Groq
+     - ``GROQ_API_KEY``
+
+Key changes take effect immediately for new requests — a backend restart is not required.
+
+Model Fallback Chains
+---------------------
+
+You can configure a primary model and one or more fallbacks per agent. If the primary model
+returns an error (rate limit, context overflow, etc.), Pantheon automatically retries with
+the next model in the chain.
+
+Fallback chains are configured in ``.pantheon/settings.json``:
+
+.. code-block:: json
+
+   {
+     "model_fallback_chains": {
+       "Analyst": [
+         "anthropic/claude-opus-4-5",
+         "openai/gpt-4o",
+         "openrouter/mistralai/mistral-large"
+       ]
+     }
+   }
+
+The UI displays the active model for each agent and indicates when a fallback is being
+used.
+
+See :doc:`/configuration/models` for the full model configuration reference.

--- a/docs/source/interfaces/ui/projects.rst
+++ b/docs/source/interfaces/ui/projects.rst
@@ -1,0 +1,138 @@
+Projects & Workspaces
+=====================
+
+Projects let you organize separate workspaces — each project has its own file workspace,
+memory store, and endpoint subprocess. Switching projects is like switching between completely
+independent Pantheon environments without restarting the application.
+
+Overview
+--------
+
+A project in Pantheon is a named container that ties together:
+
+- A **workspace directory** — the root path on disk that agents read and write files under.
+- An **isolated memory store** — conversation history and MEMORY.md files scoped to this
+  project only.
+- A **dedicated endpoint** — a separate backend subprocess (or embedded event loop) that
+  serves the project's agents, so different projects can run different team configurations
+  simultaneously.
+
+Projects are especially useful when you work across multiple distinct codebases, datasets,
+or research contexts and want clean separation between them.
+
+Creating and Switching Projects
+--------------------------------
+
+**Register a new project**
+
+Open **Settings → Projects** in the sidebar and click **Add Project**. Provide:
+
+- **Name** — a short label shown in the project switcher (e.g., ``genomics-lab``).
+- **Workspace path** — the absolute path to the directory this project works in
+  (e.g., ``/home/user/projects/rna-seq-pipeline``).
+- **Team template** (optional) — a default team to activate when this project is opened.
+
+.. code-block:: bash
+
+   # Equivalent CLI registration
+   pantheon project add --name genomics-lab --workspace /home/user/projects/rna-seq-pipeline
+
+**Switch the active project**
+
+Click the project name in the top-left project switcher dropdown. Pantheon stops the
+current project's endpoint, saves its state, and starts the selected project's endpoint.
+The conversation sidebar refreshes to show sessions for the selected project.
+
+**Remove a project**
+
+In **Settings → Projects**, click the trash icon next to a project. Removing a project
+unregisters it from the UI — it does not delete the workspace directory or the memory files
+on disk.
+
+Per-Project Isolation
+---------------------
+
+Each project maintains complete isolation across three dimensions:
+
+**Endpoint isolation**
+
+Each project runs its own endpoint subprocess. The endpoint loads the team template and
+toolsets configured for that project. Two projects can run different teams (e.g., one with
+a single-agent coding assistant, another with a multi-agent bioinformatics pipeline)
+without interfering.
+
+**Memory isolation**
+
+Conversation history, retrieved context, and MEMORY.md files are stored under the project's
+memory subdirectory. Sessions from project A are never visible to project B, even if both
+use the same model.
+
+**File access isolation**
+
+When workspace mode is enabled (see below), agents are restricted to the project's
+workspace directory. An agent in project A cannot read or write files from project B's
+workspace.
+
+Workspace Mode
+--------------
+
+Workspace mode is a per-chat setting that restricts agent file access to the project's
+workspace root. When enabled:
+
+- All relative file paths the agent constructs resolve within the workspace root.
+- Attempts to access paths outside the workspace root are blocked by the file toolset.
+- The workspace root is shown in the chat header so you always know which directory the
+  agent is operating in.
+
+Toggle workspace mode from the **...** menu in the chat header or configure it as the
+default in ``.pantheon/settings.json``:
+
+.. code-block:: json
+
+   {
+     "workspace": {
+       "restrict_to_workspace": true
+     }
+   }
+
+.. note::
+
+   Workspace mode is a soft guardrail — it governs tool-level file access, not OS-level
+   permissions. Agents that construct and execute shell commands directly can still access
+   files outside the workspace if the OS user has permission.
+
+Memory Routing
+--------------
+
+Each project has its own conversation memory that persists independently from other projects.
+
+**Per-project MEMORY.md**
+
+Pantheon maintains a ``MEMORY.md`` file in each project's memory directory. This file
+accumulates facts the agent has been asked to remember across sessions — for example,
+preferred coding style, dataset locations, or recurring collaborator names. The agent
+reads this file at the start of each session within the project.
+
+**Memory directory layout**
+
+.. code-block:: text
+
+   .pantheon/memory/
+   ├── genomics-lab/
+   │   ├── MEMORY.md
+   │   ├── session_abc123.jsonl
+   │   └── session_def456.jsonl
+   └── coding-assistant/
+       ├── MEMORY.md
+       └── session_xyz789.jsonl
+
+**Clearing project memory**
+
+In **Settings → Projects**, click **Clear Memory** next to a project to delete its session
+files and reset MEMORY.md. This does not affect the workspace directory.
+
+.. tip::
+
+   If you want a project's agent to start each session with project-specific context
+   (data paths, background papers, lab conventions), add that context to the project's
+   MEMORY.md directly — it will be included in every new session automatically.

--- a/docs/source/interfaces/ui/store-skills.rst
+++ b/docs/source/interfaces/ui/store-skills.rst
@@ -1,0 +1,164 @@
+Store & Skills
+==============
+
+The Pantheon Store is a package registry for agent skills, team templates, and toolset
+configurations. Install published packages from the store or load local skills defined in
+your workspace.
+
+Overview
+--------
+
+Skills are modular bundles that extend what agents can do — they can add domain-specific
+knowledge, pre-built prompt templates, specialized tool configurations, or entire team
+setups. The store makes it easy to share and reuse these bundles across projects and
+installations.
+
+Three sources of skills are available:
+
+- **Pantheon Store** — published packages with versioning, ratings, and metadata.
+- **Local skills** — files in ``.pantheon/skills/`` loaded automatically.
+- **Factory templates** — the built-in templates shipped with Pantheon and updated via
+  ``pantheon update-templates``.
+
+Browsing the Store
+------------------
+
+Open the **Store** panel from the sidebar (the shopping bag icon).
+
+- **Search** — type keywords in the search bar to filter packages by name or description.
+- **Categories** — click a category tab (e.g., *Omics*, *Bioimaging*) to filter by domain.
+- **Package details** — click a package card to open the detail view, which shows the
+  author, version history, a description of what the package provides (skills, templates,
+  toolsets), and the source repository URL.
+- **Ratings** — community ratings are shown as a star score averaged over user installs.
+
+Installing & Uninstalling Packages
+-----------------------------------
+
+**Install**
+
+Click **Install** on a package card or in the detail view. Pantheon downloads the package
+and writes its contents into the current ``.pantheon/`` workspace:
+
+.. code-block:: text
+
+   .pantheon/
+   ├── skills/        ← skill YAML files from the package
+   ├── teams/         ← team template files from the package
+   └── toolsets/      ← toolset config files from the package
+
+After install, click **Reload Settings** (or it reloads automatically) to make the new
+skills available to agents in the current session.
+
+**Uninstall**
+
+Open the **Installed** tab in the Store panel. Click **Uninstall** next to a package.
+Pantheon removes the files the package placed in ``.pantheon/`` and reloads settings.
+
+.. note::
+
+   Uninstalling a package only removes the files it originally installed. If you manually
+   edited those files, your edits may have been overwritten on the last update. Back up
+   custom changes before upgrading a package.
+
+Local Skills
+------------
+
+Skills defined in ``.pantheon/skills/`` are automatically loaded at startup and after a
+settings reload. No store interaction is required.
+
+A local skill file is a YAML document that defines prompts, tool configurations, or
+knowledge context available to agents. Example:
+
+.. code-block:: yaml
+
+   name: rna_seq_helper
+   description: Provides RNA-seq analysis guidance and tool configurations
+   system_prompt_extension: |
+     You are an expert in bulk and single-cell RNA sequencing analysis.
+     Preferred pipeline: Salmon → DESeq2 for bulk; Scanpy for single-cell.
+   toolsets:
+     - python_interpreter
+     - r_interpreter
+
+Place this file at ``.pantheon/skills/rna_seq_helper.yaml`` and reload settings to
+activate it.
+
+Skill Categories
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Category
+     - Description
+   * - **Omics**
+     - RNA-seq, scRNA-seq, proteomics, multi-omics integration pipelines and analysis
+       skills.
+   * - **Live View**
+     - Skills that configure and launch Live View viewers (IGV, Vitessce, Mol*, etc.)
+       from agent responses.
+   * - **Paper Writing**
+     - Literature review, abstract drafting, citation management, and figure description
+       skills.
+   * - **Bioimaging**
+     - Microscopy image analysis, segmentation, and visualization using Viv and related
+       tools.
+   * - **Structural Biology**
+     - Protein structure prediction (AlphaFold, ESMFold), docking analysis, and 3D
+       visualization via Mol*.
+   * - **Rare Disease**
+     - Clinical variant interpretation, HPO ontology integration, and gene-disease
+       association skills.
+   * - **Genomics**
+     - Variant calling, genome assembly, annotation, and GWAS skills.
+   * - **Coding Assistant**
+     - Code review, test generation, documentation, and refactoring templates for
+       multiple languages.
+   * - **Data Science**
+     - EDA templates, plotting, statistical testing, and machine learning pipeline skills.
+
+CLI Equivalent
+--------------
+
+All store operations available in the UI can also be performed from the command line:
+
+.. code-block:: bash
+
+   # List available packages
+   pantheon store list
+
+   # Search for a package
+   pantheon store search rna-seq
+
+   # Install a package
+   pantheon store install pantheon-omics-skills
+
+   # Uninstall a package
+   pantheon store remove pantheon-omics-skills
+
+   # Show installed packages
+   pantheon store installed
+
+Factory Templates
+-----------------
+
+Factory templates are the built-in agent, team, and skill templates that ship with
+Pantheon. They live inside the Pantheon package, not in your ``.pantheon/`` workspace.
+
+Keep them up to date with:
+
+.. code-block:: bash
+
+   pantheon update-templates
+
+This command downloads the latest versions of all built-in templates from the Pantheon
+release channel. Run it after upgrading the ``pantheon-agents`` package to pick up new
+or improved templates.
+
+.. tip::
+
+   If you have customized a built-in template by copying it into ``.pantheon/teams/``,
+   your copy takes precedence over the factory default. Running ``update-templates`` does
+   not overwrite files in your ``.pantheon/`` workspace.

--- a/docs/source/interfaces/ui/teams-agents.rst
+++ b/docs/source/interfaces/ui/teams-agents.rst
@@ -1,0 +1,165 @@
+Teams & Agents
+==============
+
+The UI exposes full team configuration — you can choose templates, switch the active agent
+mid-conversation, and manage agent models interactively without editing files or restarting
+the backend.
+
+Overview
+--------
+
+A **team** is a named collection of agents with defined roles, toolsets, and coordination
+logic. The UI makes it easy to:
+
+- Switch between team templates with a dropdown.
+- See which agents are active and what each one can do.
+- Change the active agent without ending the conversation.
+- Override the model for a specific agent on the fly.
+- Create and edit team templates directly in the browser.
+
+Selecting a Team Template
+--------------------------
+
+The **Team** dropdown in the top navigation bar shows the currently active template. Click
+it to open the template browser.
+
+**Built-in templates**
+
+Pantheon ships with a set of built-in templates covering common workflows:
+
+- ``default`` — single general-purpose agent
+- ``data_research_team`` — analyst + coder + critic
+- ``single_cell`` — scRNA-seq analysis pipeline
+- ``paper_writing`` — writer + editor + literature reviewer
+- ``structural_biology`` — structure prediction + analysis
+- ``coding_assistant`` — multi-agent code review and generation
+
+**Custom templates**
+
+Custom templates stored in ``.pantheon/teams/`` appear automatically in the dropdown.
+Template files are Markdown documents with a structured YAML front matter block. See
+:doc:`/configuration/templates/teams` for the format.
+
+.. code-block:: text
+
+   .pantheon/
+   └── teams/
+       ├── my_custom_team.md
+       └── omics_pipeline.md
+
+Switching the Active Agent
+---------------------------
+
+In a multi-agent conversation, only one agent is **active** at a time — subsequent messages
+are routed to the active agent unless the team's coordination logic overrides this.
+
+**Click an agent name**
+
+Click any agent's colored name label above its response in the chat to switch the active
+agent to that one. A brief confirmation indicator appears in the input bar.
+
+**Agent switcher panel**
+
+Open the **Agents** panel from the sidebar to see all agents in the team. Click an agent's
+row to make it active.
+
+**Slash command**
+
+In the chat input, type ``/agent <name>`` or ``/agent <number>`` (using the agent's
+position in the list) to switch programmatically.
+
+.. note::
+
+   Switching the active agent mid-conversation does not clear the conversation history.
+   The new agent receives the same context window as the previous one, so it can reference
+   earlier turns.
+
+Per-Agent Model Override
+-------------------------
+
+You can assign a different model to a specific agent without changing the team template
+file. This is useful for testing a higher-capability model on a critical agent while
+keeping cheaper models for routine tasks.
+
+**From the Agents panel**
+
+Open the **Agents** panel, click the model tag next to an agent's name, and select a
+new model from the browser. The override is applied immediately for the next response.
+
+**Persistence**
+
+Per-agent model overrides are saved to ``.pantheon/settings.json`` under
+``agent_model_overrides`` so they persist across restarts:
+
+.. code-block:: json
+
+   {
+     "agent_model_overrides": {
+       "Analyst": "openai/gpt-4o",
+       "Coder": "anthropic/claude-opus-4-5"
+     }
+   }
+
+To clear an override and return to the template default, click **Reset to default** in the
+model selector for that agent.
+
+Creating & Editing Templates
+-----------------------------
+
+The inline template editor lets you create or modify team templates without leaving the
+browser.
+
+**Open the editor**
+
+Click **Edit Template** in the Team dropdown, or click **New Template** to start from
+scratch. The editor opens as a split panel alongside the chat.
+
+**Template format**
+
+Templates use Markdown with YAML front matter. The editor provides syntax highlighting and
+a live validation panel that shows errors as you type.
+
+**Save and reload**
+
+Click **Save** to write the template to ``.pantheon/teams/<name>.md``. The team is
+reloaded immediately — the current conversation is preserved but the agent configuration
+is updated.
+
+**Validation**
+
+The editor validates the template on save and reports:
+
+- Unknown fields in the YAML front matter
+- Agent names that conflict with built-in reserved names
+- Missing required fields (``agents``, ``name``)
+
+Listing Agents
+--------------
+
+Open the **Agents** panel from the sidebar to see all agents in the current team:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 50
+
+   * - Column
+     - Example
+     - Description
+   * - **Name**
+     - ``Analyst``
+     - The agent's display name as defined in the template
+   * - **Role**
+     - ``Primary``
+     - Role in the team (Primary, Subagent, Critic, etc.)
+   * - **Model**
+     - ``claude-opus-4-5``
+     - Currently active model (template default or override)
+   * - **Toolsets**
+     - ``Shell, Python, RAG``
+     - Toolsets available to this agent
+   * - **Status**
+     - ``Idle``
+     - Current agent state (Idle / Generating / Waiting)
+
+Click any row to switch the active agent or expand the row to see the agent's full system
+prompt.

--- a/docs/source/interfaces/ui/terminal.rst
+++ b/docs/source/interfaces/ui/terminal.rst
@@ -1,0 +1,120 @@
+Integrated Terminal (PTY)
+=========================
+
+The web and desktop app includes a full integrated terminal. The terminal is backed by a
+real PTY process on the server and streams output live to your browser. You get the same
+experience as a local terminal, with no SSH required.
+
+Overview
+--------
+
+The integrated terminal is a genuine interactive shell — not a command runner that
+collects output and displays it after the fact. Input and output stream bidirectionally
+in real time. This makes it suitable for interactive programs (``vim``, ``python``,
+``htop``, ``ipython``) as well as long-running processes where you need to watch output
+as it arrives.
+
+The terminal runs on the server-side process, so it has full access to the server's
+filesystem and environment. On remote deployments, this means you get a shell on the
+remote machine without setting up SSH.
+
+Opening a Terminal
+------------------
+
+Click the **Terminal** icon in the sidebar (the ``>_`` icon). A new PTY session starts
+in the agent's current workspace directory. The terminal panel opens at the bottom of the
+UI (or in a split panel, depending on your layout setting).
+
+You can resize the terminal panel by dragging its top edge, or detach it into a floating
+window with the **Pop out** button.
+
+Terminal Sessions
+-----------------
+
+**Multiple sessions**
+
+Click the **+** button in the terminal tab bar to open additional terminal sessions.
+Each session is an independent PTY process. Switch between sessions by clicking their
+tabs. Sessions are labeled ``Terminal 1``, ``Terminal 2``, etc., and can be renamed by
+double-clicking the tab.
+
+**Persistence across reconnects**
+
+PTY sessions survive browser reconnects. When you reload the page or reattach to the
+backend after a network interruption, the terminal replays the scrollback buffer (up to
+the configured buffer size, default 10,000 lines) so you can see what happened while you
+were disconnected. The process on the server continues running during disconnects.
+
+**Idle session cleanup**
+
+Sessions that have been idle (no input or output) for longer than the configured idle
+timeout (default: 4 hours) are automatically cleaned up to free resources. The session
+tab greys out with an **Ended** badge if the session has been cleaned up. Click **Reopen**
+to start a new session in the same working directory.
+
+Shell Selection
+---------------
+
+The terminal starts the default login shell of the server OS user (determined by
+``/etc/passwd`` or the ``SHELL`` environment variable). To specify a different shell, set
+the default in **Settings → Terminal**:
+
+.. code-block:: json
+
+   {
+     "terminal": {
+       "default_shell": "/bin/zsh"
+     }
+   }
+
+When opening a terminal programmatically (e.g., from an agent or via the PTY API), the
+shell can be overridden per session.
+
+Resize Handling
+---------------
+
+The terminal component sends resize events to the PTY process whenever the panel changes
+dimensions. ``SIGWINCH`` is propagated to the running shell and any child processes. This
+means ``vim``, ``less``, ``htop``, and other terminal-aware programs reflow correctly
+when you resize the panel.
+
+The column and row counts are shown in the bottom-right corner of the terminal panel and
+update in real time.
+
+Terminal vs Shell Toolset
+--------------------------
+
+The integrated terminal and the ``ShellToolSet`` serve different purposes:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Aspect
+     - Integrated Terminal
+     - ShellToolSet
+   * - **Interaction model**
+     - Interactive, persistent PTY session
+     - Discrete commands with captured output
+   * - **Persistence**
+     - Session persists; shell state carries over between commands
+     - Each tool call spawns a subprocess; state is not retained between calls
+   * - **Use case**
+     - Interactive programs, long-running processes, manual work
+     - Agent-controlled command execution within workflows
+   * - **Who drives it**
+     - Human user
+     - Agent (LLM)
+   * - **Output handling**
+     - Streamed to the UI panel live
+     - Returned as text in the tool result for the agent to read
+
+For agent workflows, always use the ``ShellToolSet`` — it gives the agent clean,
+capturable output. Use the terminal for interactive manual tasks, environment debugging,
+or situations where you need a persistent shell state.
+
+.. tip::
+
+   You can use the terminal and the agent side by side. For example: run a long build in
+   the terminal and ask the agent to monitor a log file or help you interpret error output
+   that you paste into the chat.

--- a/docs/source/toolsets/fleet.rst
+++ b/docs/source/toolsets/fleet.rst
@@ -1,0 +1,178 @@
+Pantheon Fleet Toolset
+======================
+
+The ``FleetToolSet`` gives agents the ability to observe and control a cluster of machines registered on the same Pantheon Fleet hub. Agents can list nodes, run code or shell commands on remote nodes, transfer files, and receive results — all without leaving a conversation.
+
+Overview
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Capability
+     - Description
+   * - **Observe**
+     - List nodes, query node info and labels, check fleet status
+   * - **Execute**
+     - Run shell commands or Python snippets on any node or label group
+   * - **Transfer**
+     - Send or gather files across nodes with resume, compression, and integrity checks
+   * - **Broadcast**
+     - Fan-out a command to all matching nodes simultaneously
+
+Quick Start
+-----------
+
+.. code-block:: python
+
+   from pantheon.agent import Agent
+   from pantheon.toolsets.fleet import FleetToolSet
+
+   fleet = FleetToolSet(
+       name="fleet",
+       nats_url="nats://localhost:4222",   # hub NATS address
+   )
+
+   agent = Agent(
+       name="cluster_manager",
+       instructions="You manage a compute cluster."
+   )
+   await agent.toolset(fleet)
+   await agent.chat()
+
+The ``nats_url`` can also be set in ``.pantheon/settings.json`` under ``fleet.nats_url``.
+
+Tool Reference
+--------------
+
+Observe
+~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tool
+     - Description
+   * - ``fleet_list_nodes``
+     - Return all connected nodes with hostname, OS, labels, and last-seen time.
+   * - ``fleet_node_info``
+     - Detailed information about a specific node: capabilities, labels, resource tags.
+   * - ``fleet_status``
+     - High-level cluster health: number of nodes, unreachable nodes, hub latency.
+   * - ``fleet_pick_node``
+     - Select the best node matching given criteria (OS, label, resource availability).
+
+Execute
+~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tool
+     - Description
+   * - ``run_on_node``
+     - Run a shell command or Python snippet on a specific node. Streams stdout/stderr back. OS-aware (Windows vs Unix path handling).
+   * - ``run_on_label``
+     - Fan-out a command to all nodes that match a label. Returns per-node results.
+
+Transfer
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tool
+     - Description
+   * - ``transfer``
+     - Send a file to a remote node. Supports SHA-256 integrity check, zstd compression, and resume from partial transfer.
+   * - ``broadcast``
+     - Send a file to all matching nodes simultaneously.
+   * - ``gather``
+     - Retrieve a file from a remote node back to the hub machine.
+   * - ``transfer_status``
+     - Check the progress of an in-flight or completed transfer.
+
+Usage Examples
+--------------
+
+List all nodes
+~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   User: Show me all nodes in the fleet.
+   Agent: [calls fleet_list_nodes]
+   → node-01  Linux  labels: [gpu, research]  last seen: 2s ago
+   → node-02  macOS  labels: [dev]            last seen: 5s ago
+   → win-03   Windows labels: [build]         last seen: 12s ago
+
+Run a command on one node
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   User: Run `nvidia-smi` on node-01 to check GPU status.
+   Agent: [calls run_on_node(node="node-01", command="nvidia-smi")]
+   → GPU 0: NVIDIA A100 80GB PCIe | Mem: 3241MiB / 81920MiB | ...
+
+Run across a label group
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   User: Restart the data pipeline on all GPU nodes.
+   Agent: [calls run_on_label(label="gpu", command="systemctl restart pipeline")]
+   → node-01: OK (exit 0)
+   → node-04: OK (exit 0)
+
+Transfer a script to all nodes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   # Agent-side code — called by the fleet toolset
+   await fleet.transfer(
+       source="/home/user/scripts/preprocess.py",
+       destination="/opt/pipeline/preprocess.py",
+       label="gpu",
+       verify=True,
+   )
+
+Configuration
+-------------
+
+Fleet connection settings live in ``.pantheon/settings.json``:
+
+.. code-block:: json
+
+   {
+     "fleet": {
+       "nats_url": "nats://your-hub:4222",
+       "controller_api_key": "optional-key-for-http-api"
+     }
+   }
+
+``controller_api_key`` is only needed if your fleet hub exposes an HTTP management API.
+
+Joining a Fleet
+---------------
+
+To add a machine to the fleet, install the fleet binary and run:
+
+.. code-block:: bash
+
+   # On the remote machine
+   fleet join --token <token-from-hub>
+
+Tokens are minted from the Web App (see :doc:`/interfaces/ui/fleet`) or programmatically.
+
+See Also
+--------
+
+- :doc:`/interfaces/ui/fleet` — Fleet management from the web/desktop app
+- :doc:`/advanced/distributed` — Distributed deployment architecture
+- ``docs/pantheon-fleet.md`` in the repository — Fleet binary installation and Go CLI reference

--- a/docs/source/toolsets/index.rst
+++ b/docs/source/toolsets/index.rst
@@ -1,5 +1,5 @@
-Toolsets
-========
+Toolsets Reference
+==================
 
 Toolsets extend agent capabilities by providing access to external functions, APIs, and services. They are bundled with the ``pantheon-agents`` package and can be used directly with agents.
 
@@ -36,6 +36,89 @@ The toolset system consists of:
 1. **ToolSet Base Class**: Base class that all toolsets inherit from
 2. **Tool Decorator**: Marks methods as tools with docstring descriptions
 3. **Provider System**: Handles tool discovery and execution
+
+Complete Toolset Catalog
+------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Toolset
+     - Category
+     - Key Capabilities
+   * - :doc:`python_interpreter`
+     - Code Execution
+     - Persistent Python sessions, run code, manage interpreters
+   * - :doc:`r_interpreter`
+     - Code Execution
+     - Persistent R sessions
+   * - :doc:`julia_interpreter`
+     - Code Execution
+     - Persistent Julia sessions
+   * - :doc:`shell`
+     - Code Execution
+     - Shell commands, background processes, timeouts
+   * - :doc:`notebook`
+     - Code Execution
+     - Jupyter notebooks, cell ops, kernel management
+   * - :doc:`file_editor`
+     - Files
+     - Read/write/edit files, search, patch, PDF, images
+   * - :doc:`file_transfer`
+     - Files
+     - Chunked streaming file I/O
+   * - :doc:`web_browse`
+     - Web & Search
+     - DuckDuckGo search, URL crawl/extract
+   * - :doc:`scraper_api`
+     - Web & Search
+     - JS-rendered scraping, selectors, pagination
+   * - :doc:`fleet`
+     - Infrastructure
+     - Multi-node execution, file transfer, cluster management
+   * - :doc:`live_view`
+     - Visualization
+     - Interactive browser visualizations (11 viewer types)
+   * - :doc:`scfm`
+     - Bioinformatics
+     - Single-cell foundation models: annotate, embed, perturb
+   * - :doc:`evolution`
+     - AI/ML
+     - LLM-guided evolutionary code optimization
+   * - :doc:`evaluator`
+     - AI/ML
+     - Code evaluation, metrics, LLM review
+   * - :doc:`knowledge`
+     - Knowledge & RAG
+     - Qdrant hybrid search, collection management
+   * - :doc:`vector_rag`
+     - Knowledge & RAG
+     - LanceDB vector retrieval
+   * - :doc:`database_api`
+     - Data
+     - 26+ biological database queries via natural language
+   * - :doc:`scraper_api`
+     - Data
+     - Web scraping with ScraperAPI
+   * - :doc:`image_generation`
+     - Media
+     - AI image generation (DALL-E, Gemini, …)
+   * - :doc:`task`
+     - Workflow
+     - Task boundaries, user notifications, output registration
+   * - :doc:`skillbook`
+     - Learning
+     - Skill CRUD, trajectory tracking, effectiveness tagging
+   * - :doc:`package`
+     - Discovery
+     - Search packages and tools by keyword
+   * - :doc:`code_toolset`
+     - Code Analysis
+     - AST-based code outline and item extraction
+   * - :doc:`custom_toolsets`
+     - Extensibility
+     - Build your own toolsets
 
 Built-in Toolsets
 -----------------
@@ -180,6 +263,26 @@ Evolution & Evaluation
   - ``evaluate_codebase``: Evaluate entire projects
   - ``compute_code_metrics``: Static code metrics
   - ``get_llm_code_review``: AI-powered code review
+
+Infrastructure & Visualization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :doc:`fleet` - Multi-node cluster management
+
+  - ``fleet_list_nodes``, ``fleet_node_info``, ``fleet_status``: Observe cluster
+  - ``run_on_node``, ``run_on_label``: Execute on remote nodes
+  - ``transfer``, ``broadcast``, ``gather``: Move files across nodes
+
+- :doc:`live_view` - Interactive browser visualizations
+
+  - ``open_live_view``: Open IGV, Vitessce, Mol*, Gosling, Cytoscape, and 6 more
+  - ``update_live_view``, ``close_live_view``: Manage open panels
+
+- :doc:`scfm` - Single-cell foundation models
+
+  - ``list_scfm_models``: Browse available models
+  - ``select_scfm_model``, ``run_scfm``: Run annotation, embedding, perturbation
+  - ``interpret_scfm_results``: Summarize and explain model output
 
 Quick Start
 -----------
@@ -344,24 +447,28 @@ See :doc:`/api/utils` for more details on MCP integration.
    :hidden:
    :maxdepth: 1
 
-   file_editor
-   file_transfer
-   shell
+   builtin_toolsets
    python_interpreter
    r_interpreter
    julia_interpreter
+   shell
    notebook
-   code_toolset
+   file_editor
+   file_transfer
    web_browse
    scraper_api
-   knowledge
-   vector_rag
-   image_generation
-   database_api
-   task
-   skillbook
-   package
+   fleet
+   live_view
+   scfm
    evolution
    evaluator
-   custom_toolset
+   knowledge
+   vector_rag
+   database_api
+   image_generation
+   task
+   skillbook
+   code_toolset
+   package
+   custom_toolsets
 

--- a/docs/source/toolsets/live_view.rst
+++ b/docs/source/toolsets/live_view.rst
@@ -1,0 +1,188 @@
+Live View Toolset
+=================
+
+The ``LiveViewToolSet`` lets agents open interactive, browser-rendered visualizations alongside the conversation. When an agent calls ``open_live_view``, a panel appears in the web or desktop app showing a live, data-driven visualization — no separate tool, no copy-pasting outputs.
+
+Overview
+--------
+
+Live View covers a wide range of scientific and data visualization types:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Viewer
+     - Type
+     - Best For
+   * - **IGV**
+     - Genomics
+     - Genome browser: alignments, variants, tracks (BAM, VCF, BED, …)
+   * - **Vitessce**
+     - Single-cell / spatial
+     - Multi-modal single-cell and spatial omics dashboards
+   * - **Viv**
+     - Microscopy
+     - High-resolution OME-TIFF and Zarr microscopy images
+   * - **Mol***
+     - Structural biology
+     - Interactive 3D molecular structures (PDB, mmCIF, SDF)
+   * - **Gosling**
+     - Genomics charts
+     - Circular and linear genomic visualizations
+   * - **Cytoscape**
+     - Networks
+     - Biological and general network / graph visualization
+   * - **MSA**
+     - Bioinformatics
+     - Multiple sequence alignment viewer
+   * - **Phylotree**
+     - Bioinformatics
+     - Phylogenetic tree visualization
+   * - **RDKit**
+     - Cheminformatics
+     - 2D and 3D chemical structure rendering
+   * - **Spatial3D**
+     - Spatial omics
+     - 3D spatial transcriptomics point clouds
+   * - **Volume3D**
+     - Imaging
+     - 3D volumetric data rendering
+
+Quick Start
+-----------
+
+.. code-block:: python
+
+   from pantheon.agent import Agent
+   from pantheon.toolsets.live_view import LiveViewToolSet
+
+   live = LiveViewToolSet(name="live_view")
+
+   agent = Agent(
+       name="analyst",
+       instructions="You are a bioinformatics analyst."
+   )
+   await agent.toolset(live)
+   await agent.chat()
+
+The Live View panel appears automatically in the web/desktop app when the agent opens a view.
+
+Tool Reference
+--------------
+
+``open_live_view``
+~~~~~~~~~~~~~~~~~~
+
+Opens an interactive visualization panel. Parameters vary by viewer type.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Parameter
+     - Description
+   * - ``viewer``
+     - Viewer type: ``"igv"``, ``"vitessce"``, ``"mol*"``, ``"viv"``, ``"gosling"``, ``"cytoscape"``, ``"msa"``, ``"phylotree"``, ``"rdkit"``, ``"spatial3d"``, ``"volume3d"``
+   * - ``data``
+     - Data payload or URL — format depends on viewer (see examples below)
+   * - ``title``
+     - Optional title for the panel
+   * - ``config``
+     - Optional viewer-specific configuration dict
+
+``list_live_views``
+~~~~~~~~~~~~~~~~~~~
+
+Returns all currently open Live View panels with their IDs, titles, and viewer types.
+
+``close_live_view``
+~~~~~~~~~~~~~~~~~~~
+
+Closes a specific Live View panel by ID.
+
+``update_live_view``
+~~~~~~~~~~~~~~~~~~~~
+
+Push updated data to an open Live View panel without reopening it.
+
+Usage Examples
+--------------
+
+Genome browser (IGV)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   await live.open_live_view(
+       viewer="igv",
+       title="Sample alignments",
+       data={
+           "genome": "hg38",
+           "tracks": [
+               {"type": "alignment", "url": "s3://bucket/sample.bam"},
+               {"type": "variant",   "url": "s3://bucket/sample.vcf.gz"},
+           ]
+       }
+   )
+
+3D molecular structure (Mol*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   await live.open_live_view(
+       viewer="mol*",
+       title="Protein structure",
+       data={"pdb_id": "1CRN"}          # fetches from RCSB PDB
+       # or: data={"url": "https://files.rcsb.org/download/1CRN.pdb"}
+   )
+
+Network graph (Cytoscape)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   import networkx as nx
+
+   G = nx.karate_club_graph()
+   elements = nx.cytoscape_data(G)["elements"]
+
+   await live.open_live_view(
+       viewer="cytoscape",
+       title="Karate club graph",
+       data={"elements": elements}
+   )
+
+In a Conversation
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   User: Visualize the structure of the EGFR kinase domain.
+   Agent: [calls open_live_view(viewer="mol*", data={"pdb_id": "1IEP"})]
+   → Live View panel opens in the UI showing 3D structure.
+
+   User: Now show me mutations from the VCF file.
+   Agent: [calls open_live_view(viewer="igv", data={...})]
+   → Second panel opens showing the genome browser.
+
+How It Works
+------------
+
+Live View is served by the Pantheon endpoint. When ``open_live_view`` is called:
+
+1. The agent writes the data payload to a temporary serve path on the endpoint.
+2. The endpoint notifies the frontend via NATS.
+3. The frontend opens a panel and loads the viewer component with the data URL.
+4. Data updates (``update_live_view``) push diffs without a full reload.
+
+.. note::
+
+   Live View panels are only visible in the web and desktop app. They do not appear in the CLI or Python API — those interfaces receive a text confirmation that the view was opened.
+
+See Also
+--------
+
+- :doc:`/interfaces/ui/live-view` — Using Live View from the web/desktop app
+- Live View skill library (in ``.pantheon/skills/live_view/``) — ready-made agent prompts for each viewer

--- a/docs/source/toolsets/scfm.rst
+++ b/docs/source/toolsets/scfm.rst
@@ -1,0 +1,139 @@
+Single-Cell Foundation Models (SCFM)
+=====================================
+
+The ``SCFMToolSet`` provides agents with access to a curated collection of single-cell foundation models. Agents can list available models, select the right one for a task, run it on single-cell data, and interpret the results — all through natural-language interaction.
+
+Overview
+--------
+
+Single-cell foundation models (SCFMs) are large pre-trained models for single-cell RNA-seq and related omics data. They perform tasks such as:
+
+- **Cell type annotation** — predict cell types from expression profiles
+- **Embedding generation** — low-dimensional representations for clustering or integration
+- **Perturbation prediction** — predict transcriptional response to a drug or genetic perturbation
+- **Gene regulatory inference** — infer regulatory networks from expression data
+- **Batch correction / integration** — harmonize data across experiments
+
+Quick Start
+-----------
+
+.. code-block:: python
+
+   from pantheon.agent import Agent
+   from pantheon.toolsets.scfm import SCFMToolSet
+
+   scfm = SCFMToolSet(name="scfm")
+
+   agent = Agent(
+       name="sc_analyst",
+       instructions="You are a single-cell analysis expert."
+   )
+   await agent.toolset(scfm)
+   await agent.chat()
+
+Tool Reference
+--------------
+
+``list_scfm_models``
+~~~~~~~~~~~~~~~~~~~~
+
+Returns the full catalog of available foundation models with name, version, task types, and data requirements.
+
+.. code-block:: text
+
+   Agent: [calls list_scfm_models]
+   → scGPT          v0.2.1  cell annotation, embedding, perturbation
+   → Geneformer     v2.0    cell annotation, embedding, dosage sensitivity
+   → UCE            v1.0    embedding, cross-species
+   → TOSICA         v1.0    cell type annotation
+   → scFoundation   v1.0    embedding, cell annotation
+   → ...
+
+``select_scfm_model``
+~~~~~~~~~~~~~~~~~~~~~
+
+Choose a model for the current task. Sets the active model for subsequent ``run_scfm`` calls.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Parameter
+     - Description
+   * - ``model_name``
+     - Name of the model (from ``list_scfm_models``)
+   * - ``task``
+     - Task type: ``"annotation"``, ``"embedding"``, ``"perturbation"``, ``"integration"``
+
+``run_scfm``
+~~~~~~~~~~~~
+
+Execute the selected model on input data.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Parameter
+     - Description
+   * - ``input_path``
+     - Path to the input AnnData (.h5ad) file
+   * - ``output_path``
+     - Where to write the result AnnData with added embeddings / annotations
+   * - ``task``
+     - Task override (optional — defaults to the task set in ``select_scfm_model``)
+   * - ``kwargs``
+     - Model-specific parameters (batch size, gene set, etc.)
+
+``interpret_scfm_results``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Ask the model to interpret its own output: explain predicted cell types, highlight uncertain predictions, flag low-quality cells, or summarize the embedding structure.
+
+Usage Examples
+--------------
+
+Cell type annotation workflow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   User: Annotate the cell types in my PBMC dataset at data/pbmc.h5ad.
+   Agent: [calls list_scfm_models → selects Geneformer for annotation]
+          [calls run_scfm(input="data/pbmc.h5ad", output="data/pbmc_annotated.h5ad")]
+   → Added column 'predicted_cell_type' to .obs
+   → Confidence scores in .obs['scfm_confidence']
+
+   User: Which cells have low confidence?
+   Agent: [calls interpret_scfm_results]
+   → 143 cells below 0.5 confidence — mostly at cluster boundaries.
+      Recommend manual review of clusters 3 and 7.
+
+Embedding for integration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   # Programmatic use
+   await scfm.select_scfm_model(model_name="scGPT", task="embedding")
+   result = await scfm.run_scfm(
+       input_path="data/dataset_a.h5ad",
+       output_path="data/dataset_a_embedded.h5ad",
+   )
+   # adata.obsm["X_scgpt"] now contains the embeddings
+
+Requirements
+------------
+
+Model weights are downloaded automatically on first use to a local cache (typically ``~/.scfm_cache/``). Disk requirements vary by model (1–10 GB). GPU acceleration is supported when a CUDA-capable device is available; CPU inference is also supported but slower.
+
+.. note::
+
+   The SCFM catalog is extensible. Additional models can be registered via the skill system (see ``.pantheon/skills/omics/`` for examples of model registration prompts and configurations).
+
+See Also
+--------
+
+- :doc:`/toolsets/python_interpreter` — Run custom single-cell Python workflows
+- :doc:`/toolsets/notebook` — Interactive Jupyter notebook for exploratory analysis
+- Omics skills (``.pantheon/skills/omics/``) — curated analysis workflows for scRNA-seq, spatial, and more


### PR DESCRIPTION
Adds a new tutorials page under the Interfaces section of the documentation. Includes all 10 PantheonOS tutorial videos detailing Web/Desktop app workflows in a responsive 2-column sphinx-design grid, registers the page in _toc.yml, and adds matching tutorial-card styles to custom.css consistent with the existing sphinx_book_theme.