### PR TITLE
fix(endpoint): app upgrades become visible without an endpoint restart

### DIFF
--- a/pantheon/endpoint/apps.py
+++ b/pantheon/endpoint/apps.py
@@ -152,7 +152,12 @@ class AppSupervisor:
                     continue
                 prev = self.entries.get(app_id)
                 if prev and prev.dir == app_dir:
-                    found[app_id] = prev  # keep live state across scans
+                    # Keep live state (process, crash count) across scans — but
+                    # the manifest follows the FILE. Keeping the old dict meant
+                    # an upgrade that added a backend was invisible until the
+                    # endpoint restarted, however many rescans ran.
+                    prev.manifest = manifest
+                    found[app_id] = prev
                 else:
                     found[app_id] = AppEntry(app_id, app_dir, scope, manifest)
         self.entries = found
@@ -309,7 +314,11 @@ class AppSupervisor:
         if not self.entries:
             self.scan()
         entry = self.entries.get(app_id)
-        if entry is None:
+        # Rescan for an unknown id — and equally for a known entry that
+        # declares no backend: an install or upgrade may have grown one since
+        # the last scan, and without the rescan that stale entry errors on
+        # every call until something else happens to poke app_registry.
+        if entry is None or not entry.manifest.get("entry", {}).get("backend"):
             self.scan()
             entry = self.entries.get(app_id)
         if entry is None:


### PR DESCRIPTION
Two stale-registry holes, surfaced by the first real h5ad→Vitessce open racing the dev sync:

1. **scan() never re-read manifests.** A same-dir known app kept its whole previous \`AppEntry\` — manifest included — to preserve live process state. An upgrade that added a backend stayed invisible until the endpoint restarted, regardless of how many \`app_registry\` rescans ran. Live state still carries over; the manifest now follows the file.
2. **call() rescanned only for unknown ids.** A known entry without a backend now also triggers one rescan before refusing.

Observed on staging: vitessce's manifest grew \`entry.backend\` via dev sync moments after the supervisor first scanned it; every subsequent \`app_call\` refused with \`app 'vitessce' declares no backend\` even though the file on disk declared one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn