### PR TITLE
feat(desktop): who is looking — leased viewport and chat-client identity

### DIFF
--- a/pantheon/toolsets/desktop/presence.py
+++ b/pantheon/toolsets/desktop/presence.py
@@ -1,0 +1,313 @@
+"""Who is looking at this desktop, and where each chat is anchored.
+
+The session document (``desktop_session.py``) says which windows exist. This
+says which SCREENS exist — and that is a different kind of fact, so it lives in
+a different file with different rules.
+
+Two kinds of client register here:
+
+  * a **viewport** — something rendering the desktop (the side panel, or
+    ``desktop.html``). Directed requests are addressed to one, and a cursor
+    belongs to one.
+  * a **chat client** — one chat UI. One per Agent app *window* in the desktop,
+    one per chat pane in pantheon-ui. It carries the chat it shows and the
+    ``host_viewport_id`` of the desktop in the same page.
+
+That host field is the whole anchoring link. `anchor_for(chat_id)` takes the
+chat's clients, picks the most recently active one, and follows its host — so
+three Agent windows in one page all resolve to the same viewport, and a chat
+open in two places anchors wherever the person last touched it.
+
+**Registration is a LEASE, not a registration.** Unregistering on close is
+best-effort and cannot be anything more: `pagehide` fires when a tab is closed
+and not when the browser crashes, the network drops, or a laptop sleeps — and
+every one of those would otherwise leave an entry claiming to be a live screen.
+An agent addressed to it waits for a timeout and reports "the desktop did not
+answer", which is the exact failure this whole line of work exists to end. So
+clients renew on a heartbeat and entries expire on their own; the explicit
+leave only makes the common case instant instead of taking a TTL.
+
+Expiry is applied when the registry is READ, not only by a sweeper. If a
+periodic reaper were the only thing enforcing it, its period would be a window
+in which the agent is addressed to a dead tab.
+
+Not in process memory (the toolset is a ProcessJob per toolset — the lesson
+desktop_session.py learned the hard way) and deliberately not in the session
+document either: the two have opposite lifetimes and opposite broadcast rules.
+A heartbeat is not a change anyone needs to hear about, and folding it into the
+document would bump `seq` and fan out to every viewport every few seconds per
+open tab, for nothing.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pantheon.utils.log import logger
+
+from .desktop_session import boot_token
+
+RECORD = ".pantheon/desktop-presence.json"
+
+# How long a lease survives without renewal, and how often a client should
+# renew. The gap is deliberate: a client gets two chances to miss a beat (a
+# stalled tab, one dropped request) before it is declared gone.
+TTL_S = 45.0
+HEARTBEAT_S = 15.0
+
+
+@dataclass
+class Presence:
+    """Every screen currently looking at this desktop."""
+
+    viewports: dict[str, dict[str, Any]] = field(default_factory=dict)
+    clients: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "v": 1,
+            # A registry written by a container that is gone describes screens
+            # that cannot exist: every one of those browsers lost its
+            # connection when the sandbox did.
+            "boot": boot_token(),
+            "viewports": self.viewports,
+            "clients": self.clients,
+        }
+
+    @classmethod
+    def from_record(cls, data: dict[str, Any]) -> "Presence":
+        if not isinstance(data, dict) or data.get("boot") != boot_token():
+            return cls()
+        p = cls()
+        p.viewports = dict(data.get("viewports") or {})
+        p.clients = dict(data.get("clients") or {})
+        return p
+
+
+class PresenceStore:
+    """The registry, read through and written through a lock.
+
+    Mutators take `now` explicitly so the expiry rules can be tested without
+    sleeping through a TTL.
+    """
+
+    def __init__(self, work_dir: Path | None = None):
+        self.presence = Presence()
+        self._work_dir = work_dir
+
+    # ── persistence (same discipline as DesktopSessionStore) ─────────────
+
+    def _record_path(self) -> Path | None:
+        if self._work_dir is None:
+            try:
+                from pantheon.settings import get_settings
+
+                self._work_dir = Path(get_settings().work_dir)
+            except Exception:  # noqa: BLE001
+                return None
+        return self._work_dir / RECORD
+
+    @contextmanager
+    def _locked(self):
+        path = self._record_path()
+        if path is None:
+            yield
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fh = open(path.with_name(path.name + ".lock"), "a+")
+        except OSError:
+            yield
+            return
+        try:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+            finally:
+                fh.close()
+
+    def load(self) -> None:
+        path = self._record_path()
+        if path is None:
+            return
+        try:
+            raw = path.read_text()
+        except OSError:
+            return
+        try:
+            self.presence = Presence.from_record(json.loads(raw))
+        except Exception as e:  # noqa: BLE001
+            logger.warning("desktop presence unreadable, starting empty: {}", e)
+            self.presence = Presence()
+
+    def _write(self) -> None:
+        path = self._record_path()
+        if path is None:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_name(path.name + f".{os.getpid()}.tmp")
+            tmp.write_text(json.dumps(self.presence.to_record(), indent=1))
+            os.replace(tmp, path)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("desktop presence save failed: {}", e)
+
+    # ── the lease ────────────────────────────────────────────────────────
+
+    def announce(
+        self,
+        *,
+        viewport_id: str = "",
+        clients: list[dict[str, Any]] | None = None,
+        visible: bool = True,
+        active: bool = False,
+        now: float | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        """Renew this page's leases. Returns (registry, membership_changed).
+
+        One call per page: a page has at most one viewport and any number of
+        chat clients, and sending them together keeps a heartbeat to a single
+        message rather than one per entity.
+
+        `membership_changed` says whether anyone joined or left — the only
+        thing worth broadcasting. A renewal that changes nothing must not
+        wake every other viewport.
+        """
+        now = time.time() if now is None else now
+        expires = now + TTL_S
+        with self._locked():
+            # Read-modify-write, like the session document: several pages beat
+            # at once, and each must land on what the others already wrote.
+            self.load()
+            p = self.presence
+            before = self._members(now)
+            self._announce_into(p, viewport_id, clients, visible, active, now, expires)
+            self._sweep(now)
+            self._write()
+            return self.snapshot(now), self._members(now) != before
+
+    def _announce_into(self, p, viewport_id, clients, visible, active, now, expires):
+        if viewport_id:
+            prev = p.viewports.get(viewport_id) or {}
+            p.viewports[viewport_id] = {
+                "visible": bool(visible),
+                # Only real input moves this. A background tab beating its
+                # heart is not a person, and must not win "most recently
+                # active" against the window someone is actually typing in.
+                "last_input_at": now if active else prev.get("last_input_at", 0.0),
+                "expires_at": expires,
+            }
+        for c in clients or []:
+            cid = str(c.get("client_id") or "")
+            if not cid:
+                continue
+            prev = p.clients.get(cid) or {}
+            p.clients[cid] = {
+                "chat_id": str(c.get("chat_id") or ""),
+                "host_viewport_id": str(c.get("host_viewport_id") or ""),
+                "last_input_at": now if active else prev.get("last_input_at", 0.0),
+                "expires_at": expires,
+            }
+
+    def leave(
+        self, *, viewport_id: str = "", client_ids: list[str] | None = None,
+        now: float | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        """Give up leases now rather than at expiry. Best-effort by nature."""
+        now = time.time() if now is None else now
+        with self._locked():
+            self.load()
+            before = self._members(now)
+            self.presence.viewports.pop(viewport_id, None)
+            for cid in client_ids or []:
+                self.presence.clients.pop(cid, None)
+            self._sweep(now)
+            self._write()
+            return self.snapshot(now), self._members(now) != before
+
+    def current(self, now: float | None = None) -> dict[str, Any]:
+        """The registry as whoever wrote it last has it."""
+        with self._locked():
+            self.load()
+            return self.snapshot(now)
+
+    def _sweep(self, now: float) -> None:
+        for table in (self.presence.viewports, self.presence.clients):
+            for key in [k for k, v in table.items() if v.get("expires_at", 0) <= now]:
+                del table[key]
+
+    def _members(self, now: float) -> tuple:
+        s = self.snapshot(now)
+        return (tuple(sorted(s["viewports"])), tuple(sorted(s["clients"])))
+
+    def snapshot(self, now: float | None = None) -> dict[str, Any]:
+        """The live registry. Expired entries are filtered HERE, not merely
+        swept on a timer — a reaper's period would otherwise be a window in
+        which a dead tab still looks addressable."""
+        now = time.time() if now is None else now
+        return {
+            "viewports": {k: v for k, v in self.presence.viewports.items()
+                          if v.get("expires_at", 0) > now},
+            "clients": {k: v for k, v in self.presence.clients.items()
+                        if v.get("expires_at", 0) > now},
+            "ttl_s": TTL_S,
+            "heartbeat_s": HEARTBEAT_S,
+        }
+
+    # ── the question this file exists to answer ──────────────────────────
+
+    def anchor_for(self, chat_id: str, now: float | None = None) -> dict[str, Any]:
+        """Which viewport should this chat's directed requests reach?
+
+        The ladder, in order (docs/desktop/anchoring.md §2):
+
+          1. the viewport hosting this chat — via the chat's own clients;
+          2. failing that, the pod's most recently active viewport;
+          3. failing that, nothing, and the caller answers from the document
+             or says so honestly. Never a silent nothing.
+
+        `reason` is returned with the answer because "why this screen?" is
+        otherwise unanswerable after the fact, and that was the whole
+        difficulty of debugging the session work.
+        """
+        now = time.time() if now is None else now
+        live = self.current(now)
+        viewports = live["viewports"]
+
+        hosted = [
+            c for c in live["clients"].values()
+            if c["chat_id"] == chat_id and c["host_viewport_id"] in viewports
+        ]
+        if hosted:
+            # Most recently touched wins, and a visible page beats a hidden
+            # one that was touched at the same moment (both fresh at boot).
+            best = max(hosted, key=lambda c: (
+                c["last_input_at"], viewports[c["host_viewport_id"]]["visible"]))
+            return {"viewport_id": best["host_viewport_id"], "reason": "hosts the chat"}
+
+        if viewports:
+            vid = max(viewports, key=lambda k: (
+                viewports[k]["visible"], viewports[k]["last_input_at"]))
+            return {"viewport_id": vid, "reason": "most recently active viewport"}
+
+        return {"viewport_id": None, "reason": "no viewport is open on this pod"}
+
+
+_STORE: PresenceStore | None = None
+
+
+def get_store() -> PresenceStore:
+    """A cache of the record, not the record. See desktop_session.get_store."""
+    global _STORE
+    if _STORE is None:
+        _STORE = PresenceStore()
+    return _STORE

--- a/pantheon/toolsets/desktop/toolset.py
+++ b/pantheon/toolsets/desktop/toolset.py
@@ -167,6 +167,70 @@ class DesktopToolSet(ToolSet):
         return {"success": True, "seq": store.session.seq, "ops": ops,
                 "host": store.where(), **result}
 
+    # ── who is looking (presence.py) ──────────────────────────────────────
+
+    def _presence(self):
+        from .presence import get_store as presence_store
+
+        return presence_store()
+
+    @tool(exclude=True)
+    async def desktop_presence(
+        self,
+        viewport_id: str = "",
+        clients: list | None = None,
+        visible: bool = True,
+        active: bool = False,
+    ) -> dict:
+        """UI-only: renew this page's leases, and read back who else is here.
+
+        One call per page, on a heartbeat — a page has at most one viewport and
+        any number of chat clients, so sending them together keeps this to one
+        message rather than one per entity. The reply carries the whole live
+        registry, so a viewport that wants to draw other people's cursors does
+        not need a second round trip.
+
+        `active` means real user input since the last beat, not that the beat
+        happened: a background tab must not out-rank the window someone is
+        typing in when the anchor is resolved.
+        """
+        registry, changed = self._presence().announce(
+            viewport_id=viewport_id, clients=clients,
+            visible=visible, active=active)
+        # Only membership is worth telling anyone about. Broadcasting renewals
+        # would wake every viewport on this pod every few seconds per open tab.
+        if changed:
+            await self._publish_desktop({"type": "desktop.presence", **registry})
+        return {"success": True, **registry}
+
+    @tool(exclude=True)
+    async def desktop_presence_leave(
+        self, viewport_id: str = "", client_ids: list | None = None,
+    ) -> dict:
+        """UI-only: give up leases on the way out (pagehide).
+
+        Best-effort by nature — it does not fire for a crash, a dropped
+        connection or a sleeping laptop, which is exactly why the lease exists.
+        This only saves the TTL in the common case.
+        """
+        registry, changed = self._presence().leave(
+            viewport_id=viewport_id, client_ids=client_ids)
+        if changed:
+            await self._publish_desktop({"type": "desktop.presence", **registry})
+        return {"success": True, **registry}
+
+    @tool(exclude=True)
+    async def desktop_anchor(self, chat_id: str = "") -> dict:
+        """UI-only: which viewport this chat's directed requests should reach.
+
+        Exposed rather than kept internal because "why that screen?" is
+        otherwise unanswerable after the fact, and not being able to name the
+        copy that answered was the whole difficulty of debugging the session.
+        """
+        chat_id = chat_id or self._chat_id() or ""
+        return {"success": True, "chat_id": chat_id,
+                **self._presence().anchor_for(chat_id)}
+
     def _data_roots(self) -> list:
         """Directories the data server should expose: the workspace (agent
         data + agent-written components) and the skills dirs (viewer plugins)."""

--- a/tests/test_desktop_presence.py
+++ b/tests/test_desktop_presence.py
@@ -1,0 +1,164 @@
+"""The presence registry: who is looking, and where a chat is anchored.
+
+Leases are the whole point, so every rule here is stated against an explicit
+clock rather than a sleep — a TTL you have to wait out is a test nobody runs.
+"""
+
+import json
+
+import pytest
+
+from pantheon.toolsets.desktop.presence import TTL_S, Presence, PresenceStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return PresenceStore(work_dir=tmp_path)
+
+
+def test_a_page_announces_its_viewport_and_its_chat_windows(store):
+    """One call per page: a page has one viewport and any number of chat UIs,
+    and a heartbeat must not become one message per entity."""
+    live, changed = store.announce(
+        viewport_id="v1",
+        clients=[{"client_id": "c1", "chat_id": "chat-a", "host_viewport_id": "v1"},
+                 {"client_id": "c2", "chat_id": "chat-b", "host_viewport_id": "v1"}],
+        now=1000.0)
+    assert changed is True
+    assert list(live["viewports"]) == ["v1"]
+    assert sorted(live["clients"]) == ["c1", "c2"]
+
+
+def test_a_renewal_that_changes_nothing_is_not_worth_broadcasting(store):
+    store.announce(viewport_id="v1", now=1000.0)
+    _, changed = store.announce(viewport_id="v1", now=1010.0)
+    assert changed is False          # or every tab wakes every heartbeat
+    _, changed = store.announce(viewport_id="v2", now=1011.0)
+    assert changed is True           # someone joined: cursors should appear
+
+
+def test_a_lease_that_stops_being_renewed_expires(store):
+    """The case explicit unregistering cannot cover: a crash, a dropped
+    network, a sleeping laptop. None of them send pagehide."""
+    store.announce(viewport_id="v1", now=1000.0)
+    assert list(store.current(now=1000.0 + TTL_S - 1)["viewports"]) == ["v1"]
+    assert list(store.current(now=1000.0 + TTL_S + 1)["viewports"]) == []
+
+
+def test_expiry_is_applied_when_read_not_only_when_swept(tmp_path):
+    """A reaper's period would otherwise be a window in which a dead tab is
+    still addressable. Nothing has swept this file — reading it must still
+    refuse to report the corpse."""
+    a = PresenceStore(work_dir=tmp_path)
+    a.announce(viewport_id="v1", now=1000.0)
+
+    fresh = PresenceStore(work_dir=tmp_path)     # a different process
+    assert list(fresh.current(now=1000.0 + TTL_S + 1)["viewports"]) == []
+    assert fresh.anchor_for("chat-a", now=1000.0 + TTL_S + 1)["viewport_id"] is None
+
+
+def test_leave_is_immediate_where_expiry_would_take_a_ttl(store):
+    store.announce(viewport_id="v1",
+                   clients=[{"client_id": "c1", "chat_id": "a", "host_viewport_id": "v1"}],
+                   now=1000.0)
+    live, changed = store.leave(viewport_id="v1", client_ids=["c1"], now=1001.0)
+    assert changed is True
+    assert live["viewports"] == {} and live["clients"] == {}
+
+
+def test_the_anchor_is_the_viewport_hosting_the_chat(store):
+    """Two desktops open; only one of them holds this chat's window."""
+    store.announce(viewport_id="v1", now=1000.0)
+    store.announce(viewport_id="v2",
+                   clients=[{"client_id": "c1", "chat_id": "chat-a",
+                             "host_viewport_id": "v2"}],
+                   now=1000.0)
+    got = store.anchor_for("chat-a", now=1001.0)
+    assert got["viewport_id"] == "v2"
+    assert got["reason"] == "hosts the chat"
+
+
+def test_three_agent_windows_in_one_page_are_not_an_ambiguity(store):
+    """The case a per-page {viewport_id, chats:[…]} model could not express."""
+    store.announce(
+        viewport_id="v1",
+        clients=[{"client_id": f"c{i}", "chat_id": f"chat-{i}", "host_viewport_id": "v1"}
+                 for i in range(3)],
+        now=1000.0)
+    for i in range(3):
+        assert store.anchor_for(f"chat-{i}", now=1001.0)["viewport_id"] == "v1"
+
+
+def test_one_chat_open_in_two_places_anchors_where_the_person_last_was(store):
+    """pantheon-ui and a desktop Agent window on the same conversation."""
+    store.announce(viewport_id="v1",
+                   clients=[{"client_id": "c1", "chat_id": "chat-a", "host_viewport_id": "v1"}],
+                   active=True, now=1000.0)
+    store.announce(viewport_id="v2",
+                   clients=[{"client_id": "c2", "chat_id": "chat-a", "host_viewport_id": "v2"}],
+                   active=True, now=1005.0)
+    assert store.anchor_for("chat-a", now=1006.0)["viewport_id"] == "v2"
+
+    # …and it follows the person back.
+    store.announce(viewport_id="v1",
+                   clients=[{"client_id": "c1", "chat_id": "chat-a", "host_viewport_id": "v1"}],
+                   active=True, now=1010.0)
+    assert store.anchor_for("chat-a", now=1011.0)["viewport_id"] == "v1"
+
+
+def test_a_beating_background_tab_is_not_a_person(store):
+    """Heartbeats must not count as activity, or a hidden tab left open
+    overnight outranks the window someone is typing in."""
+    store.announce(viewport_id="v1", visible=True, active=True, now=1000.0)
+    store.announce(viewport_id="v2", visible=False, active=False, now=1030.0)
+    assert store.anchor_for("chat-a", now=1031.0)["viewport_id"] == "v1"
+
+
+def test_a_chat_with_no_desktop_of_its_own_falls_to_the_live_one(store):
+    """Chatting in pantheon-ui with the desktop in another tab."""
+    store.announce(viewport_id="v1", active=True, now=1000.0)
+    store.announce(clients=[{"client_id": "c1", "chat_id": "chat-a",
+                             "host_viewport_id": ""}], now=1000.0)
+    got = store.anchor_for("chat-a", now=1001.0)
+    assert got["viewport_id"] == "v1"
+    assert got["reason"] == "most recently active viewport"
+
+
+def test_a_client_whose_host_died_does_not_anchor_to_a_ghost(store):
+    """The Agent window's page is gone but its lease has not lapsed yet."""
+    store.announce(viewport_id="v1",
+                   clients=[{"client_id": "c1", "chat_id": "chat-a", "host_viewport_id": "v1"}],
+                   now=1000.0)
+    store.announce(viewport_id="v2", now=1000.0)
+    store.leave(viewport_id="v1", now=1001.0)          # page closed, client lingers
+    got = store.anchor_for("chat-a", now=1002.0)
+    assert got["viewport_id"] == "v2"
+    assert got["reason"] == "most recently active viewport"
+
+
+def test_no_viewport_at_all_is_said_out_loud(store):
+    got = store.anchor_for("chat-a", now=1000.0)
+    assert got["viewport_id"] is None
+    assert "no viewport" in got["reason"]      # never a silent nothing
+
+
+def test_two_pages_beating_at_once_are_one_registry(tmp_path):
+    """Read-modify-write, like the session document: the toolset is a
+    ProcessJob per toolset, so two announcements can land in two processes."""
+    a = PresenceStore(work_dir=tmp_path)
+    b = PresenceStore(work_dir=tmp_path)
+    a.announce(viewport_id="v1", now=1000.0)
+    b.announce(viewport_id="v2", now=1000.0)
+    assert sorted(a.current(now=1001.0)["viewports"]) == ["v1", "v2"]
+    assert sorted(b.current(now=1001.0)["viewports"]) == ["v1", "v2"]
+
+
+def test_a_registry_from_a_dead_container_describes_nobody(tmp_path):
+    """Those browsers lost their connection when the sandbox did — restoring
+    them would populate the desktop with a crowd of ghosts."""
+    store = PresenceStore(work_dir=tmp_path)
+    store.announce(viewport_id="v1", now=1000.0)
+
+    record = json.loads((tmp_path / ".pantheon" / "desktop-presence.json").read_text())
+    record["boot"] = "a-previous-container"
+    assert Presence.from_record(record).viewports == {}


### PR DESCRIPTION
The registry the anchoring design needs (`docs/desktop/anchoring.md` §3 in
pantheon-ui), and what presence has been blocked on. Until now the Web Locks
election was **anonymous**: a copy could act and nobody could name it afterwards
— which is why "which viewport answered?" was unanswerable throughout the
session work.

**Two identities, because the page is the wrong granularity.** A *viewport* is
something rendering the desktop; a *chat client* is one chat UI — one per Agent
app window — carrying the chat it shows and the host viewport in its own page.
That host field is the anchoring link: take a chat's clients, pick the most
recently active, follow its host. Three Agent windows in one page then resolve
to the same viewport with nothing to disambiguate, and a chat open in two places
anchors wherever the person last was.

A per-page `{viewport_id, chats: […]}` model — which is what the first draft of
the design had — can express neither of those.

**Registration is a LEASE.** Unregistering on close cannot be more than
best-effort: `pagehide` does not fire for a crash, a dropped network or a
sleeping laptop, and each would leave an entry claiming to be a live screen,
which an agent then waits out into "the desktop did not answer". So clients
renew (~15 s) and entries expire (~45 s); the explicit leave only makes the
common case instant.

Two things done deliberately:

- **Expiry is applied when the registry is read**, not merely swept — a
  reaper's period would otherwise be a window in which a dead tab is
  addressable.
- **Activity is real input, not the heartbeat** — or a tab left open overnight
  outranks the window someone is typing in.

**Where it lives:** a file under `flock`, boot-stamped so a dead container's
registry is discarded rather than restored as a crowd of ghosts — the same
discipline as the session document, for the same reason (the toolset is a
ProcessJob per toolset). But **not in** the session document: a heartbeat is not
a change anyone needs to hear, and folding it in would bump `seq` and fan out to
every viewport every few seconds per open tab. Membership changes broadcast;
renewals do not.

Three UI-only tools: `desktop_presence` (renew + read back),
`desktop_presence_leave`, and `desktop_anchor` — the last exposed rather than
kept internal because "why that screen?" is otherwise unanswerable after the
fact.

**Not in scope:** nothing is addressed by `viewport_id` yet. Rewiring
`desktop_read` / `desktop_call` / `desktop_screenshot` onto the anchor, and
retiring the Web Locks election for directed requests, is the next change.

14 new tests, all against an explicit clock — a TTL you have to sleep through is
a test nobody runs. 71 desktop tests pass.

Verified on staging (`sha-ed47717`) with two desktops open:

| | |
|---|---|
| both register | 2 viewports, ttl 45s / heartbeat 15s |
| after a real click in B, `desktop_anchor(chat)` | B's own viewport id, reason `hosts the chat` |
| close B | viewports back to 1 |
| anchor after B is gone | moves to A — not a dead page |

Browser half is on pantheon-ui `feat/absorb-atrium`.