### PR TITLE
feat(desktop): the toolset learns the virtual desktops

### DIFF
--- a/pantheon/toolsets/live_view/toolset.py
+++ b/pantheon/toolsets/live_view/toolset.py
@@ -1044,6 +1044,11 @@ class LiveViewToolSet(ToolSet):
     async def desktop_windows(self) -> dict:
         """List every window on the user's desktop — whoever opened it.
 
+        The desktop has virtual spaces (mac-style, numbered from 1): the
+        top-level `active_space` / `space_count` describe them, and each
+        window carries its `space`. Focusing or opening a window on another
+        space carries the user there.
+
         Each entry: `window_id`, `app_id` (manifest id for packaged apps),
         `name`, `title`, `path` (the file it shows, when opened on one),
         `controllable` (whether desktop_read/update/call can drive it — true


### PR DESCRIPTION
Atrium grew mac-style virtual desktops; the agent surface catches up: desktop_windows reports active_space/space_count + per-window space, desktop_open takes space (0=current, past-the-end mints a new desktop), desktop_call gains $move_to_space. Skill updated; Atrium answers the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn