### PR TITLE
fix(chatroom): the disk-usage walk was starving the event loop

### DIFF
--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -64,6 +64,16 @@ def _is_internal_notification(message: list[dict]) -> bool:
     return False
 
 
+# How long after boot to leave the workspace disk walk alone.
+#
+# The first `_ping` from a desktop arrives seconds after the agent answers,
+# when the volume's FUSE cache is empty and every stat is a network round trip.
+# Walking then is both the most expensive the walk will ever be and the worst
+# possible moment: the user is opening windows and typing into a terminal.
+# Nothing waits on a disk-usage figure, so it can start after the rush.
+_DISK_WALK_QUIET_SECONDS = 120.0
+
+
 class ChatRoom(ToolSet):
     """
     ChatRoom is a service that allows user to interact with a team of agents.
@@ -100,6 +110,12 @@ class ChatRoom(ToolSet):
     ):
         # Initialize ToolSet (will handle worker creation in run())
         super().__init__(name=name, **kwargs)
+
+        # When this process started, for work that should keep out of the way
+        # while a sandbox is still finding its feet. See _DISK_WALK_QUIET_SECONDS.
+        import time as _t_boot
+
+        self._started_monotonic = _t_boot.monotonic()
 
         # ChatRoom specific initialization (before endpoint setup for workspace_path default)
         # Convert to absolute path BEFORE Endpoint creation (Endpoint does os.chdir)
@@ -575,20 +591,47 @@ class ChatRoom(ToolSet):
         except Exception as e:  # noqa: BLE001
             logger.warning(f"ChatRoom: model catalog warmup skipped: {e}")
 
+    # The walk yields the GIL every this many entries, for this long. 200/1 ms
+    # costs a few percent of walk time on a tree of a few thousand files and
+    # takes the thread from monopolising a core to sharing one.
+    _WALK_YIELD_EVERY = 200
+    _WALK_YIELD_SECONDS = 0.001
+
     @staticmethod
     def _walk_workspace_bytes(root: str) -> int:
-        """Sum file sizes under `root`. Runs in a daemon thread (NOT the event
-        loop) because on Modal FUSE volumes this is thousands of slow stat()
-        round-trips. os.scandir/stat release the GIL during the syscall, so
-        the event loop keeps serving NATS RPCs while this runs."""
+        """Sum file sizes under `root`. Runs in a daemon thread, and yields.
+
+        The thread was added so the walk would not block the event loop, on the
+        reasoning that os.scandir/stat release the GIL during the syscall. That
+        holds for the syscalls; it does not hold for the walk. Sampled with
+        py-spy on a sandbox 30 seconds old, this thread was at **96% CPU** —
+        the per-entry Python work (iteration, path building, the stack) runs
+        with the GIL held, and on a two-core sandbox the event loop then has to
+        contend for it. A `_ping`, which is answered by the RPC framework and
+        touches no toolset, took **1674 ms** during that window against a
+        68 ms median once things settled.
+
+        So the walk now yields: a short sleep every so many entries, which
+        hands the GIL to the event loop and caps this thread's share. The walk
+        takes marginally longer and stops being felt, which is the right trade
+        for a disk-usage figure nobody is waiting on.
+        """
         import os
+        import time as _t
+
         used = 0
+        seen = 0
         stack = [root]
         while stack:
             cur = stack.pop()
             try:
                 with os.scandir(cur) as it:
                     for entry in it:
+                        seen += 1
+                        # Sleeping — not just `pass` — is what actually releases
+                        # the GIL to a waiting thread.
+                        if seen % ChatRoom._WALK_YIELD_EVERY == 0:
+                            _t.sleep(ChatRoom._WALK_YIELD_SECONDS)
                         try:
                             if entry.is_symlink():
                                 continue
@@ -691,7 +734,19 @@ class ChatRoom(ToolSet):
                     # read_chunk_at — stalling file downloads. So refresh the
                     # cache in a detached daemon thread and only ever READ the
                     # cached value here. A single-flight flag prevents pile-up.
-                    if (cached is None or now - cached[1] > 300.0) and not getattr(self, "_disk_walk_running", False):
+                    # Not during the sandbox's opening minutes. The first
+                    # `_ping` a desktop sends arrives seconds after boot, when
+                    # the FUSE cache is empty and every stat is a round trip —
+                    # so the very first walk is both the most expensive one and
+                    # the one that lands while the user is opening windows and
+                    # typing. Nothing waits on a disk figure; it can start
+                    # after the rush.
+                    too_young = (now - getattr(self, "_started_monotonic", now)) < _DISK_WALK_QUIET_SECONDS
+                    if (
+                        not too_young
+                        and (cached is None or now - cached[1] > 300.0)
+                        and not getattr(self, "_disk_walk_running", False)
+                    ):
                         self._disk_walk_running = True
 
                         def _refresh_disk_used():


### PR DESCRIPTION
## What was observed

A desktop was sluggish for roughly the first minute on a fresh sandbox — `get_cwd` 0.9 s, keystrokes 0.8–2.3 s — settling to ~60 ms afterwards. Sampled with py-spy against that sandbox, thirty seconds old:

```
Thread 33 (active): "disk-usage-walk"        96% CPU
    _walk_workspace_bytes (pantheon/chatroom/room.py:591)
    _refresh_disk_used     (pantheon/chatroom/room.py:699)

Thread 2 (idle): "MainThread"                 7.7%
    select (selectors.py:468)
```

One thread on a full core; the event loop idle behind it.

## Why the existing design did not hold

The walk was already moved to a daemon thread, deliberately, with the reasoning recorded in the docstring:

> os.scandir/stat release the GIL during the syscall, so the event loop keeps serving NATS RPCs while this runs.

True of the syscalls, not of the walk. The per-entry Python work — iteration, path building, the stack — runs with the GIL held. On a two-core sandbox the loop then has to contend for it, and `_ping`, which is answered by the RPC framework and touches no toolset, took **1674 ms** during that window against a **68 ms** median once things settled. A slow `_ping` is the cleanest possible signal here: nothing in it can be slow except the process itself.

## Two changes

**The walk yields.** A 1 ms sleep every 200 entries — sleeping, not `pass`, is what hands the GIL to a waiting thread. Measured with a 10 ms heartbeat alongside 40k entries of the same per-entry work:

```
as it was   walk  17 ms | ticks  0
yielding    walk 275 ms | ticks 25,  p50 11.0 ms,  worst 11.2 ms
```

`ticks 0` is a heartbeat that never once ran. The walk takes longer and stops being felt — the right trade for a number nobody is waiting on.

**It keeps out of the opening minutes.** The first `_ping` from a desktop arrives seconds after the agent starts answering, when the volume's FUSE cache is empty and every `stat` is a network round trip. So the first walk is simultaneously the most expensive it will ever be and the worst-timed — it lands while windows are opening and someone is typing into a terminal. Warm, the same tree (1614 files, 806 dirs, 5.7 GB) walks in **0.2 s**.

`_DISK_WALK_QUIET_SECONDS = 120`. Nothing waits on a disk-usage figure.

## Why not something cheaper than a walk

`statvfs` on the volume reports the mount, not the volume's contents:

```
/workspace -> total 409.6 GB, free 409.6 GB, used 0.0 GB
```

So the walk is the only way to get the number, and the question is only when and how politely it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhPiGNfkhLZ89Sqhoz9ebP