### PR TITLE
feat(endpoint): app backend supervisor — one process per Atrium app

### DIFF
--- a/pantheon/endpoint/app_runtime.py
+++ b/pantheon/endpoint/app_runtime.py
@@ -1,0 +1,214 @@
+"""App backend bootstrap — the child half of the supervisor's protocol.
+
+Run BY PATH under whatever interpreter the app's manifest names:
+
+    <interpreter> app_runtime.py --app-dir … --app-id … --workspace … --state-dir …
+
+STDLIB-ONLY, load-bearing: the interpreter is typically a conda analysis env
+(``pantheon-base``) in which the ``pantheon`` package does not exist and must
+not need to. Everything this file is arrives in this file.
+
+Protocol (line-delimited JSON-RPC 2.0 on stdio):
+
+  child → parent, once:   {"ready": true, "api": 1, "methods": [...]}
+  parent → child:         {"id", "method": "invoke", "params": {method, args}}
+                          {"method": "shutdown"} / {"method": "ping", "id"}
+  child → parent:         responses; and its own AppContext requests
+                          ("ctx.serve", "ctx.log"), interleaved on the pipe.
+
+The app's backend package is imported from ``<app-dir>/backend``; its
+``register(ctx)`` collects methods via the ``@ctx.method`` decorator. Durable
+state is a JSON file under ``--state-dir`` — outside the package directory,
+so reinstalls and resyncs cannot eat it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import inspect
+import json
+import sys
+import traceback
+from pathlib import Path
+
+
+def _out(msg: dict) -> None:
+    sys.stdout.write(json.dumps(msg, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+class _State:
+    """A small KV that survives the process — one JSON file, written whole."""
+
+    def __init__(self, state_dir: Path):
+        self._path = state_dir / "state.json"
+        try:
+            self._data = json.loads(self._path.read_text())
+        except (OSError, json.JSONDecodeError):
+            self._data = {}
+
+    def get(self, key: str, default=None):
+        return self._data.get(key, default)
+
+    def set(self, key: str, value) -> None:
+        self._data[key] = value
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._data, ensure_ascii=False, indent=1))
+        tmp.replace(self._path)
+
+
+class AppContext:
+    """The backend's one door to the world (spec §6.3)."""
+
+    def __init__(self, app_id: str, workspace: Path, state_dir: Path, rpc: "_Rpc"):
+        self.app_id = app_id
+        self.workspace = workspace
+        self.state = _State(state_dir)
+        self._rpc = rpc
+        self._methods: dict[str, object] = {}
+
+    def method(self, fn):
+        """Register ``fn`` as a callable backend method. Decorator."""
+        self._methods[fn.__name__] = fn
+        return fn
+
+    async def serve(self, path) -> str:
+        """A data-server URL for a file — answered by the endpoint."""
+        res = await self._rpc.request("ctx.serve", {"path": str(path)})
+        return res["url"]
+
+    def log(self, message: str) -> None:
+        self._rpc.notify("ctx.log", {"message": str(message)})
+
+
+class _Rpc:
+    """The child's side of the pipe: requests up, responses matched back."""
+
+    def __init__(self):
+        self._seq = 0
+        self._pending: dict[str, asyncio.Future] = {}
+
+    def notify(self, method: str, params: dict) -> None:
+        self._seq += 1
+        _out({"jsonrpc": "2.0", "id": f"n{self._seq}", "method": method, "params": params})
+
+    async def request(self, method: str, params: dict, timeout_s: float = 60.0):
+        self._seq += 1
+        rid = f"q{self._seq}"
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[rid] = fut
+        _out({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        try:
+            msg = await asyncio.wait_for(fut, timeout_s)
+        finally:
+            self._pending.pop(rid, None)
+        if "error" in msg:
+            raise RuntimeError(str((msg["error"] or {}).get("message", method + " failed")))
+        return msg.get("result")
+
+    def settle(self, msg: dict) -> bool:
+        fut = self._pending.get(str(msg.get("id")))
+        if fut and not fut.done():
+            fut.set_result(msg)
+            return True
+        return False
+
+
+def _load_backend(app_dir: Path):
+    """Import ``<app-dir>/backend`` as an isolated module.
+
+    ``_vendor`` (pinned pure-Python deps, spec §3.3) goes FIRST on sys.path so
+    the app's pins win inside the app's own process — there is nothing else in
+    this process for them to conflict with.
+    """
+    backend_dir = app_dir / "backend"
+    vendor = backend_dir / "_vendor"
+    if vendor.is_dir():
+        sys.path.insert(0, str(vendor))
+    spec = importlib.util.spec_from_file_location(
+        f"atrium_app_{app_dir.name}_backend", backend_dir / "__init__.py",
+        submodule_search_locations=[str(backend_dir)],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--app-dir", required=True)
+    ap.add_argument("--app-id", required=True)
+    ap.add_argument("--workspace", required=True)
+    ap.add_argument("--state-dir", required=True)
+    ns = ap.parse_args()
+
+    rpc = _Rpc()
+    ctx = AppContext(ns.app_id, Path(ns.workspace), Path(ns.state_dir), rpc)
+
+    try:
+        mod = _load_backend(Path(ns.app_dir))
+        register = getattr(mod, "register", None)
+        if register is None:
+            raise RuntimeError("backend/__init__.py defines no register(ctx)")
+        out = register(ctx)
+        if inspect.isawaitable(out):
+            await out
+    except Exception as e:  # noqa: BLE001 — the parent needs the reason
+        traceback.print_exc()
+        _out({"ready": False, "error": f"{type(e).__name__}: {e}"})
+        return 1
+
+    _out({"ready": True, "api": 1, "methods": sorted(ctx._methods)})
+
+    async def handle(msg: dict) -> None:
+        mid = msg.get("id")
+        method = msg.get("method")
+        if method == "ping":
+            _out({"jsonrpc": "2.0", "id": mid, "result": {}})
+            return
+        if method != "invoke":
+            _out({"jsonrpc": "2.0", "id": mid,
+                  "error": {"code": -32601, "message": f"unknown method {method}"}})
+            return
+        params = msg.get("params") or {}
+        name = params.get("method", "")
+        fn = ctx._methods.get(name)
+        if fn is None:
+            _out({"jsonrpc": "2.0", "id": mid,
+                  "error": {"code": -32601, "message": f"no registered method '{name}'"}})
+            return
+        try:
+            result = fn(**(params.get("args") or {}))
+            if inspect.isawaitable(result):
+                result = await result
+            _out({"jsonrpc": "2.0", "id": mid, "result": result if result is not None else {}})
+        except Exception as e:  # noqa: BLE001 — errors must cross as JSON
+            traceback.print_exc()
+            _out({"jsonrpc": "2.0", "id": mid,
+                  "error": {"code": -32000, "message": f"{type(e).__name__}: {e}"}})
+
+    # stdin as an async stream
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader()
+    await loop.connect_read_pipe(lambda: asyncio.StreamReaderProtocol(reader), sys.stdin)
+
+    while True:
+        line = await reader.readline()
+        if not line:
+            return 0  # parent closed the pipe: we are being reaped
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("method") == "shutdown":
+            return 0
+        # A response to one of OUR requests, or work for us — one pipe, both.
+        if not rpc.settle(msg):
+            asyncio.create_task(handle(msg))
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/pantheon/endpoint/apps.py
+++ b/pantheon/endpoint/apps.py
@@ -1,0 +1,393 @@
+"""App backend supervisor (Atrium app runtime, docs/app-spec.md in
+pantheon-atrium, frozen v1 §5–§6).
+
+An Atrium app may ship a Python backend. Each backend runs in ITS OWN
+subprocess, spawned lazily and supervised here; the endpoint itself runs no
+app code, so nothing an app does can take down routing, the file panel, or
+another app. This is the third rung of a ladder this codebase already climbs:
+ChatRoom spawns the endpoint as a subprocess, and the Python toolset moved
+user code into a Jupyter kernel precisely so ``sys.exit()`` kills the kernel
+and not the agent.
+
+Transport is line-delimited JSON-RPC 2.0 over the child's stdio — deliberately
+not the NATS bus. The child never holds bus credentials; everything it wants
+(the data server, durable state, logging) it asks for over its one pipe, and
+the supervisor answers with the endpoint's own facilities. Backends cannot
+reach each other by geometry rather than by discipline.
+
+The registration mechanism, end to end:
+
+  scan          manifests found under the install scopes become REGISTERED
+                entries (id, dir, scope, manifest) — visible before any
+                process exists;
+  handshake     on first use the child imports the backend, runs
+                ``register(ctx)``, and reports the method names it collected;
+                those become the entry's callable surface;
+  dispatch      ``call()`` refuses methods the handshake never registered —
+                ``unknown_method`` comes from the table, not from a timeout;
+  lifecycle     registered → spawning → ready → (idle) reaped → registered,
+                or → crashed(n) with exponential backoff, capped, → failed.
+
+State the child asks us to persist lives OUTSIDE the package directory
+(``.pantheon/app-state/<id>/``), so an uninstall or a dev resync of the
+package never deletes user data. (Erratum to spec §6.3, which placed it
+inside ``apps/<id>/``.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pantheon.utils.log import logger
+
+# Where a scope's packages live, relative to their root (workspace / home).
+_SCOPE_REL = ".pantheon/apps"
+_BUILTIN_ROOT = Path("/app/pantheon/factory/templates/apps")
+
+_HANDSHAKE_TIMEOUT_S = 10.0
+_IDLE_REAP_S = 600.0
+_BACKOFF_S = [1.0, 2.0, 4.0, 8.0, 16.0]  # then: failed
+_STDERR_TAIL = 4000
+
+
+@dataclass
+class AppEntry:
+    """One registered app — the unit the registration mechanism tracks."""
+
+    app_id: str
+    dir: Path
+    scope: str  # workspace | user | builtin
+    manifest: dict
+    state: str = "registered"  # registered|spawning|ready|failed
+    methods: list[str] = field(default_factory=list)
+    crashes: int = 0
+    last_error: str = ""
+
+    def describe(self) -> dict:
+        return {
+            "id": self.app_id,
+            "version": self.manifest.get("version", "0"),
+            "scope": self.scope,
+            "state": self.state,
+            "methods": list(self.methods),
+            "actions": self.manifest.get("actions", []),
+            "opens": self.manifest.get("opens", []),
+            "error": self.last_error or None,
+        }
+
+
+class _AppProcess:
+    """A live backend child: its pipes, its pending calls, its reader."""
+
+    def __init__(self, entry: AppEntry, proc: asyncio.subprocess.Process):
+        self.entry = entry
+        self.proc = proc
+        self.pending: dict[str, asyncio.Future] = {}
+        self.seq = 0
+        self.last_used = time.monotonic()
+        self.stderr_tail = ""
+        self.reader_task: asyncio.Task | None = None
+        self.stderr_task: asyncio.Task | None = None
+
+    def next_id(self) -> str:
+        self.seq += 1
+        return f"c{self.seq}"
+
+
+class AppSupervisor:
+    """Spawns, watches, and speaks for app backends.
+
+    Owns no app code. The ``endpoint`` reference exists solely to answer the
+    child's AppContext requests with the endpoint's own facilities — today
+    ``serve`` (the live_view data server) and logging.
+    """
+
+    def __init__(self, endpoint: Any, workspace: Path):
+        self.endpoint = endpoint
+        self.workspace = Path(workspace)
+        self.entries: dict[str, AppEntry] = {}
+        self.procs: dict[str, _AppProcess] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._reaper: asyncio.Task | None = None
+
+    # ── registration: scan ──────────────────────────────────────────────
+
+    def scope_roots(self) -> list[tuple[Path, str]]:
+        return [
+            (self.workspace / _SCOPE_REL, "workspace"),
+            (Path.home() / _SCOPE_REL, "user"),
+            (_BUILTIN_ROOT, "builtin"),
+        ]
+
+    def scan(self) -> list[dict]:
+        """(Re)read the install scopes. First scope wins per id (§9).
+
+        Cheap and synchronous — a handful of manifest reads — and run on every
+        registry query rather than cached, because an install is a file write
+        and polling filesystems is how every stale-cache bug here starts.
+        Running processes of apps that vanished are left to the idle reaper.
+        """
+        found: dict[str, AppEntry] = {}
+        for root, scope in self.scope_roots():
+            if not root.is_dir():
+                continue
+            for app_dir in sorted(root.iterdir()):
+                mf = app_dir / "atrium.json"
+                if not mf.is_file():
+                    continue
+                try:
+                    manifest = json.loads(mf.read_text())
+                except (json.JSONDecodeError, OSError):
+                    continue  # half a package must not wedge the registry
+                app_id = manifest.get("id")
+                if not app_id or app_id in found:
+                    continue
+                prev = self.entries.get(app_id)
+                if prev and prev.dir == app_dir:
+                    found[app_id] = prev  # keep live state across scans
+                else:
+                    found[app_id] = AppEntry(app_id, app_dir, scope, manifest)
+        self.entries = found
+        return [e.describe() for e in self.entries.values()]
+
+    # ── lifecycle ───────────────────────────────────────────────────────
+
+    def _interpreter(self, entry: AppEntry) -> str:
+        """The interpreter the backend runs under (§6.5).
+
+        A named env resolves against the conda machinery's env roots; a
+        missing or unnamed env falls back to this process's interpreter. The
+        child script is stdlib-only precisely so ANY interpreter can run it —
+        a conda env has no ``pantheon`` package and must not need one.
+        """
+        env = ((entry.manifest.get("caps") or {}).get("python") or {}).get("env")
+        if env:
+            for root in ("/opt/pantheon/envs", str(Path.home() / ".local/share/pantheon/envs")):
+                cand = Path(root) / env / "bin" / "python"
+                if cand.is_file():
+                    return str(cand)
+            logger.warning(f"app {entry.app_id}: python env '{env}' not found, using endpoint python")
+        return sys.executable
+
+    async def _spawn(self, entry: AppEntry) -> _AppProcess:
+        runtime = Path(__file__).with_name("app_runtime.py")
+        state_dir = self.workspace / ".pantheon" / "app-state" / entry.app_id
+        state_dir.mkdir(parents=True, exist_ok=True)
+        entry.state = "spawning"
+        proc = await asyncio.create_subprocess_exec(
+            self._interpreter(entry),
+            str(runtime),
+            "--app-dir", str(entry.dir),
+            "--app-id", entry.app_id,
+            "--workspace", str(self.workspace),
+            "--state-dir", str(state_dir),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # Its own group, so an endpoint shutdown can sweep children and a
+            # child's own children die with it.
+            start_new_session=True,
+        )
+        ap = _AppProcess(entry, proc)
+        ap.stderr_task = asyncio.create_task(self._drain_stderr(ap))
+
+        # Handshake: one line, {"ready": true, "api": 1, "methods": [...]}.
+        try:
+            line = await asyncio.wait_for(proc.stdout.readline(), _HANDSHAKE_TIMEOUT_S)
+            hello = json.loads(line)
+            if not hello.get("ready"):
+                raise RuntimeError(hello.get("error") or "backend reported not-ready")
+        except Exception as e:
+            with contextlib_suppress():
+                proc.kill()
+            entry.state = "registered"
+            raise RuntimeError(
+                f"backend for '{entry.app_id}' failed to start: {e}; stderr: {ap.stderr_tail[-800:]}"
+            ) from e
+
+        entry.methods = [str(m) for m in hello.get("methods", [])]
+        entry.state = "ready"
+        entry.last_error = ""
+        ap.reader_task = asyncio.create_task(self._read_loop(ap))
+        self.procs[entry.app_id] = ap
+        self._ensure_reaper()
+        logger.info(f"app backend up: {entry.app_id} ({len(entry.methods)} methods)")
+        return ap
+
+    async def _drain_stderr(self, ap: _AppProcess) -> None:
+        try:
+            while True:
+                chunk = await ap.proc.stderr.read(1024)
+                if not chunk:
+                    return
+                ap.stderr_tail = (ap.stderr_tail + chunk.decode(errors="replace"))[-_STDERR_TAIL:]
+        except Exception:
+            return
+
+    async def _read_loop(self, ap: _AppProcess) -> None:
+        """Demultiplex the child's stdout: responses to our invokes, and the
+        child's own AppContext requests, interleaved on one pipe."""
+        try:
+            while True:
+                line = await ap.proc.stdout.readline()
+                if not line:
+                    break
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if "method" in msg:
+                    asyncio.create_task(self._serve_ctx(ap, msg))
+                else:
+                    fut = ap.pending.pop(str(msg.get("id")), None)
+                    if fut and not fut.done():
+                        fut.set_result(msg)
+        finally:
+            await self._on_exit(ap)
+
+    async def _on_exit(self, ap: _AppProcess) -> None:
+        entry = ap.entry
+        code = ap.proc.returncode
+        for fut in ap.pending.values():
+            if not fut.done():
+                fut.set_exception(RuntimeError(
+                    f"backend for '{entry.app_id}' exited (code {code}); stderr: {ap.stderr_tail[-800:]}"
+                ))
+        ap.pending.clear()
+        if self.procs.get(entry.app_id) is ap:
+            del self.procs[entry.app_id]
+        if entry.state == "reaped":
+            entry.state = "registered"
+            return
+        entry.crashes += 1
+        entry.last_error = ap.stderr_tail[-800:] or f"exited with code {code}"
+        if entry.crashes > len(_BACKOFF_S):
+            entry.state = "failed"
+            logger.error(f"app backend failed permanently: {entry.app_id}")
+        else:
+            entry.state = "registered"
+            logger.warning(f"app backend exited: {entry.app_id} (crash {entry.crashes}, code {code})")
+
+    async def _serve_ctx(self, ap: _AppProcess, msg: dict) -> None:
+        """Answer one AppContext request from the child (§6.3/§6.4)."""
+        method = msg.get("method", "")
+        params = msg.get("params") or {}
+        out: dict = {"jsonrpc": "2.0", "id": msg.get("id")}
+        try:
+            if method == "ctx.serve":
+                res = await self.endpoint.proxy_toolset(
+                    "serve_local_data", {"path": params["path"]}, "live_view",
+                )
+                if not res.get("success"):
+                    raise RuntimeError(res.get("error") or "serve_local_data refused")
+                out["result"] = {"url": res["url"]}
+            elif method == "ctx.log":
+                logger.info(f"[app:{ap.entry.app_id}] {params.get('message', '')}")
+                out["result"] = {}
+            else:
+                out["error"] = {"code": -32601, "message": f"unknown ctx method {method}"}
+        except Exception as e:  # noqa: BLE001 — everything must cross as JSON
+            out["error"] = {"code": -32000, "message": str(e)}
+        await self._send(ap, out)
+
+    async def _send(self, ap: _AppProcess, msg: dict) -> None:
+        data = (json.dumps(msg, ensure_ascii=False) + "\n").encode()
+        ap.proc.stdin.write(data)
+        await ap.proc.stdin.drain()
+
+    # ── dispatch ────────────────────────────────────────────────────────
+
+    async def call(self, app_id: str, method: str, args: dict | None, timeout_s: float) -> Any:
+        if not self.entries:
+            self.scan()
+        entry = self.entries.get(app_id)
+        if entry is None:
+            self.scan()
+            entry = self.entries.get(app_id)
+        if entry is None:
+            raise RuntimeError(f"no app '{app_id}' is installed")
+        if not entry.manifest.get("entry", {}).get("backend"):
+            raise RuntimeError(f"app '{app_id}' declares no backend")
+        if entry.state == "failed":
+            raise RuntimeError(
+                f"backend for '{app_id}' has failed repeatedly and is parked; "
+                f"last error: {entry.last_error}"
+            )
+
+        lock = self._locks.setdefault(app_id, asyncio.Lock())
+        async with lock:
+            ap = self.procs.get(app_id)
+            if ap is None or ap.proc.returncode is not None:
+                if entry.crashes:
+                    delay = _BACKOFF_S[min(entry.crashes, len(_BACKOFF_S)) - 1]
+                    await asyncio.sleep(delay)
+                ap = await self._spawn(entry)
+
+        # The handshake's method list is the dispatch table: an unknown method
+        # is refused here, from the registration, not discovered by timeout.
+        if entry.methods and method not in entry.methods:
+            raise RuntimeError(
+                f"app '{app_id}' registers no method '{method}' "
+                f"(has: {', '.join(entry.methods) or 'none'})"
+            )
+
+        ap.last_used = time.monotonic()
+        call_id = ap.next_id()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        ap.pending[call_id] = fut
+        await self._send(ap, {
+            "jsonrpc": "2.0", "id": call_id, "method": "invoke",
+            "params": {"method": method, "args": args or {}},
+        })
+        try:
+            msg = await asyncio.wait_for(fut, timeout_s)
+        except asyncio.TimeoutError:
+            ap.pending.pop(call_id, None)
+            raise RuntimeError(
+                f"'{app_id}.{method}' timed out after {timeout_s:.0f}s; "
+                f"stderr: {ap.stderr_tail[-400:] or '(quiet)'}"
+            ) from None
+        if "error" in msg:
+            raise RuntimeError(str((msg["error"] or {}).get("message", "backend error")))
+        return msg.get("result")
+
+    # ── reaping ─────────────────────────────────────────────────────────
+
+    def _ensure_reaper(self) -> None:
+        if self._reaper is None or self._reaper.done():
+            self._reaper = asyncio.create_task(self._reap_loop())
+
+    async def _reap_loop(self) -> None:
+        while self.procs:
+            await asyncio.sleep(60)
+            now = time.monotonic()
+            for app_id, ap in list(self.procs.items()):
+                if now - ap.last_used > _IDLE_REAP_S and not ap.pending:
+                    ap.entry.state = "reaped"
+                    logger.info(f"app backend idle, reaping: {app_id}")
+                    with contextlib_suppress():
+                        ap.proc.terminate()
+
+    async def shutdown(self) -> None:
+        for ap in list(self.procs.values()):
+            ap.entry.state = "reaped"
+            with contextlib_suppress():
+                ap.proc.terminate()
+
+
+class contextlib_suppress:
+    """``contextlib.suppress(Exception)`` without the import noise."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return True

--- a/pantheon/endpoint/core.py
+++ b/pantheon/endpoint/core.py
@@ -12,6 +12,7 @@ from pantheon.settings import get_settings
 from pantheon.toolset import tool
 from pantheon.toolsets.file_transfer import FileTransferToolSet
 from pantheon.utils.log import log_startup_profile, logger
+from .apps import AppSupervisor
 from .mcp import MCPManager
 from .toolsets import ToolSetManager
 from .mcp import MCPServerConfig
@@ -68,6 +69,11 @@ class Endpoint(FileTransferToolSet):
         # Convert to absolute path BEFORE chdir to avoid path resolution issues
         workspace_path = str(Path(workspace_path).resolve())
         Path(workspace_path).mkdir(parents=True, exist_ok=True)
+
+        # App backends (Atrium packaged apps): supervised subprocesses,
+        # spawned lazily by app_call. Constructed here because the workspace
+        # path is what scopes their registry.
+        self._app_supervisor = AppSupervisor(self, Path(workspace_path))
 
         # Switch to workspace directory for this Endpoint instance
         os.chdir(workspace_path)
@@ -403,6 +409,50 @@ class Endpoint(FileTransferToolSet):
         return method
 
     # ===== ToolSet Management (delegated to ToolSetManager) =====
+
+    @tool
+    async def app_call(
+        self,
+        app_id: str,
+        method: str,
+        args: dict | None = None,
+        timeout_s: float = 120.0,
+    ) -> dict:
+        """Call a method on an installed Atrium app's backend.
+
+        The backend runs in its own supervised subprocess (see
+        ``endpoint/apps.py``); this is the dispatch table the app-spec's §6
+        describes, spelled as arguments rather than a munged method name.
+        Spawns lazily on first use.
+
+        Args:
+            app_id: The app's manifest id, e.g. "viv".
+            method: A method the backend registered via ``@ctx.method``.
+            args: Keyword arguments for the method.
+            timeout_s: How long the call may run — conversions take a while.
+
+        Returns:
+            {"success": True, "result": ...} or {"success": False, "error": ...}.
+        """
+        try:
+            result = await self._app_supervisor.call(app_id, method, args, timeout_s)
+            return {"success": True, "result": result}
+        except Exception as e:  # noqa: BLE001 — the browser needs the reason
+            return {"success": False, "error": str(e)}
+
+    @tool
+    async def app_registry(self) -> dict:
+        """The installed Atrium apps and their registration state.
+
+        Rescans the install scopes on every call — an install is a file
+        write, and a cached registry is how it goes stale. Includes each
+        app's lifecycle state and, once its backend has handshaken, the
+        methods it registered.
+        """
+        try:
+            return {"success": True, "apps": self._app_supervisor.scan()}
+        except Exception as e:  # noqa: BLE001
+            return {"success": False, "error": str(e)}
 
     @tool
     async def services_ready(self) -> bool:


### PR DESCRIPTION
The Atrium app runtime's cut 2, endpoint half (pantheon-atrium `docs/app-spec.md`, frozen v1 §5–§6). An installed Atrium app may ship a Python backend; it runs in **its own subprocess**, spawned lazily and supervised by the project endpoint. The endpoint runs no app code — nothing an app does can take down routing, the file panel, or another app. Same ladder as ChatRoom spawning the endpoint and the Python toolset moving user code into a Jupyter kernel: the failure domain moves, the state does not.

## What's in it

- **`pantheon/endpoint/apps.py`** — `AppSupervisor`: scans the install scopes (`<workspace>/.pantheon/apps` → `~/.pantheon/apps` → factory templates, first per id), spawns backends lazily, speaks line-delimited JSON-RPC over the child's stdio, reaps idle processes (10 min), backs off on crashes ([1,2,4,8,16]s, 5 tries, then parked with the stderr tail as the reason).
- **`pantheon/endpoint/app_runtime.py`** — the child bootstrap. **Stdlib-only, by path, deliberately**: the interpreter comes from the manifest (`caps.python.env`, resolved against the conda env roots) and a conda analysis env has no `pantheon` package to import. Imports the app's `backend/`, runs `register(ctx)`, serves the pipe. `AppContext` = `workspace` / `@method` / `serve()` (answered by the endpoint's live_view data server) / `state` (JSON KV under `.pantheon/app-state/<id>/`, outside the package dir so resync and uninstall cannot eat it) / `log`.
- **`core.py`** — two new tools: `app_call(app_id, method, args, timeout_s)` (the dispatch; refuses methods the handshake never registered — `unknown method` comes from the registration table, never from a timeout) and `app_registry()` (rescans on every call; an install is a file write and a cached registry is how it goes stale).

## The registration mechanism

scan → REGISTERED entries before any process exists; handshake → the methods `register(ctx)` collected become the entry's callable surface; dispatch → refusal from the table; lifecycle → `registered → spawning → ready → reaped`, or `crashed(n) → failed`.

## Verification

Smoke-tested end to end without a pod (child and supervisor halves, stub endpoint): handshake + method registration, invoke with interleaved `ctx.log`, `ctx.serve` round trip, error crossing, dispatch-table refusal, clean shutdown, state surviving restart, and `kill -9` → backoff → respawn. First real consumer is Atrium's packaged Viv (`apps/viv/backend/` — the OME conversion moving out of the shell), already merged on the Atrium side and gated on this landing.

No behaviour change for anything that does not call the two new tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn