### PR TITLE
feat(desktop): let the agent author apps — desktop_open(module=…) + skill

### DIFF
--- a/pantheon/factory/templates/skills/desktop/SKILL.md
+++ b/pantheon/factory/templates/skills/desktop/SKILL.md
@@ -118,3 +118,76 @@ w = desktop_open(path="/workspace/scan.tif")["result"]["window_id"]  # viv conve
 state = desktop_read(w)["result"]["state"]         # see the auto-filled channels
 desktop_update(w, {"channels": [{**state["channels"][0], "color": [255, 0, 0]}]})
 ```
+
+# Building your own app
+
+When no installed app fits, BUILD one. There are two paths — a quick
+bespoke window, and a real installed package.
+
+## A. Bespoke window (fast, no install)
+
+Pass a frontend module SOURCE to `desktop_open(module=…)`. It opens with no
+manifest and no install, and is drivable with the same
+desktop_read/update/set/call. The module is one function:
+
+```python
+desktop_open(module='''
+export function setup(app, root) {
+  // render only in onState; mutate only through setState — ONE state path.
+  app.onState((s) => {
+    root.innerHTML = `<div style="font:20px sans-serif;padding:24px">
+      count: ${s.n ?? 0}
+      <button id="inc">+1</button></div>`
+    root.querySelector("#inc").onclick = () => app.setState({ n: (s.n ?? 0) + 1 })
+  })
+  // an action the AGENT (or a menu) can call — same handler as any UI click
+  app.defineAction("bump", () => { const n = (app.state?.n ?? 0) + 1; app.setState({ n }); return n })
+  app.ready()
+}
+''', state={"n": 5}, title="Counter")
+# → window_id; then desktop_call(window_id, "bump") or desktop_read/set it.
+```
+
+The bridge `app` gives: `onState(cb)` / `setState(patch)` / `emitState(full)`
+/ `state`, `defineAction(name, fn)`, `onSnapshot(fn)`, `ready()` / `fail(msg)`,
+`fs.read/write/ls(path)` (workspace files), `window.setTitle/close`. It runs
+in a sandboxed iframe — bundle any framework you like, but keep the module
+self-contained. (This replaces the retired `open_live_view`; do NOT use
+`live_view_*` tools.)
+
+## B. Installed package (reusable, claims file types, may have a backend)
+
+Write a package under `.pantheon/apps/<id>/` with ordinary file tools — a
+file write IS the install (workspace scope), discovered on the next
+`desktop_open`:
+
+```
+.pantheon/apps/<id>/
+  atrium.json          # manifest (below)
+  frontend/index.js    # export function setup(app, root)  — same contract as A
+  backend/__init__.py  # optional: def register(ctx): @ctx.method async def …
+  skill/SKILL.md       # optional: how you (the agent) drive it later
+```
+
+Minimal `atrium.json`:
+
+```json
+{
+  "id": "my-app",
+  "name": "My App",
+  "version": "0.1.0",
+  "atriumApi": 1,
+  "surface": "dom",
+  "entry": { "frontend": "frontend/index.js" },
+  "launcher": true,
+  "icon": { "path": "assets/icon.svg", "tint": "#5b6ee0" },
+  "opens": [".myext"],
+  "actions": [{ "name": "bump", "description": "increment", "params": {} }]
+}
+```
+
+Then `desktop_open(app="my-app")` (a just-written app is re-scanned on the
+open that misses, so no reconnect needed). A backend method is reached from
+the frontend with `app.call("methodName", args)` and from you with
+`app_call(app_id="my-app", method="methodName", args={…})`. Prefer path A
+for a one-off; path B when the user will reuse it or it needs a backend.

--- a/pantheon/factory/templates/skills/live_view/live-view-app.md
+++ b/pantheon/factory/templates/skills/live_view/live-view-app.md
@@ -1,19 +1,33 @@
 ---
 id: live_view_app
-name: Generate an Agent-Controllable LiveView App
+name: Generate an Agent-Controllable App — DEPRECATED
 description: |
-  Write a custom interactive visualization component that the agent can
-  open, drive, and observe — using the LiveView SDK. Covers the SDK API,
-  the component contract, how to serve and open it, and how the agent
-  drives it via live_view_update / live_view_call.
-tags: [live-view, sdk, custom-component, visualization, interactive, generate-app]
+  DEPRECATED. The live_view_* tools (open_live_view, live_view_call…) are no
+  longer exposed. To build a bespoke app now, use desktop_open(module=…) or
+  a package under .pantheon/apps/ — see the `desktop` skill, "Building your
+  own app". This file is kept only for the setup(app, root) contract, which
+  is unchanged.
+tags: [deprecated, desktop, generate-app]
 ---
 
-# Generating an Agent-Controllable LiveView App
+# DEPRECATED — build apps with the `desktop` skill
 
-When no existing viewer fits, write your own interactive component. With the
-**LiveView SDK** the component is controllable-by-construction: the agent
-drives it and reads it back, with no extra wiring.
+> **This mechanism is retired.** `open_live_view` / `live_view_*` are no
+> longer exposed to the agent. Build a bespoke window with
+> `desktop_open(module="export function setup(app, root){…}", state=…)`, or a
+> reusable package under `.pantheon/apps/<id>/`. Both are documented in the
+> **`desktop` skill → "Building your own app"**. The `setup(app, root)`
+> component contract below is unchanged and still describes what to write —
+> only the open/drive tools differ (desktop_open / desktop_call, not
+> live_view_*).
+
+---
+
+<details><summary>Historical LiveView authoring notes (contract only)</summary>
+
+When no existing viewer fits, write your own interactive component. The
+component is controllable-by-construction: the agent drives it and reads it
+back, with no extra wiring.
 
 Use this for bespoke dashboards, custom plots, tailored data views. **First
 check the existing viewer skills — a custom build is the last resort, not the
@@ -324,3 +338,5 @@ selection; `live_view_get_state(view_id)` shows which point the user clicked.
   commands as actions, and have those actions call `lv.setState`.
 - The component runs in a sandboxed iframe; it can fetch CORS-enabled URLs
   (use `serve_local_data` for workspace files) and import CDN libraries.
+
+</details>

--- a/pantheon/toolsets/live_view/toolset.py
+++ b/pantheon/toolsets/live_view/toolset.py
@@ -1064,6 +1064,7 @@ class LiveViewToolSet(ToolSet):
     @tool
     async def desktop_open(
         self, app: str = "", path: str = "", state: dict = {}, window_id: str = "",
+        module: str = "", title: str = "",
     ) -> dict:
         """Open an app window on the desktop, the way a double-click would.
 
@@ -1083,14 +1084,57 @@ class LiveViewToolSet(ToolSet):
             state: initial state instead of / merged over a file, for apps
                 driven by state (the contract each app's skill documents).
             window_id: show it in THIS existing window instead of a new one.
+            module: a frontend ES-module SOURCE you wrote —
+                `export function setup(app, root) { … }` — to open as a BESPOKE
+                window with no install and no manifest. The app gets the full
+                bridge (app.onState / setState / defineAction / onSnapshot /
+                fs) and is drivable with desktop_read / update / set / call
+                exactly like a packaged app. This is the fast path for a
+                one-off UI. For something reusable, write a package under
+                `.pantheon/apps/<id>/` and open it by `app` id instead. (This
+                replaces the retired open_live_view custom path.)
+            title: window title, used with `module`.
 
         Returns `window_id`, and `reused: true` when it landed in a window
         that was already showing that file.
         """
+        if module:
+            url = await self._serve_bespoke_module(module)
+            if not url:
+                return {
+                    "success": False,
+                    "error": (
+                        "the data server has no browser-reachable URL for the "
+                        "module yet (tunnel not delivered) — try again shortly"
+                    ),
+                }
+            return await self._desktop_request("desktop.open", {
+                "app": "", "path": "", "state": state or {},
+                "window_id": window_id, "module_url": url,
+                "title": title or "Agent app",
+            }, timeout=90.0)
         return await self._desktop_request(
             "desktop.open",
             {"app": app, "path": path, "state": state or {}, "window_id": window_id},
             timeout=120.0)
+
+    async def _serve_bespoke_module(self, source: str) -> str | None:
+        """Write an agent-authored frontend module to the workspace and serve
+        it, returning a browser-reachable URL (or None if unservable).
+
+        Written as `.jsx` so the app host transpiles it (Sucrase) — valid for
+        plain JS too, so the agent can use JSX without a build step.
+        """
+        import hashlib
+        from pantheon.settings import get_settings
+
+        slug = hashlib.sha1(source.encode("utf-8")).hexdigest()[:12]
+        bespoke_dir = get_settings().work_dir / ".pantheon" / "bespoke"
+        bespoke_dir.mkdir(parents=True, exist_ok=True)
+        mod_path = (bespoke_dir / f"{slug}.jsx").resolve()
+        mod_path.write_text(source, encoding="utf-8")
+        server = await self._ensure_data_server()
+        return server.url_for(mod_path)
 
     @tool
     async def desktop_set(self, window_id: str, state: dict) -> dict:


### PR DESCRIPTION
## What

Closes the "agent can drive apps but can't ergonomically **build** one" gap. The architecture already lets an agent install a workspace app by writing files (workspace scope is "the agent, automatically"), but the fast ephemeral path was retired-and-excluded (`open_live_view`) and no skill taught authoring. **live_view stays retired** — this routes everything through the current `desktop.*` surface.

## Pod (this PR)

- **`desktop_open(module=…, title=…)`** — pass a frontend ES-module SOURCE (`export function setup(app, root){…}`) and it opens as a **bespoke window**: no manifest, no install, drivable by `desktop_read/update/set/call` like any packaged app. The pod writes it under `.pantheon/bespoke/`, serves it via the data server, and emits `desktop.open` with the `module_url`. This replaces `open_live_view`'s custom path (which stays `@tool(exclude=True)`).
- **desktop skill → "Building your own app"** — path A (bespoke `desktop_open(module=…)`) and path B (a package under `.pantheon/apps/<id>/`, where a file write *is* the install), with the `setup(app,root)` bridge contract and a minimal `atrium.json`.
- **`live-view-app.md` marked DEPRECATED**, pointing at the desktop skill; the `setup()` contract is preserved in a `<details>` block.

## Shell (companion, in pantheon-atrium, already merged)

- Bespoke open: `desktop.open` with `module_url` → `agent-view` window under the same WindowBridge.
- **Re-discover on miss**: `desktop_open` of an unknown id re-scans `.pantheon/apps` once before erroring — a just-written app opens without a reconnect.
- **Init-state race fix**: the app-host's boot-time `init` could lose the race against module load (confirmed: iframe `onState` never fired while the shell cache held the state); the bespoke branch re-pushes open-state once the window is READY.

## Verification

Headless against a live staging pod: author a `setup(app,root)` module (both `.js` and `.jsx`/Sucrase), open it, drive it — `desktop_call` runs the action, initial state arrives (n=5 → bump → 6), `desktop_read` round-trips. Full agent-in-chat e2e after this image builds + deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)