### PR TITLE
feat: the desktop plane is the agent's one UI mechanism

### DIFF
--- a/pantheon/factory/templates/skills/desktop/SKILL.md
+++ b/pantheon/factory/templates/skills/desktop/SKILL.md
@@ -1,0 +1,79 @@
+---
+id: desktop
+name: Atrium Desktop — driving apps
+description: |
+  Drive the user's Atrium desktop: open files in installed viewer apps
+  (Viv bioimages, Vitessce/Spatial 3D omics, Mol* structures, IGV/Gosling
+  genomics, Volume 3D, Cytoscape, MSA, PhyloTree, RDKit), read and steer
+  ANY window — including ones the user opened — and call app backends.
+tags: [desktop, apps, visualization, interactive, atrium]
+---
+
+# The Atrium Desktop
+
+The user works on a desktop of windows. Apps are installed packages; each
+claims file types, exposes actions, may run its own Python backend, and
+ships a skill documenting its **state contract**. You drive all of it with
+five tools — the SAME windows the user sees and clicks.
+
+## The tools
+
+```python
+desktop_windows()
+# → every open window: window_id, app_id, title, path, actions, controllable
+
+desktop_open(path="/abs/path/to/file")          # like a double-click:
+# routes by extension, runs the app's own open pipeline (conversion,
+# backend prepare). Returns window_id. NEVER serve_local_data a file
+# just to view it — desktop_open does everything.
+
+desktop_open(app="viv", state={...})            # open on a state instead;
+# each app's skill documents its state shape
+
+desktop_read(window_id)                          # current state, skill-shaped
+desktop_update(window_id, patch)                 # deep-merge a state patch
+desktop_call(window_id, action, args={})         # run a named action
+desktop_call(window_id, "$close")                # close the window
+
+app_call(app_id, method, args={})                # an app's backend method,
+# in the app's own process. app_registry() lists live method signatures.
+```
+
+Windows the **user** opened are first-class: find them with
+`desktop_windows()`, then read/update/call exactly as if you opened them.
+
+## File routing (what opens what)
+
+| Extensions | App |
+|---|---|
+| .ome.tif/.ome.tiff/.ome.zarr/.zarr/.tif/.tiff | viv (Volume 3D also claims .zarr) |
+| .h5ad | vitessce (Spatial 3D as alternative) |
+| .pdb/.cif/.mmcif | molstar |
+| .nwk/.newick/.tree | phylotree |
+| .fasta/.fa/.aln | msa |
+| .sdf/.mol/.smi | rdkit |
+| .cyjs | cytoscape |
+
+## Each app's contract
+
+Every installed app ships its skill in the workspace:
+`.pantheon/apps/<app_id>/skill/SKILL.md` — read it (read_file) before
+driving an app with non-trivial state. It documents the state fields,
+actions, backend methods, and worked examples. `viv` is the reference
+example of the format.
+
+## Example — steer a window the user opened
+
+```python
+wins = desktop_windows()["result"]["windows"]
+tree = next(w for w in wins if w["app_id"] == "phylotree")
+desktop_update(tree["window_id"], {"layout": "radial"})
+```
+
+## Example — open and tune a bioimage
+
+```python
+w = desktop_open(path="/workspace/scan.tif")["result"]["window_id"]  # viv converts + opens
+state = desktop_read(w)["result"]["state"]         # see the auto-filled channels
+desktop_update(w, {"channels": [{**state["channels"][0], "color": [255, 0, 0]}]})
+```

--- a/pantheon/factory/templates/skills/live_view/SKILL.md
+++ b/pantheon/factory/templates/skills/live_view/SKILL.md
@@ -11,7 +11,15 @@ description: |
 tags: [live-view, visualization, vitessce, viv, bioimage, spatial, single-cell, interactive]
 ---
 
-# LiveView — Agent-Controllable UI Components
+# LiveView — DEPRECATED index (see the `desktop` skill)
+
+> **This mechanism is superseded.** The `live_view_*` tools are no longer
+> exposed; the same viewers are installed as Atrium desktop apps and driven
+> with `desktop_open` / `desktop_read` / `desktop_update` / `desktop_call`
+> (+ `app_call` for backends). Load the **`desktop`** skill. Each app's own
+> skill lives at `.pantheon/apps/<id>/skill/SKILL.md` in the workspace and
+> documents its state contract for the desktop tools. The per-viewer files
+> below remain as adapter sources and state references only.
 
 A **LiveView** is an interactive component the agent opens in the Pantheon
 UI's right sidebar, then drives and observes through the `live_view` tools.

--- a/pantheon/factory/templates/teams/default.md
+++ b/pantheon/factory/templates/teams/default.md
@@ -23,7 +23,7 @@ leader:
     - integrated_notebook
     - web
     - evolution
-    - live_view
+    - desktop
     - think
 ---
 
@@ -121,22 +121,31 @@ call_agent("researcher", "Search the web for best practices on X. Gather informa
 **Delegate for:** Schematic diagrams, conceptual illustrations, architecture diagrams, publication-quality figures — tasks where the output is a conceptual diagram, not a data-driven chart.
 **Execute directly (or via Researcher):** Data visualizations, statistical plots, charts derived from analysis results.
 
-### Interactive UI → Live View
+### Interactive visualization → Desktop apps
 
-When the user asks for an **interactive component, app, widget, dashboard,
-or a visualization they can manipulate** — a counter, a plot they click, a
-control panel, a data browser — build it as a **LiveView**: load the
-`live_view` skill and open it with `open_live_view` so it renders live in
-the sidebar and you can drive it and read it back. This is the default for
-anything interactive, even when the user does not say "live view". Do NOT
-write a standalone `.html` file for this — that is only right when the user
-explicitly wants a file to download or open separately.
+The user works on an Atrium desktop with installed viewer apps (Viv for
+bioimages, Vitessce and Spatial 3D for single-cell/spatial omics, Mol* for
+structures, IGV/Gosling for genomics, Volume 3D, Cytoscape, MSA, PhyloTree,
+RDKit). When the user asks to SEE or explore data interactively, drive
+those apps with the `desktop` tools — load the `desktop` skill first:
+
+- `desktop_open(path=...)` opens a file in the right app, exactly like a
+  double-click — the app's own pipeline handles conversion; never
+  serve_local_data a file just to view it.
+- `desktop_open(app=..., state=...)` opens an app on a state (each app's
+  skill documents its state contract).
+- `desktop_windows()` lists every open window — including ones the USER
+  opened; `desktop_read` / `desktop_update` / `desktop_call` drive any of
+  them. `app_call(app_id, method, args)` runs an app's backend methods.
+
+Do NOT write a standalone `.html` file for interactive views — that is
+only right when the user explicitly wants a downloadable file.
 
 ### Decision Summary
 
 | Task Type | Action |
 |---|---|
-| Interactive component / app / widget / manipulable viz | **Build as a LiveView** (`open_live_view`) |
+| Interactive / manipulable visualization | **Drive a desktop app** (`desktop_open` / `desktop_update`) |
 | Explore/read/understand codebase | **MUST delegate** to researcher |
 | Web search or documentation lookup | **MUST delegate** to researcher |
 | Data analysis or research | **MUST delegate** to researcher |

--- a/pantheon/toolsets/live_view/toolset.py
+++ b/pantheon/toolsets/live_view/toolset.py
@@ -98,7 +98,15 @@ class LiveViewSession:
 
 
 class LiveViewToolSet(ToolSet):
-    """Toolset for opening and controlling agent-driven UI components."""
+    """The desktop plane: the agent's hands and eyes on Atrium windows.
+
+    Agent-facing surface: desktop_windows / desktop_open / desktop_read /
+    desktop_update / desktop_call (+ serve_local_data and the generic data
+    endpoints). The legacy live_view_* tools are hidden from agents
+    (exclude=True) — they drove the old Pantheon-UI sidebar; Atrium windows
+    are the one mechanism now — but remain callable so existing UI paths and
+    old transcripts keep working.
+    """
 
     def __init__(self, name: str = "live_view", **kwargs):
         super().__init__(name, **kwargs)
@@ -213,7 +221,7 @@ class LiveViewToolSet(ToolSet):
 
     # ── agent-facing tools ────────────────────────────────────────────────
 
-    @tool
+    @tool(exclude=True)  # superseded by the desktop plane; UI/back-compat only
     async def open_live_view(
         self,
         view_type: str,
@@ -315,7 +323,7 @@ class LiveViewToolSet(ToolSet):
         logger.info("live_view: opened {} ({}) for chat {}", view_id, view_type, chat_id)
         return {"success": True, "view_id": view_id, "state": session.snapshot()}
 
-    @tool
+    @tool(exclude=True)  # superseded by the desktop plane; UI/back-compat only
     async def live_view_update(self, view_id: str, patch: dict) -> dict:
         """Apply a partial-state patch to an open LiveView (drive the component).
 
@@ -349,7 +357,7 @@ class LiveViewToolSet(ToolSet):
         })
         return {"success": True, "state": session.snapshot()}
 
-    @tool
+    @tool(exclude=True)  # superseded by the desktop plane; UI/back-compat only
     async def live_view_set_state(self, view_id: str, state: dict) -> dict:
         """Replace an open LiveView's whole state.
 
@@ -377,7 +385,7 @@ class LiveViewToolSet(ToolSet):
         })
         return {"success": True, "state": session.snapshot()}
 
-    @tool
+    @tool(exclude=True)  # superseded by the desktop plane; UI/back-compat only
     async def live_view_call(self, view_id: str, action: str, args: dict = {}) -> dict:
         """Invoke a named action the component exposes, and wait for its result.
 
@@ -421,7 +429,7 @@ class LiveViewToolSet(ToolSet):
         finally:
             self._pending_actions.pop(action_id, None)
 
-    @tool
+    @tool(exclude=True)  # superseded by the desktop plane; UI/back-compat only
     async def live_view_get_state(self, view_id: str) -> dict:
         """Read an open LiveView's current state, status, and diagnostics.
 
@@ -449,7 +457,7 @@ class LiveViewToolSet(ToolSet):
             return {"success": False, "error": str(e)}
         return {"success": True, "state": session.snapshot()}
 
-    @tool
+    @tool(exclude=True)  # superseded by the desktop plane; UI/back-compat only
     async def live_view_screenshot(self, view_id: str) -> dict:
         """Capture what an open LiveView currently looks like, as an image.
 
@@ -746,7 +754,7 @@ class LiveViewToolSet(ToolSet):
         except ValueError:
             return False
 
-    @tool
+    @tool(exclude=True)  # superseded by the desktop plane; UI/back-compat only
     async def list_live_views(self) -> dict:
         """List the LiveViews currently open in this chat."""
         chat_id = self._chat_id()
@@ -756,7 +764,7 @@ class LiveViewToolSet(ToolSet):
         ]
         return {"success": True, "views": views}
 
-    @tool
+    @tool(exclude=True)  # superseded by the desktop plane; UI/back-compat only
     async def close_live_view(self, view_id: str) -> dict:
         """Close an open LiveView and remove its sidebar tab.
 


### PR DESCRIPTION
Two UI mechanisms confused the agent. live_view_* tools are now hidden from agents (UI/back-compat intact), the default team prompt teaches the desktop tools, a new desktop meta skill documents the model, and the live_view index is deprecated with a pointer. The viv package's skill (pantheon-atrium) is rewritten as the reference contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn