### PR TITLE
feat(endpoint): handshake carries method signatures and docs

### DIFF
--- a/pantheon/endpoint/app_runtime.py
+++ b/pantheon/endpoint/app_runtime.py
@@ -161,7 +161,34 @@ async def main() -> int:
         _out({"ready": False, "error": f"{type(e).__name__}: {e}"})
         return 1
 
-    _out({"ready": True, "api": 1, "methods": sorted(ctx._methods)})
+    def _method_info(name, fn):
+        """Signature + first doc line, best-effort — the Interfaces UI's food."""
+        info = {"name": name, "params": [], "doc": ""}
+        try:
+            import inspect
+            for pname, param in inspect.signature(fn).parameters.items():
+                if pname in ("self", "ctx"):
+                    continue
+                entry = {"name": pname}
+                if param.annotation is not inspect.Parameter.empty:
+                    ann = param.annotation
+                    entry["type"] = getattr(ann, "__name__", None) or str(ann)
+                if param.default is not inspect.Parameter.empty:
+                    entry["default"] = repr(param.default)
+                info["params"].append(entry)
+            doc = inspect.getdoc(fn) or ""
+            info["doc"] = doc.strip().split("\n")[0][:200]
+        except Exception:
+            pass
+        return info
+
+    _out({
+        "ready": True, "api": 1,
+        "methods": sorted(ctx._methods),
+        # Names alone say nothing; the desktop's Interfaces view shows the
+        # agent-callable surface with signatures and one-line docs.
+        "methods_info": [_method_info(n, f) for n, f in sorted(ctx._methods.items())],
+    })
 
     async def handle(msg: dict) -> None:
         mid = msg.get("id")

--- a/pantheon/endpoint/apps.py
+++ b/pantheon/endpoint/apps.py
@@ -242,6 +242,7 @@ class AppSupervisor:
             ) from e
 
         entry.methods = [str(m) for m in hello.get("methods", [])]
+        entry.methods_info = [m for m in hello.get("methods_info", []) if isinstance(m, dict)]
         entry.state = "ready"
         entry.last_error = ""
         ap.reader_task = asyncio.create_task(self._read_loop(ap))


### PR DESCRIPTION
app_registry exposed method names only. The desktop's new per-app Interfaces view needs the callable surface: each backend method's parameters (name/annotation/default via inspect) and first docstring line now ride the handshake as \`methods_info\`, stored on the entry, exposed through describe(). Back-compatible — \`methods\` unchanged, older children simply omit the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn