### PR TITLE
feat(desktop): desktop_apps — the agent can see what is installed

### DIFF
--- a/pantheon/factory/templates/skills/desktop/SKILL.md
+++ b/pantheon/factory/templates/skills/desktop/SKILL.md
@@ -19,6 +19,11 @@ five tools — the SAME windows the user sees and clicks.
 ## The tools
 
 ```python
+desktop_apps()
+# → what is INSTALLED: app_id, name, description, opens, actions, backend,
+#   skill path. Use it to name an app explicitly or to see what opens a
+#   given file type — never guess an app_id.
+
 desktop_windows()
 # → every open window: window_id, app_id, title, path, actions, controllable
 
@@ -41,6 +46,14 @@ app_call(app_id, method, args={})                # an app's backend method,
 
 Windows the **user** opened are first-class: find them with
 `desktop_windows()`, then read/update/call exactly as if you opened them.
+
+## Choosing the app
+
+`desktop_open(path=...)` picks the app that claims the extension — the
+same routing a double-click uses. **Name it explicitly** when you want a
+particular viewer (the file has more than one candidate, or the user asked
+for one): `desktop_open(app="spatial3d", path="cells.h5ad")`. `desktop_apps()`
+gives you the exact ids.
 
 ## File routing (what opens what)
 

--- a/pantheon/toolsets/live_view/toolset.py
+++ b/pantheon/toolsets/live_view/toolset.py
@@ -1026,6 +1026,21 @@ class LiveViewToolSet(ToolSet):
             self._pending_desktop.pop(request_id, None)
 
     @tool
+    async def desktop_apps(self) -> dict:
+        """List the apps installed on the user's desktop — what you can open.
+
+        Each entry: `app_id` (what desktop_open's `app` takes), `name`,
+        `description`, `opens` (file extensions it claims), `actions`
+        (names for desktop_call), `backend` (whether app_call reaches a
+        backend process), and `skill` (the path of the doc describing its
+        state contract — read_file it before driving anything non-trivial).
+
+        Call this when you need to name an app explicitly, or to see what
+        can open a given file type.
+        """
+        return await self._desktop_request("desktop.apps", {})
+
+    @tool
     async def desktop_windows(self) -> dict:
         """List every window on the user's desktop — whoever opened it.
 


### PR DESCRIPTION
The agent could always name an app via desktop_open(app=...), but had no way to discover which apps exist or what ids they use — so it guessed and looped. desktop_apps() returns the installed apps (id, name, description, opens, actions, backend, skill path); the desktop skill now teaches discovery first. Atrium answers desktop.apps from its registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn