### PR TITLE
feat(sandbox): keep the environment a user installs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -196,6 +196,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxshmfence1 \
     # Fonts for better rendering (removed emoji fonts to save ~20MB)
     fonts-liberation \
+    # Interactive shell tools. The sandbox now serves a real terminal (the pty
+    # toolset), and a terminal without an editor or a pager is not one: `vim`
+    # was "command not found", so was `less`, and installing them by hand does
+    # not survive — apt writes to /usr, which is the image, while only the
+    # Volume persists. Belongs here, where every sandbox gets it. ~35 MB.
+    vim \
+    less \
+    nano \
+    tree \
+    htop \
+    jq \
+    unzip \
+    zip \
+    procps \
+    file \
     # Paper writing and scientific figure dependencies
     pandoc \
     # qpdf: linearize (web-optimize) compiled PDFs so the viewer can render

--- a/docker/docker-entrypoint-dual-mode.sh
+++ b/docker/docker-entrypoint-dual-mode.sh
@@ -380,6 +380,49 @@ EOF
             > /tmp/fleet-node.log 2>&1 &
     fi
 
+    # ── User setup hook ───────────────────────────────────────────────────
+    #
+    # Everything a user installs with apt lands in /usr, which is the image,
+    # not the Volume — so it is gone the next time the sandbox is recreated,
+    # and sandboxes are recreated often: on restart, after an idle reclaim,
+    # and on every agent-image update. "I installed vim yesterday and today it
+    # is missing" is the whole shape of the problem.
+    #
+    # The persistent half of the filesystem cannot hold binaries in system
+    # paths, but it can hold the *instructions* for putting them back. This
+    # runs one script the user owns, from the Volume, on every boot — so the
+    # environment is declared rather than accumulated, which also means it
+    # survives an image update instead of being erased by one.
+    #
+    #   <Volume>/.pantheon/on-start.sh
+    #
+    # Keyed off the Volume, NOT off HOME. Under the default_workspace layout
+    # HOME *is* the Volume, but in the legacy layout HOME is /root, which is
+    # ephemeral — a hook stored there would vanish with the container it was
+    # meant to outlive, which is the exact bug this fixes. (Checked on a live
+    # staging sandbox: HOME=/root, and the Volume is elsewhere.)
+    #
+    # Deliberately: not fatal, so a broken line cannot cost the user their
+    # sandbox; bounded, so an accidental `read` cannot hang the boot forever;
+    # and logged where both the user and support can find it.
+    # WORKSPACE only gets its default in the standalone branch above, so it
+    # may be unset here; /workspace is the Volume mount in both hub layouts.
+    VOLUME_ROOT="${WORKSPACE:-/workspace}"
+    SETUP_HOOK="${VOLUME_ROOT}/.pantheon/on-start.sh"
+    if [ -f "$SETUP_HOOK" ]; then
+        SETUP_LOG=/tmp/pantheon-on-start.log
+        echo "[setup] running $SETUP_HOOK (log: $SETUP_LOG) ..."
+        if timeout "${PANTHEON_SETUP_TIMEOUT:-300}" bash "$SETUP_HOOK" > "$SETUP_LOG" 2>&1; then
+            echo "[setup] ✓ finished"
+        else
+            rc=$?
+            [ $rc -eq 124 ] && echo "[setup] ✗ timed out; continuing without it" \
+                            || echo "[setup] ✗ exited $rc; continuing without it"
+            tail -n 20 "$SETUP_LOG" 2>/dev/null | sed 's/^/[setup]   /'
+        fi
+        cp "$SETUP_LOG" "${VOLUME_ROOT}/.pantheon/on-start.log" 2>/dev/null || true
+    fi
+
     # Run the endpoint IN the default workspace so work_dir (=cwd at import) makes
     # default_workspace the active project, while HOME=/workspace keeps ~/.pantheon
     # (global store) at the Volume root. Users create sibling workspaces under


### PR DESCRIPTION
## The report

> I installed vim, and the next time I went in it was gone. Surely a user's environment shouldn't be wiped by every update?

It is a fair complaint and the current answer is bad. Everything `apt` writes lands in `/usr` — the image — while only the Modal Volume survives. So a user's environment is erased by every sandbox recreation, and sandboxes are recreated **often**: on restart, after an idle reclaim, and on every agent-image update. An environment that cannot survive an update is not an environment.

This is much more visible now that the sandbox serves a real terminal (#156): people use it like a machine, and a machine that forgets is worse than no machine.

## Two halves

**1. The obvious tools ship in the image.**

A terminal with no editor and no pager is not a terminal. `vim` was command-not-found; so were `less`, `nano`, `htop`, `tree`, `jq`, `unzip`, `zip`, `file` and `procps`. About 35 MB on a 2.5 GB image, and it removes the most common reason to reach for apt at all.

**2. Anything else is declared, not accumulated.**

The persistent half of the filesystem cannot hold binaries in system paths — but it can hold the *instructions* for putting them back. The entrypoint now runs, on every boot:

```
~/.pantheon/on-start.sh
```

`HOME` is the Volume under the `default_workspace` layout, so that file persists. A user writes `apt-get install -y ripgrep` into it once and every future sandbox has ripgrep.

Declared rather than accumulated, which is the property that matters here: it **survives an image update instead of being wiped by one**, and it is inspectable and reproducible — unlike a container someone has been hand-editing for a month, which nobody can reconstruct.

## Forgiving on purpose

This runs before the agent, and the user wrote it:

- **Not fatal.** A bad line cannot cost someone their sandbox; the boot continues and the last 20 lines of output are logged.
- **Bounded.** `PANTHEON_SETUP_TIMEOUT` (default 300 s), so an accidental `read` cannot hang the boot forever.
- **Findable.** Output is copied to `~/.pantheon/on-start.log`, on the Volume, where both the user and support can read it after the fact.

Exercised locally across all four paths:

```
1) no hook            → boot proceeds, nothing logged
2) working hook       → [setup] ✓ finished
3) failing hook       → [setup] ✗ exited 9; continuing without it   (+ tail)
4) hanging hook (cap) → [setup] ✗ timed out; continuing without it
5) log on the volume  → on-start.log, on-start.sh
```

## Not in scope here

A UI for editing the hook, and a `packages.txt`-style declarative form on top of it. The shell script is the primitive; both of those are sugar over it and belong in the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhPiGNfkhLZ89Sqhoz9ebP