### PR TITLE
feat(browser): scroll metrics + scroll input for the UI scrollbar

### DIFF
--- a/pantheon/toolsets/live_view/browser.py
+++ b/pantheon/toolsets/live_view/browser.py
@@ -390,6 +390,11 @@ class BrowserEngine:
                     elif t == "wheel":
                         await page.mouse.move(ev["x"], ev["y"])
                         await page.mouse.wheel(ev.get("dx", 0), ev.get("dy", 0))
+                    elif t == "scroll":
+                        # Absolute scroll from the UI's scrollbar-thumb drag.
+                        await page.evaluate(
+                            "(y) => window.scrollTo(0, y)", ev.get("y", 0)
+                        )
                     elif t == "keydown":
                         await page.keyboard.down(ev["key"])
                     elif t == "keyup":
@@ -430,6 +435,18 @@ class BrowserEngine:
             "X-W": str(session.width),
             "X-H": str(session.height),
         }
+        # Scroll metrics for the UI's own scrollbar overlay — headless Chromium
+        # paints no native scrollbar, so the frontend draws one from these.
+        # `scrollY,scrollHeight,innerHeight`; cheap eval, only on repaints.
+        try:
+            m = await session.page.evaluate(
+                "() => [Math.round(scrollY),"
+                " Math.round(document.documentElement.scrollHeight),"
+                " Math.round(innerHeight)]"
+            )
+            headers["X-Scroll"] = f"{m[0]},{m[1]},{m[2]}"
+        except Exception:
+            pass
         # Report each spawned popup once, then forget it — the UI opens a tab.
         if session.pending_popups:
             headers["X-Popup"] = ",".join(session.pending_popups)

--- a/pantheon/toolsets/live_view/data_server.py
+++ b/pantheon/toolsets/live_view/data_server.py
@@ -72,7 +72,8 @@ async def _cors_middleware(request: web.Request, handler):
     # browser-frame response, and a bare "*" is NOT honoured for exposed
     # headers by browsers, so they must be listed explicitly.
     resp.headers["Access-Control-Expose-Headers"] = (
-        "X-Seq, X-Url, X-Title, X-Loading, X-Back, X-Fwd, X-Favicon, X-Popup, X-W, X-H"
+        "X-Seq, X-Url, X-Title, X-Loading, X-Back, X-Fwd, X-Favicon, X-Popup, "
+        "X-Scroll, X-W, X-H"
     )
     # Never let the browser cache anything this server returns. Two reasons:
     #  1. Viewer modules (adapter.js) are edited during development — an ES module


### PR DESCRIPTION
Headless Chromium renders no native scrollbar (confirmed: neither the CDP screencast nor Playwright's own screenshot shows one, and `::-webkit-scrollbar` CSS doesn't paint offscreen). So the Atrium Browser draws its own scrollbar overlay — this PR gives it the data and the control:

- **`status_headers`** adds `X-Scroll = "scrollY,scrollHeight,innerHeight"` (a cheap eval, only on repaints), listed in `Access-Control-Expose-Headers`.
- **`dispatch`** accepts `{t:"scroll", y}` → `window.scrollTo(0, y)` for thumb drags.

Frontend overlay (thumb sized/positioned from X-Scroll, draggable) is in pantheon-atrium (already merged). Forward-compatible: an older image without X-Scroll just shows no scrollbar; the page still scrolls by wheel.

Verified off-sandbox: `X-Scroll 0,9581,800` → `scroll(1500)` → `1500,9581,800`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)