### PR TITLE
fix(endpoint): methods_info actually reaches app_registry

### DIFF
--- a/pantheon/endpoint/apps.py
+++ b/pantheon/endpoint/apps.py
@@ -68,6 +68,7 @@ class AppEntry:
     manifest: dict
     state: str = "registered"  # registered|spawning|ready|failed
     methods: list[str] = field(default_factory=list)
+    methods_info: list[dict] = field(default_factory=list)
     crashes: int = 0
     last_error: str = ""
 
@@ -78,6 +79,7 @@ class AppEntry:
             "scope": self.scope,
             "state": self.state,
             "methods": list(self.methods),
+            "methods_info": list(self.methods_info),
             "actions": self.manifest.get("actions", []),
             "opens": self.manifest.get("opens", []),
             "error": self.last_error or None,


### PR DESCRIPTION
#171 landed the handshake and the storage assignment but dropped the AppEntry field + describe() emission — methods_info was stored and then omitted from every app_registry answer. Two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn