### PR TITLE
fix(teams): restore the live_view toolset entry — desktop tools live inside it

### DIFF
--- a/pantheon/factory/templates/teams/default.md
+++ b/pantheon/factory/templates/teams/default.md
@@ -23,7 +23,7 @@ leader:
     - integrated_notebook
     - web
     - evolution
-    - desktop
+    - live_view
     - think
 ---
 


### PR DESCRIPTION
#175 mistook the leader's toolsets list for a skills list and renamed live_view→desktop; no toolset registers under that name, so the leader silently lost the entire toolset — the new desktop_* tools included. Restore the entry; the internal toolset name stays (UI proxy calls depend on it), and agents only ever see tool names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn