### PR TITLE
feat(desktop): the pod owns the window session

### DIFF
--- a/pantheon/chatroom/stream.py
+++ b/pantheon/chatroom/stream.py
@@ -39,6 +39,30 @@ class NATSStreamAdapter:
         except Exception as e:
             logger.error(f"Error publishing stream: {e}")
 
+    async def publish_stream(self, stream_id: str, data: dict):
+        """Publish to a named stream that is NOT a chat.
+
+        The desktop is the pod's, not a conversation's: every viewport of this
+        pod listens on one stream regardless of which chat it has open, which
+        is what lets a window opened from one conversation show up in a
+        standalone desktop page that has none. Both ends derive the subject as
+        `<prefix>.pantheon.stream.<id>`, and the prefix is this pod's.
+        """
+        from pantheon.remote.backend.base import StreamMessage, StreamType
+
+        backend = await self._get_backend()
+        message = StreamMessage(
+            type=StreamType.CUSTOM,
+            session_id=stream_id,
+            timestamp=time.time(),
+            data=data,
+        )
+        channel = await backend.get_or_create_stream(stream_id, StreamType.CUSTOM)
+        try:
+            await channel.publish(message)
+        except Exception as e:
+            logger.error(f"Error publishing stream {stream_id}: {e}")
+
     def create_hooks(self, chat_id: str):
         """Create NATS hooks for chat() method
 

--- a/pantheon/toolsets/live_view/browser.py
+++ b/pantheon/toolsets/live_view/browser.py
@@ -390,6 +390,11 @@ class BrowserEngine:
                     elif t == "wheel":
                         await page.mouse.move(ev["x"], ev["y"])
                         await page.mouse.wheel(ev.get("dx", 0), ev.get("dy", 0))
+                    elif t == "scroll":
+                        # Absolute scroll from the UI's scrollbar-thumb drag.
+                        await page.evaluate(
+                            "(y) => window.scrollTo(0, y)", ev.get("y", 0)
+                        )
                     elif t == "keydown":
                         await page.keyboard.down(ev["key"])
                     elif t == "keyup":
@@ -430,6 +435,18 @@ class BrowserEngine:
             "X-W": str(session.width),
             "X-H": str(session.height),
         }
+        # Scroll metrics for the UI's own scrollbar overlay — headless Chromium
+        # paints no native scrollbar, so the frontend draws one from these.
+        # `scrollY,scrollHeight,innerHeight`; cheap eval, only on repaints.
+        try:
+            m = await session.page.evaluate(
+                "() => [Math.round(scrollY),"
+                " Math.round(document.documentElement.scrollHeight),"
+                " Math.round(innerHeight)]"
+            )
+            headers["X-Scroll"] = f"{m[0]},{m[1]},{m[2]}"
+        except Exception:
+            pass
         # Report each spawned popup once, then forget it — the UI opens a tab.
         if session.pending_popups:
             headers["X-Popup"] = ",".join(session.pending_popups)

--- a/pantheon/toolsets/live_view/data_server.py
+++ b/pantheon/toolsets/live_view/data_server.py
@@ -72,7 +72,8 @@ async def _cors_middleware(request: web.Request, handler):
     # browser-frame response, and a bare "*" is NOT honoured for exposed
     # headers by browsers, so they must be listed explicitly.
     resp.headers["Access-Control-Expose-Headers"] = (
-        "X-Seq, X-Url, X-Title, X-Loading, X-Back, X-Fwd, X-Favicon, X-Popup, X-W, X-H"
+        "X-Seq, X-Url, X-Title, X-Loading, X-Back, X-Fwd, X-Favicon, X-Popup, "
+        "X-Scroll, X-W, X-H"
     )
     # Never let the browser cache anything this server returns. Two reasons:
     #  1. Viewer modules (adapter.js) are edited during development — an ES module

--- a/pantheon/toolsets/live_view/desktop_session.py
+++ b/pantheon/toolsets/live_view/desktop_session.py
@@ -1,0 +1,359 @@
+"""The desktop session — one document, however many views are open on it.
+
+A desktop is not a page: it is a view onto THIS pod, which already owns the
+files, the processes and the installed apps. Which windows are open is a
+property of the machine, so the record of them belongs here rather than in
+whichever browser happens to be looking.
+
+Before this, each viewport kept its own window list and wrote the whole thing
+to `.pantheon/desktop.json` on a debounce, reading it back only at boot and
+only onto an empty desktop. Two viewports were therefore two writers with no
+reader between them: they took turns overwriting each other, neither ever saw
+the result, and the loser found out at the next reload. The sidebar panel and
+the popped-out page showed different desktops because, in every sense that
+mattered, they *were* different desktops.
+
+Now clients send INTENTS and this applies them. Every change bumps `seq` and
+goes out as a delta on a pod-scoped stream, so a viewport that misses one can
+tell (its own seq no longer follows) and ask for the whole document back
+rather than drifting. Ids are minted here, which retires an entire class of
+bug: a per-tab counter gave every copy its own `win-3`.
+
+What is deliberately NOT in here: which space a viewport is looking at, and
+which window has its keyboard focus. Those belong to the person, not the
+machine — sharing them would drag one viewer's screen around when another
+switched spaces, and make two people typing fight over one caret. Stacking
+order IS shared: that is a property of the arrangement, and one screen has
+only one of it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pantheon.utils.log import logger
+
+# The stream every viewport listens on. Pod-scoped, NOT per chat: a desktop is
+# the machine's, and tying its events to a conversation is what produced "the
+# desktop did not answer — is an Atrium window open on this chat?". Both sides
+# derive the subject as `<prefix>.pantheon.stream.<id>` and the prefix is the
+# pod's, so this reaches every viewport of this pod and no other.
+DESKTOP_STREAM = "desktop"
+
+RECORD = ".pantheon/desktop.json"
+
+# Windows the agent opens for its own purposes are not part of the desktop a
+# person comes back to: their module URLs are minted against a tunnel that
+# outlives nothing, and their sessions belong to the conversation.
+EPHEMERAL_APPS = {"agent-view"}
+
+MAX_SPACES = 6
+
+
+@dataclass
+class DesktopSession:
+    """Everything about the desktop that is the same in every view of it."""
+
+    seq: int = 0
+    # The desktop's own resolution. Viewports scale to fit it, so a window at
+    # x=1200 is the same place in a 660px panel and an 1800px page. A viewport
+    # may propose a larger one; see `propose_nominal`.
+    nominal_w: int = 1280
+    nominal_h: int = 800
+    spaces: int = 1
+    top_z: int = 10
+    windows: dict[str, dict[str, Any]] = field(default_factory=dict)
+    _next_id: int = 1
+
+    # ── serialisation ────────────────────────────────────────────────────
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "seq": self.seq,
+            "nominal_w": self.nominal_w,
+            "nominal_h": self.nominal_h,
+            "spaces": self.spaces,
+            "top_z": self.top_z,
+            "windows": self.windows,
+        }
+
+    def to_record(self) -> dict[str, Any]:
+        """What lands on the volume. Ephemeral windows are left out.
+
+        The id is carried INSIDE each window: the document keys by it, a JSON
+        list does not, and reading back a record whose windows have no id is
+        how a restart quietly loses every window on the desktop.
+        """
+        return {
+            "v": 2,
+            "nominal_w": self.nominal_w,
+            "nominal_h": self.nominal_h,
+            "spaces": self.spaces,
+            "next_id": self._next_id,
+            "windows": [
+                {**w, "id": wid} for wid, w in self.windows.items()
+                if w.get("app_id") not in EPHEMERAL_APPS
+            ],
+        }
+
+    @classmethod
+    def from_record(cls, data: dict[str, Any]) -> "DesktopSession":
+        s = cls()
+        if not isinstance(data, dict):
+            return s
+        if data.get("v") == 2:
+            s.nominal_w = int(data.get("nominal_w") or 1280)
+            s.nominal_h = int(data.get("nominal_h") or 800)
+            s.spaces = max(1, min(MAX_SPACES, int(data.get("spaces") or 1)))
+            s._next_id = max(1, int(data.get("next_id") or 1))
+            for w in data.get("windows") or []:
+                wid = str(w.get("id") or "")
+                if wid:
+                    s.windows[wid] = w
+                    s.top_z = max(s.top_z, int(w.get("z") or 0))
+            return s
+        # v1 — the browser's own record, a list of windows with no ids. Adopt
+        # it rather than dropping the user's layout on the floor at upgrade.
+        s.spaces = max(1, min(MAX_SPACES, int(data.get("spaces") or 1)))
+        for w in data.get("windows") or []:
+            app_id = str(w.get("appId") or "")
+            if not app_id or app_id in EPHEMERAL_APPS:
+                continue
+            s.windows[s._mint()] = _window(
+                s._next_id - 1, app_id, w.get("args") or {}, w.get("title") or app_id,
+                x=w.get("x"), y=w.get("y"), width=w.get("width"), height=w.get("height"),
+                space=w.get("space"), minimized=w.get("minimized"),
+                maximized=w.get("maximized"), fullscreen=w.get("fullscreen"),
+                z=s._bump_z(),
+            )
+        return s
+
+    # ── ids and stacking ─────────────────────────────────────────────────
+
+    def _mint(self) -> str:
+        wid = f"win-{self._next_id}"
+        self._next_id += 1
+        return wid
+
+    def _bump_z(self) -> int:
+        self.top_z += 1
+        return self.top_z
+
+
+def _window(
+    _n: int, app_id: str, args: dict, title: str, *, z: int,
+    x=None, y=None, width=None, height=None, space=None,
+    minimized=None, maximized=None, fullscreen=None, path: str = "",
+    opened_by: str = "",
+) -> dict[str, Any]:
+    return {
+        "app_id": app_id,
+        "title": title,
+        "path": path,
+        "args": args,
+        "x": int(x if x is not None else 80),
+        "y": int(y if y is not None else 64),
+        "width": int(width if width is not None else 720),
+        "height": int(height if height is not None else 460),
+        "space": int(space if space is not None else 1),
+        "z": z,
+        "minimized": bool(minimized),
+        "maximized": bool(maximized),
+        "fullscreen": bool(fullscreen),
+        "status": "opening",
+        "opened_by": opened_by,
+        "updated_seq": 0,
+    }
+
+
+class DesktopSessionStore:
+    """Owns the document, applies intents, and says what changed.
+
+    Every mutator returns `(ops, result)`: the ops go out as a delta, the
+    result goes back to whoever asked. Nothing here publishes or writes — the
+    toolset does both, so the reducer stays a pure function of the document
+    and is testable without a pod.
+    """
+
+    def __init__(self, work_dir: Path | None = None):
+        self.session = DesktopSession()
+        self._work_dir = work_dir
+        self._dirty = False
+        self._loaded = False
+
+    # ── persistence ──────────────────────────────────────────────────────
+
+    def load(self) -> None:
+        """Read the record once. A missing or broken one is an empty desktop."""
+        if self._loaded:
+            return
+        self._loaded = True
+        path = self._record_path()
+        if path is None or not path.exists():
+            return
+        try:
+            self.session = DesktopSession.from_record(json.loads(path.read_text()))
+            logger.info("desktop session restored: {} window(s)", len(self.session.windows))
+        except Exception as e:  # noqa: BLE001
+            logger.warning("desktop session record unreadable, starting empty: {}", e)
+
+    def save(self) -> None:
+        if not self._dirty:
+            return
+        path = self._record_path()
+        if path is None:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(self.session.to_record(), indent=1))
+            self._dirty = False
+        except Exception as e:  # noqa: BLE001
+            # A failed save costs one snapshot; a SILENT one costs the whole
+            # feature, invisibly. The browser's version shipped with that bug.
+            logger.warning("desktop session save failed: {}", e)
+
+    def _record_path(self) -> Path | None:
+        if self._work_dir is None:
+            try:
+                from pantheon.settings import get_settings
+
+                self._work_dir = Path(get_settings().work_dir)
+            except Exception:  # noqa: BLE001
+                return None
+        return self._work_dir / RECORD
+
+    # ── intents ──────────────────────────────────────────────────────────
+
+    def apply(self, kind: str, args: dict[str, Any]) -> tuple[list[dict], dict]:
+        handler = getattr(self, f"_do_{kind}", None)
+        if handler is None:
+            raise ValueError(f"unknown desktop intent '{kind}'")
+        ops, result = handler(args or {})
+        if ops:
+            self.session.seq += 1
+            for op in ops:
+                op["seq"] = self.session.seq
+            self._dirty = True
+        return ops, result
+
+    def _touch(self, wid: str) -> dict:
+        w = self.session.windows.get(wid)
+        if w is None:
+            raise KeyError(f"no window '{wid}'")
+        w["updated_seq"] = self.session.seq + 1
+        return w
+
+    def _upsert(self, wid: str) -> dict:
+        return {"op": "upsert", "id": wid, "window": self.session.windows[wid]}
+
+    def _do_open(self, a: dict) -> tuple[list[dict], dict]:
+        s = self.session
+        app_id = str(a.get("app_id") or "")
+        if not app_id:
+            raise ValueError("open needs an app_id")
+        wid = str(a.get("window_id") or "")
+        if wid and wid in s.windows:
+            # Reuse: showing a different file in a window the user already has
+            # beats piling up another one.
+            w = s.windows[wid]
+            w["args"] = a.get("args") or w["args"]
+            w["path"] = a.get("path") or w["path"]
+            w["title"] = a.get("title") or w["title"]
+            w["status"] = "opening"
+            w["z"] = s._bump_z()
+            w["minimized"] = False
+            w["updated_seq"] = s.seq + 1
+            return [self._upsert(wid)], {"window_id": wid, "reused": True}
+        wid = s._mint()
+        # Cascade, so a second window of the same app does not hide the first.
+        offset = (len(s.windows) % 8) * 28
+        s.windows[wid] = _window(
+            0, app_id, a.get("args") or {}, str(a.get("title") or app_id),
+            z=s._bump_z(), path=str(a.get("path") or ""),
+            x=a.get("x", 80 + offset), y=a.get("y", 64 + offset),
+            width=a.get("width"), height=a.get("height"),
+            space=min(s.spaces, max(1, int(a.get("space") or 1))),
+            opened_by=str(a.get("opened_by") or ""),
+        )
+        s.windows[wid]["updated_seq"] = s.seq + 1
+        return [self._upsert(wid)], {"window_id": wid, "reused": False}
+
+    def _do_close(self, a: dict) -> tuple[list[dict], dict]:
+        wid = str(a.get("window_id") or "")
+        if wid not in self.session.windows:
+            return [], {"closed": False}
+        self.session.windows.pop(wid)
+        return [{"op": "remove", "id": wid}], {"closed": True}
+
+    def _do_move(self, a: dict) -> tuple[list[dict], dict]:
+        w = self._touch(str(a.get("window_id") or ""))
+        w["x"] = max(0, int(a.get("x") or 0))
+        w["y"] = max(0, int(a.get("y") or 0))
+        return [self._upsert(str(a["window_id"]))], {}
+
+    def _do_resize(self, a: dict) -> tuple[list[dict], dict]:
+        w = self._touch(str(a.get("window_id") or ""))
+        w["width"] = max(320, int(a.get("width") or 320))
+        w["height"] = max(180, int(a.get("height") or 180))
+        return [self._upsert(str(a["window_id"]))], {}
+
+    def _do_raise(self, a: dict) -> tuple[list[dict], dict]:
+        wid = str(a.get("window_id") or "")
+        w = self._touch(wid)
+        w["z"] = self.session._bump_z()
+        w["minimized"] = False
+        return [self._upsert(wid), {"op": "meta", "top_z": self.session.top_z}], {}
+
+    def _do_set(self, a: dict) -> tuple[list[dict], dict]:
+        """Patch the flags a window carries. Only these keys, by name: an
+        open-ended merge would let a stale client write geometry back."""
+        wid = str(a.get("window_id") or "")
+        w = self._touch(wid)
+        patch = a.get("patch") or {}
+        for key in ("title", "minimized", "maximized", "fullscreen", "status", "path"):
+            if key in patch:
+                w[key] = patch[key]
+        if "space" in patch:
+            w["space"] = min(self.session.spaces, max(1, int(patch["space"] or 1)))
+        if "args" in patch and isinstance(patch["args"], dict):
+            w["args"] = {**(w.get("args") or {}), **patch["args"]}
+        return [self._upsert(wid)], {}
+
+    def _do_spaces(self, a: dict) -> tuple[list[dict], dict]:
+        n = max(1, min(MAX_SPACES, int(a.get("count") or 1)))
+        s = self.session
+        if n == s.spaces:
+            return [], {"spaces": n}
+        ops: list[dict] = []
+        if n < s.spaces:
+            # Windows on a retired space fall into the one below it, as they do
+            # when a space is closed by hand.
+            for wid, w in s.windows.items():
+                if w["space"] > n:
+                    w["space"] = n
+                    w["updated_seq"] = s.seq + 1
+                    ops.append(self._upsert(wid))
+        s.spaces = n
+        ops.append({"op": "meta", "spaces": n})
+        return ops, {"spaces": n}
+
+    def _do_nominal(self, a: dict) -> tuple[list[dict], dict]:
+        """A viewport proposes the desktop's resolution.
+
+        Grow-only, and only from a viewport big enough to hold it: the desktop
+        should be as large as the largest screen looking at it, and a narrow
+        panel attaching must not shrink the page's desktop under it.
+        """
+        s = self.session
+        w = max(640, int(a.get("w") or 0))
+        h = max(480, int(a.get("h") or 0))
+        if w <= s.nominal_w and h <= s.nominal_h:
+            return [], {"nominal_w": s.nominal_w, "nominal_h": s.nominal_h}
+        s.nominal_w = max(s.nominal_w, w)
+        s.nominal_h = max(s.nominal_h, h)
+        return ([{"op": "meta", "nominal_w": s.nominal_w, "nominal_h": s.nominal_h}],
+                {"nominal_w": s.nominal_w, "nominal_h": s.nominal_h})

--- a/pantheon/toolsets/live_view/desktop_session.py
+++ b/pantheon/toolsets/live_view/desktop_session.py
@@ -357,3 +357,21 @@ class DesktopSessionStore:
         s.nominal_h = max(s.nominal_h, h)
         return ([{"op": "meta", "nominal_w": s.nominal_w, "nominal_h": s.nominal_h}],
                 {"nominal_w": s.nominal_w, "nominal_h": s.nominal_h})
+
+
+# One pod, one desktop.
+#
+# The toolset is instantiated per connection, so holding the store on the
+# instance gave every browser its own document: three viewports attached at
+# three different seqs and never saw each other's windows, which is the exact
+# bug this module exists to fix, reintroduced one layer up. The desktop is a
+# property of the PROCESS.
+_STORE: DesktopSessionStore | None = None
+
+
+def get_store() -> DesktopSessionStore:
+    global _STORE
+    if _STORE is None:
+        _STORE = DesktopSessionStore()
+        _STORE.load()
+    return _STORE

--- a/pantheon/toolsets/live_view/desktop_session.py
+++ b/pantheon/toolsets/live_view/desktop_session.py
@@ -29,8 +29,12 @@ only one of it.
 
 from __future__ import annotations
 
+import fcntl
 import json
+import os
 import time
+import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -52,6 +56,39 @@ RECORD = ".pantheon/desktop.json"
 EPHEMERAL_APPS = {"agent-view"}
 
 MAX_SPACES = 6
+
+# A token every process in this container agrees on, and that no other
+# container can produce. It marks the record with the LIFETIME that wrote it,
+# which is what tells a reload "these agent views are still live" apart from
+# "these agent views point at a tunnel that died with the last container".
+_BOOT_FILE = Path("/tmp/pantheon-desktop-boot")
+_BOOT: str | None = None
+
+
+def boot_token() -> str:
+    global _BOOT
+    if _BOOT is not None:
+        return _BOOT
+    token = uuid.uuid4().hex
+    try:
+        fd = os.open(_BOOT_FILE, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        try:
+            os.write(fd, token.encode())
+        finally:
+            os.close(fd)
+    except FileExistsError:
+        # Someone else in this container got there first — theirs is the one.
+        try:
+            token = _BOOT_FILE.read_text().strip() or token
+        except OSError:
+            pass
+    except OSError:
+        # No /tmp to agree through. A per-process token is the safe way to be
+        # wrong: every load looks like a restart, so ephemeral windows are
+        # dropped rather than resurrected against a dead tunnel.
+        pass
+    _BOOT = token
+    return token
 
 
 @dataclass
@@ -82,7 +119,14 @@ class DesktopSession:
         }
 
     def to_record(self) -> dict[str, Any]:
-        """What lands on the volume. Ephemeral windows are left out.
+        """What lands on the volume — the WHOLE document, ephemera included.
+
+        This file is not a backup taken on the way out, it is where the
+        document lives between one call and the next, so leaving anything out
+        of it deletes that thing. Ephemeral windows are dropped on the way back
+        IN, and only when the record was written by an earlier container (see
+        `from_record`): within one lifetime an agent view is a real window and
+        has to survive the next reader as much as any other.
 
         The id is carried INSIDE each window: the document keys by it, a JSON
         list does not, and reading back a record whose windows have no id is
@@ -90,14 +134,14 @@ class DesktopSession:
         """
         return {
             "v": 2,
+            "boot": boot_token(),
+            "seq": self.seq,
             "nominal_w": self.nominal_w,
             "nominal_h": self.nominal_h,
             "spaces": self.spaces,
+            "top_z": self.top_z,
             "next_id": self._next_id,
-            "windows": [
-                {**w, "id": wid} for wid, w in self.windows.items()
-                if w.get("app_id") not in EPHEMERAL_APPS
-            ],
+            "windows": [{**w, "id": wid} for wid, w in self.windows.items()],
         }
 
     @classmethod
@@ -110,11 +154,20 @@ class DesktopSession:
             s.nominal_h = int(data.get("nominal_h") or 800)
             s.spaces = max(1, min(MAX_SPACES, int(data.get("spaces") or 1)))
             s._next_id = max(1, int(data.get("next_id") or 1))
+            s.seq = max(0, int(data.get("seq") or 0))
+            s.top_z = max(s.top_z, int(data.get("top_z") or 0))
+            # Written by a container that is gone: its agent views point at a
+            # tunnel that died with it, so they are not part of the desktop the
+            # user comes back to.
+            same_life = data.get("boot") == boot_token()
             for w in data.get("windows") or []:
                 wid = str(w.get("id") or "")
-                if wid:
-                    s.windows[wid] = w
-                    s.top_z = max(s.top_z, int(w.get("z") or 0))
+                if not wid:
+                    continue
+                if not same_life and w.get("app_id") in EPHEMERAL_APPS:
+                    continue
+                s.windows[wid] = w
+                s.top_z = max(s.top_z, int(w.get("z") or 0))
             return s
         # v1 — the browser's own record, a list of windows with no ids. Adopt
         # it rather than dropping the user's layout on the floor at upgrade.
@@ -174,9 +227,19 @@ class DesktopSessionStore:
     """Owns the document, applies intents, and says what changed.
 
     Every mutator returns `(ops, result)`: the ops go out as a delta, the
-    result goes back to whoever asked. Nothing here publishes or writes — the
-    toolset does both, so the reducer stays a pure function of the document
-    and is testable without a pod.
+    result goes back to whoever asked. The mutators themselves neither read
+    nor write the record — they are a pure function of the document, testable
+    without a pod — but `apply` wraps them in one.
+
+    THE RECORD IS THE DOCUMENT, not a backup of it. A process-wide singleton
+    was not enough: the toolset does not run in one process, so `desktop_intent`
+    and `desktop_session_get` could land on different copies of a Python object
+    and the second would honestly report an empty desktop while the first had
+    just opened a window on it. The only thing every one of them shares is the
+    filesystem, so each call reads the record, applies, and writes it back
+    under a lock. At desktop rates — a few clicks a second — that costs a
+    stat and a few kilobytes, and it is the difference between a shared
+    session and three private ones.
     """
 
     def __init__(self, work_dir: Path | None = None):
@@ -188,28 +251,48 @@ class DesktopSessionStore:
     # ── persistence ──────────────────────────────────────────────────────
 
     def load(self) -> None:
-        """Read the record once. A missing or broken one is an empty desktop."""
-        if self._loaded:
-            return
+        """Adopt the record. A missing or broken one is an empty desktop.
+
+        Called before every read and every write, not once at boot: another
+        process may have applied an intent since we last looked, and the whole
+        point is to notice. Deliberately NOT skipped when the file looks
+        unchanged — an mtime-and-size guard would silently keep a stale
+        document whenever two writes of the same length land in one filesystem
+        tick, which is the exact failure this read-through exists to prevent.
+        The record is kilobytes; re-reading it is cheaper than being wrong.
+        """
         self._loaded = True
         path = self._record_path()
-        if path is None or not path.exists():
+        if path is None:
             return
         try:
-            self.session = DesktopSession.from_record(json.loads(path.read_text()))
-            logger.info("desktop session restored: {} window(s)", len(self.session.windows))
+            raw = path.read_text()
+        except OSError:
+            return
+        try:
+            self.session = DesktopSession.from_record(json.loads(raw))
+            self._dirty = False
         except Exception as e:  # noqa: BLE001
             logger.warning("desktop session record unreadable, starting empty: {}", e)
 
     def save(self) -> None:
         if not self._dirty:
             return
+        with self._locked():
+            self._write()
+
+    def _write(self) -> None:
+        """Replace the record atomically. Caller holds the lock."""
         path = self._record_path()
         if path is None:
             return
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps(self.session.to_record(), indent=1))
+            # A reader without the lock (a person, a backup) must never catch
+            # the file half-written, so build it beside and rename over.
+            tmp = path.with_name(path.name + f".{os.getpid()}.tmp")
+            tmp.write_text(json.dumps(self.session.to_record(), indent=1))
+            os.replace(tmp, path)
             self._dirty = False
         except Exception as e:  # noqa: BLE001
             # A failed save costs one snapshot; a SILENT one costs the whole
@@ -226,18 +309,69 @@ class DesktopSessionStore:
                 return None
         return self._work_dir / RECORD
 
+    @contextmanager
+    def _locked(self):
+        """Serialise readers and writers across processes.
+
+        Two intents arriving at once must not both read seq 7 and both write
+        seq 8 — one of the two changes would simply not exist, while its
+        client had already been told it did.
+        """
+        path = self._record_path()
+        if path is None:
+            yield
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fh = open(path.with_name(path.name + ".lock"), "a+")
+        except OSError:
+            yield  # unlockable is still better than unusable
+            return
+        try:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+            finally:
+                fh.close()
+
+    def current(self) -> dict[str, Any]:
+        """The document as it stands, from whoever wrote it last."""
+        with self._locked():
+            self.load()
+            return self.session.snapshot()
+
+    def where(self) -> dict[str, Any]:
+        """Which copy of the desktop this is — pid, container, record.
+
+        Kept because the failure it diagnoses is silent: a viewport talking to
+        a different document simply sees an empty desktop, with no error to
+        go on. Compare these across viewports and the answer is immediate.
+        """
+        return {
+            "pid": os.getpid(),
+            "boot": boot_token()[:8],
+            "record": str(self._record_path() or ""),
+        }
+
     # ── intents ──────────────────────────────────────────────────────────
 
     def apply(self, kind: str, args: dict[str, Any]) -> tuple[list[dict], dict]:
         handler = getattr(self, f"_do_{kind}", None)
         if handler is None:
             raise ValueError(f"unknown desktop intent '{kind}'")
-        ops, result = handler(args or {})
-        if ops:
-            self.session.seq += 1
-            for op in ops:
-                op["seq"] = self.session.seq
-            self._dirty = True
+        with self._locked():
+            # Read-modify-write: whatever anyone else did lands before this
+            # intent does, so seq stays monotonic and no change is overwritten.
+            self.load()
+            ops, result = handler(args or {})
+            if ops:
+                self.session.seq += 1
+                for op in ops:
+                    op["seq"] = self.session.seq
+                self._dirty = True
+                self._write()
         return ops, result
 
     def _touch(self, wid: str) -> dict:
@@ -364,8 +498,13 @@ class DesktopSessionStore:
 # The toolset is instantiated per connection, so holding the store on the
 # instance gave every browser its own document: three viewports attached at
 # three different seqs and never saw each other's windows, which is the exact
-# bug this module exists to fix, reintroduced one layer up. The desktop is a
-# property of the PROCESS.
+# bug this module exists to fix, reintroduced one layer up.
+#
+# Process-wide was the second wrong answer. The toolset does not run in one
+# process either (`run_toolsets` submits a ProcessJob per toolset), so this is
+# a CACHE of the record rather than the document itself — every call reloads it
+# if the file has moved on. What makes the desktop shared is the record; this
+# just saves re-parsing it when nothing has changed.
 _STORE: DesktopSessionStore | None = None
 
 

--- a/pantheon/toolsets/live_view/toolset.py
+++ b/pantheon/toolsets/live_view/toolset.py
@@ -120,6 +120,7 @@ class LiveViewToolSet(ToolSet):
         # chats whose desktop has answered a ping — subscription is live.
         self._desktop_ready: set[str] = set()
         self._nats = None  # lazy NATSStreamAdapter
+        self._desktop_store = None  # lazy DesktopSessionStore
         self._data_server = None  # lazy LiveViewDataServer
         self._browser_endpoints = False  # browser-frame/-input registered
 
@@ -148,6 +149,66 @@ class LiveViewToolSet(ToolSet):
             await self._nats.publish(chat_id, event["type"], event)
         except Exception as e:  # streaming is best-effort
             logger.error("live_view: publish failed: {}", e)
+
+    # ── the desktop session ───────────────────────────────────────────────
+
+    def _desktop(self):
+        """The window document, loaded from the volume on first use."""
+        if self._desktop_store is None:
+            from .desktop_session import DesktopSessionStore
+
+            self._desktop_store = DesktopSessionStore()
+            self._desktop_store.load()
+        return self._desktop_store
+
+    async def _publish_desktop(self, event: dict[str, Any]) -> None:
+        """Announce a change to every viewport of this pod.
+
+        Pod-scoped, not per chat: a desktop belongs to the machine, and every
+        view of it has to hear about a window opening whatever conversation —
+        or none — that view has on screen.
+        """
+        from .desktop_session import DESKTOP_STREAM
+
+        if self._nats is None:
+            from pantheon.chatroom.stream import NATSStreamAdapter
+
+            self._nats = NATSStreamAdapter()
+        try:
+            await self._nats.publish_stream(DESKTOP_STREAM, event)
+        except Exception as e:  # noqa: BLE001  streaming is best-effort
+            logger.error("desktop: publish failed: {}", e)
+
+    @tool(exclude=True)
+    async def desktop_session_get(self) -> dict:
+        """UI-only: the whole window document, for a viewport attaching or
+        recovering from a missed delta."""
+        return {"success": True, "session": self._desktop().snapshot()}
+
+    @tool(exclude=True)
+    async def desktop_intent(self, kind: str, args: dict | None = None) -> dict:
+        """UI-only: ask for a change to the desktop.
+
+        Clients send intents rather than state, so this is the only writer and
+        the order of two viewports' edits is decided in one place. The reply
+        carries whatever the caller needs back — a minted window id — and the
+        ops themselves, so the caller can show the result now instead of
+        waiting to hear its own broadcast come back. Applying by `seq` makes
+        that idempotent: the broadcast arrives, is not newer, and is dropped.
+        """
+        store = self._desktop()
+        try:
+            ops, result = store.apply(kind, args or {})
+        except (KeyError, ValueError) as e:
+            return {"success": False, "error": str(e)}
+        if ops:
+            await self._publish_desktop({
+                "type": "desktop.delta",
+                "seq": store.session.seq,
+                "ops": ops,
+            })
+            store.save()
+        return {"success": True, "seq": store.session.seq, "ops": ops, **result}
 
     def _require(self, view_id: str) -> LiveViewSession:
         session = self._views.get(view_id)
@@ -1059,7 +1120,33 @@ class LiveViewToolSet(ToolSet):
         here, then desktop_read / desktop_update / desktop_call it exactly
         like a view you opened yourself.
         """
-        return await self._desktop_request("desktop.windows", {})
+        # Answered from the pod's own document, so this works with no desktop
+        # on screen at all — the window list is a property of the machine, and
+        # asking a browser for it was what produced "the desktop did not
+        # answer" for a question the pod could always answer itself.
+        s = self._desktop().session
+        windows = [
+            {
+                "window_id": wid,
+                "app_id": w.get("app_id"),
+                "name": w.get("app_id"),
+                "title": w.get("title"),
+                "path": w.get("path") or None,
+                "space": w.get("space", 1),
+                "minimized": bool(w.get("minimized")),
+                "status": w.get("status", "ready"),
+                "opened_by": w.get("opened_by") or None,
+            }
+            for wid, w in sorted(s.windows.items(), key=lambda kv: kv[1].get("z", 0))
+        ]
+        return {"success": True, "result": {
+            "windows": windows,
+            "space_count": s.spaces,
+            # Which space a person is LOOKING at belongs to that person, not to
+            # the machine — two viewports may be on different ones. Reported
+            # for compatibility as the space the topmost window sits on.
+            "active_space": windows[-1]["space"] if windows else 1,
+        }}
 
     @tool
     async def desktop_open(

--- a/pantheon/toolsets/live_view/toolset.py
+++ b/pantheon/toolsets/live_view/toolset.py
@@ -120,7 +120,6 @@ class LiveViewToolSet(ToolSet):
         # chats whose desktop has answered a ping — subscription is live.
         self._desktop_ready: set[str] = set()
         self._nats = None  # lazy NATSStreamAdapter
-        self._desktop_store = None  # lazy DesktopSessionStore
         self._data_server = None  # lazy LiveViewDataServer
         self._browser_endpoints = False  # browser-frame/-input registered
 
@@ -153,13 +152,15 @@ class LiveViewToolSet(ToolSet):
     # ── the desktop session ───────────────────────────────────────────────
 
     def _desktop(self):
-        """The window document, loaded from the volume on first use."""
-        if self._desktop_store is None:
-            from .desktop_session import DesktopSessionStore
+        """The window document — process-wide, not per toolset instance.
 
-            self._desktop_store = DesktopSessionStore()
-            self._desktop_store.load()
-        return self._desktop_store
+        The toolset is built per connection; a store held on `self` gave every
+        browser its own desktop, which is the bug the document exists to fix
+        wearing a different hat.
+        """
+        from .desktop_session import get_store
+
+        return get_store()
 
     async def _publish_desktop(self, event: dict[str, Any]) -> None:
         """Announce a change to every viewport of this pod.

--- a/pantheon/toolsets/live_view/toolset.py
+++ b/pantheon/toolsets/live_view/toolset.py
@@ -152,11 +152,12 @@ class LiveViewToolSet(ToolSet):
     # ── the desktop session ───────────────────────────────────────────────
 
     def _desktop(self):
-        """The window document — process-wide, not per toolset instance.
+        """The window document, as the record on disk currently has it.
 
-        The toolset is built per connection; a store held on `self` gave every
-        browser its own desktop, which is the bug the document exists to fix
-        wearing a different hat.
+        Not per toolset instance (built per connection) and not per process
+        either (a ProcessJob per toolset): both gave some browser its own
+        desktop, which is the bug the document exists to fix wearing a
+        different hat. The store reads the record through on every call.
         """
         from .desktop_session import get_store
 
@@ -184,7 +185,8 @@ class LiveViewToolSet(ToolSet):
     async def desktop_session_get(self) -> dict:
         """UI-only: the whole window document, for a viewport attaching or
         recovering from a missed delta."""
-        return {"success": True, "session": self._desktop().snapshot()}
+        store = self._desktop()
+        return {"success": True, "session": store.current(), "host": store.where()}
 
     @tool(exclude=True)
     async def desktop_intent(self, kind: str, args: dict | None = None) -> dict:
@@ -208,8 +210,8 @@ class LiveViewToolSet(ToolSet):
                 "seq": store.session.seq,
                 "ops": ops,
             })
-            store.save()
-        return {"success": True, "seq": store.session.seq, "ops": ops, **result}
+        return {"success": True, "seq": store.session.seq, "ops": ops,
+                "host": store.where(), **result}
 
     def _require(self, view_id: str) -> LiveViewSession:
         session = self._views.get(view_id)
@@ -1125,7 +1127,9 @@ class LiveViewToolSet(ToolSet):
         # on screen at all — the window list is a property of the machine, and
         # asking a browser for it was what produced "the desktop did not
         # answer" for a question the pod could always answer itself.
-        s = self._desktop().session
+        store = self._desktop()
+        store.current()          # read the record through before answering
+        s = store.session
         windows = [
             {
                 "window_id": wid,

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -109,7 +109,7 @@ def test_set_patches_only_named_keys(store):
     assert "nonsense" not in w
 
 
-def test_a_record_round_trips_with_its_ids(store):
+def test_a_record_round_trips_with_its_ids(store, tmp_path):
     """Regression: to_record wrote windows without their ids while from_record
     keyed on them, so every window vanished on the next restart."""
     a = store.apply("open", {"app_id": "files", "title": "Files"})[1]["window_id"]
@@ -119,9 +119,9 @@ def test_a_record_round_trips_with_its_ids(store):
     back = DesktopSession.from_record(json.loads(json.dumps(store.session.to_record())))
     assert sorted(back.windows) == sorted([a, b])
     assert (back.windows[b]["x"], back.windows[b]["y"]) == (300, 90)
+    assert back.seq == store.session.seq   # or every client re-syncs backwards
     # And a window opened after the reload must not reuse a live id.
-    reloaded = DesktopSessionStore()
-    reloaded._loaded = True
+    reloaded = DesktopSessionStore(work_dir=tmp_path / "elsewhere")
     reloaded.session = back
     assert reloaded.apply("open", {"app_id": "terminal"})[1]["window_id"] not in (a, b)
 
@@ -138,11 +138,26 @@ def test_the_record_survives_a_real_save_and_load(tmp_path):
     assert second.session.windows[wid]["title"] == "Files"
 
 
-def test_agent_windows_are_not_part_of_the_desktop_you_come_back_to(store):
+def test_agent_windows_outlive_a_reader_but_not_a_restart(tmp_path):
+    """The record is where the document lives between two calls, not a backup
+    taken on the way out — so leaving a window out of it deletes that window.
+    Agent views must survive another process reading the record, and must not
+    survive the container whose tunnel they point at."""
+    store = DesktopSessionStore(work_dir=tmp_path)
+    store.load()
     store.apply("open", {"app_id": "files"})
     store.apply("open", {"app_id": "agent-view", "title": "a view"})
-    assert len(store.session.windows) == 2
-    assert len(store.session.to_record()["windows"]) == 1
+
+    # Another process, same container: both windows are still there.
+    peer = DesktopSessionStore(work_dir=tmp_path)
+    peer.load()
+    assert len(peer.session.windows) == 2
+
+    # A later container: the agent view's module URL died with the old tunnel.
+    record = json.loads((tmp_path / ".pantheon" / "desktop.json").read_text())
+    record["boot"] = "some-other-container"
+    after_restart = DesktopSession.from_record(record)
+    assert [w["app_id"] for w in after_restart.windows.values()] == ["files"]
 
 
 def test_a_v1_browser_record_is_adopted_not_dropped(tmp_path):
@@ -160,6 +175,45 @@ def test_a_v1_browser_record_is_adopted_not_dropped(tmp_path):
     only = next(iter(s.session.windows.values()))
     assert (only["x"], only["y"], only["space"]) == (10, 20, 2)
     assert s.session.spaces == 2
+
+
+def test_two_stores_on_one_record_are_one_desktop(tmp_path):
+    """THE bug this file is about, at the layer it actually bit.
+
+    The toolset is built per connection and run as a ProcessJob per toolset,
+    so `desktop_intent` and `desktop_session_get` need not reach the same
+    Python object — and when they did not, one viewport opened a window while
+    the other was told, honestly, that the desktop was empty. Two stores over
+    one record have to behave as one."""
+    a = DesktopSessionStore(work_dir=tmp_path)
+    b = DesktopSessionStore(work_dir=tmp_path)
+    a.load()
+    b.load()
+
+    wid = a.apply("open", {"app_id": "terminal", "title": "Terminal"})[1]["window_id"]
+    assert list(b.current()["windows"]) == [wid]
+
+    # And B's own intent continues A's sequence rather than colliding with it:
+    # two clients that both minted seq 2 would each be told a change landed
+    # while one of the two silently did not exist.
+    ops, _ = b.apply("move", {"window_id": wid, "x": 400, "y": 120})
+    assert ops[0]["seq"] == a.session.seq + 1
+    assert a.current()["windows"][wid]["x"] == 400
+    assert a.session.seq == b.session.seq
+
+
+def test_a_reader_does_not_lose_what_it_has_not_written(tmp_path):
+    """Reloading must not clobber: B holding a stale copy, then applying its
+    own intent, must not roll A's window back out of existence."""
+    a = DesktopSessionStore(work_dir=tmp_path)
+    b = DesktopSessionStore(work_dir=tmp_path)
+    a.load()
+    b.load()
+    b.apply("open", {"app_id": "files"})          # B's copy is warm
+    wid = a.apply("open", {"app_id": "terminal"})[1]["window_id"]
+    b.apply("spaces", {"count": 2})               # B never re-read in between
+    assert wid in b.session.windows
+    assert len(a.current()["windows"]) == 2
 
 
 def test_an_unreadable_record_is_an_empty_desktop_not_a_crash(tmp_path):

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1,0 +1,171 @@
+"""The desktop session reducer.
+
+A pure function of the document — no pod, no NATS, no volume — so the rules
+that keep several viewports agreeing can be pinned down here rather than
+discovered on a staging desktop.
+"""
+
+import json
+
+import pytest
+
+from pantheon.toolsets.live_view.desktop_session import (
+    DesktopSession,
+    DesktopSessionStore,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = DesktopSessionStore(work_dir=tmp_path)
+    s.load()
+    return s
+
+
+def test_open_mints_an_id_and_bumps_seq(store):
+    ops, result = store.apply("open", {"app_id": "files", "title": "Files"})
+    assert result["window_id"] == "win-1"
+    assert result["reused"] is False
+    assert [o["op"] for o in ops] == ["upsert"]
+    assert store.session.seq == 1
+    assert ops[0]["seq"] == 1
+
+
+def test_ids_are_the_pods_so_two_viewports_cannot_disagree(store):
+    """The bug this replaces: a per-tab counter gave every copy its own win-3,
+    so an id the agent held could resolve to a different window elsewhere."""
+    first = store.apply("open", {"app_id": "files"})[1]["window_id"]
+    second = store.apply("open", {"app_id": "terminal"})[1]["window_id"]
+    assert first != second
+
+
+def test_open_with_a_window_id_reuses_it(store):
+    wid = store.apply("open", {"app_id": "vitessce"})[1]["window_id"]
+    ops, result = store.apply(
+        "open", {"app_id": "vitessce", "window_id": wid, "path": "/w/other.h5ad"})
+    assert result == {"window_id": wid, "reused": True}
+    assert len(store.session.windows) == 1
+    assert ops[0]["window"]["path"] == "/w/other.h5ad"
+
+
+def test_move_and_resize_clamp_to_the_floor(store):
+    wid = store.apply("open", {"app_id": "files"})[1]["window_id"]
+    store.apply("move", {"window_id": wid, "x": -50, "y": -10})
+    store.apply("resize", {"window_id": wid, "width": 10, "height": 10})
+    w = store.session.windows[wid]
+    assert (w["x"], w["y"]) == (0, 0)
+    assert (w["width"], w["height"]) == (320, 180)
+
+
+def test_close_removes_and_reports(store):
+    wid = store.apply("open", {"app_id": "files"})[1]["window_id"]
+    ops, result = store.apply("close", {"window_id": wid})
+    assert result == {"closed": True}
+    assert ops == [{"op": "remove", "id": wid, "seq": store.session.seq}]
+    assert store.session.windows == {}
+
+
+def test_closing_what_is_gone_changes_nothing(store):
+    ops, result = store.apply("close", {"window_id": "win-404"})
+    assert result == {"closed": False}
+    assert ops == []
+    assert store.session.seq == 0  # nothing happened, so nothing to tell anyone
+
+
+def test_retiring_a_space_carries_its_windows_down(store):
+    store.apply("spaces", {"count": 3})
+    wid = store.apply("open", {"app_id": "files", "space": 3})[1]["window_id"]
+    assert store.session.windows[wid]["space"] == 3
+    store.apply("spaces", {"count": 1})
+    assert store.session.windows[wid]["space"] == 1
+
+
+def test_nominal_size_only_grows(store):
+    """The desktop should be as large as the largest screen looking at it: a
+    narrow sidebar panel attaching must not shrink the page's desktop."""
+    assert store.apply("nominal", {"w": 1700, "h": 1000})[1] == {
+        "nominal_w": 1700, "nominal_h": 1000}
+    ops, result = store.apply("nominal", {"w": 660, "h": 900})
+    assert result == {"nominal_w": 1700, "nominal_h": 1000}
+    assert ops == []
+
+
+def test_unknown_intent_and_missing_window_raise(store):
+    with pytest.raises(ValueError):
+        store.apply("teleport", {})
+    with pytest.raises(KeyError):
+        store.apply("move", {"window_id": "win-404", "x": 1, "y": 1})
+
+
+def test_set_patches_only_named_keys(store):
+    """An open-ended merge would let a stale client write geometry back."""
+    wid = store.apply("open", {"app_id": "files"})[1]["window_id"]
+    store.apply("set", {"window_id": wid, "patch": {
+        "title": "renamed", "minimized": True, "x": 9999, "nonsense": 1}})
+    w = store.session.windows[wid]
+    assert w["title"] == "renamed"
+    assert w["minimized"] is True
+    assert w["x"] != 9999
+    assert "nonsense" not in w
+
+
+def test_a_record_round_trips_with_its_ids(store):
+    """Regression: to_record wrote windows without their ids while from_record
+    keyed on them, so every window vanished on the next restart."""
+    a = store.apply("open", {"app_id": "files", "title": "Files"})[1]["window_id"]
+    b = store.apply("open", {"app_id": "vitessce", "title": "pbmc"})[1]["window_id"]
+    store.apply("move", {"window_id": b, "x": 300, "y": 90})
+
+    back = DesktopSession.from_record(json.loads(json.dumps(store.session.to_record())))
+    assert sorted(back.windows) == sorted([a, b])
+    assert (back.windows[b]["x"], back.windows[b]["y"]) == (300, 90)
+    # And a window opened after the reload must not reuse a live id.
+    reloaded = DesktopSessionStore()
+    reloaded._loaded = True
+    reloaded.session = back
+    assert reloaded.apply("open", {"app_id": "terminal"})[1]["window_id"] not in (a, b)
+
+
+def test_the_record_survives_a_real_save_and_load(tmp_path):
+    first = DesktopSessionStore(work_dir=tmp_path)
+    first.load()
+    wid = first.apply("open", {"app_id": "files", "title": "Files"})[1]["window_id"]
+    first.save()
+
+    second = DesktopSessionStore(work_dir=tmp_path)
+    second.load()
+    assert list(second.session.windows) == [wid]
+    assert second.session.windows[wid]["title"] == "Files"
+
+
+def test_agent_windows_are_not_part_of_the_desktop_you_come_back_to(store):
+    store.apply("open", {"app_id": "files"})
+    store.apply("open", {"app_id": "agent-view", "title": "a view"})
+    assert len(store.session.windows) == 2
+    assert len(store.session.to_record()["windows"]) == 1
+
+
+def test_a_v1_browser_record_is_adopted_not_dropped(tmp_path):
+    """Upgrading must not throw away the layout the user already had."""
+    record = tmp_path / ".pantheon" / "desktop.json"
+    record.parent.mkdir(parents=True)
+    record.write_text(json.dumps({"v": 1, "spaces": 2, "windows": [
+        {"appId": "files", "title": "Files", "x": 10, "y": 20,
+         "width": 700, "height": 500, "space": 2},
+        {"appId": "agent-view", "title": "ephemeral"},
+    ]}))
+    s = DesktopSessionStore(work_dir=tmp_path)
+    s.load()
+    assert len(s.session.windows) == 1        # agent-view is not restored
+    only = next(iter(s.session.windows.values()))
+    assert (only["x"], only["y"], only["space"]) == (10, 20, 2)
+    assert s.session.spaces == 2
+
+
+def test_an_unreadable_record_is_an_empty_desktop_not_a_crash(tmp_path):
+    record = tmp_path / ".pantheon" / "desktop.json"
+    record.parent.mkdir(parents=True)
+    record.write_text("{not json")
+    s = DesktopSessionStore(work_dir=tmp_path)
+    s.load()
+    assert s.session.windows == {}


### PR DESCRIPTION
## Why

Three desktops open on one pod showed three different sets of windows. Each viewport kept its own window list and wrote the whole thing to `.pantheon/desktop.json` on a debounce, reading it back only at boot and only onto an empty desktop — **two writers to one file with no reader between them**. They took turns overwriting each other and neither ever saw the result.

A desktop is not a page: it is a view onto the pod, which already owns the files, the processes and the installed apps. Which windows are open is a property of the machine.

## What

- `desktop_session.py` — the document, and a reducer that is a pure function of it. Clients send **intents**; every change bumps `seq` and emits ops.
- `desktop_intent` / `desktop_session_get` (UI-only) — apply-and-broadcast, and the snapshot a viewport attaches or re-syncs with. The intent reply carries its own ops so the caller can render immediately; applying by `seq` makes the broadcast idempotent.
- **Pod-scoped stream** (`<prefix>.pantheon.stream.desktop`), not per chat. Tying desktop events to a conversation is what produced *"the desktop did not answer — is an Atrium window open on this chat?"*, and it left the standalone desktop page — which has no chat — unable to participate.
- **Ids are minted pod-side.** A per-tab counter gave every copy its own `win-3`.
- `desktop_windows` is answered from the document, so it needs no browser.

Not shared, deliberately: the space a viewport is looking at, and keyboard focus. Those belong to the person; stacking order belongs to the arrangement.

## Verification

The reducer was exercised standalone (no pod): intents, pod-minted ids, space collapse, grow-only resolution, unknown-intent and missing-window errors, and a v1 record migrating rather than being dropped at upgrade.

That last test caught a real bug before it shipped: `to_record` wrote windows without their ids while `from_record` keyed on them, so **every window would have vanished on restart**.

Frontend half is on `feat/absorb-atrium` in pantheon-ui; end-to-end verification needs this image pinned on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ups1TP9FXNqxbaaUXuEDrn