### PR TITLE
feat(desktop): an ephemeral channel for state whose only version is the newest

### DIFF
--- a/pantheon/toolsets/desktop/toolset.py
+++ b/pantheon/toolsets/desktop/toolset.py
@@ -204,6 +204,31 @@ class DesktopToolSet(ToolSet):
         return {"success": True, **registry}
 
     @tool(exclude=True)
+    async def desktop_broadcast(self, topic: str = "", payload: dict | None = None) -> dict:
+        """UI-only: pass an EPHEMERAL value to the pod's other viewports.
+
+        The counterpart to `desktop_intent`, for state whose only interesting
+        version is the newest one — a camera mid-drag, a cursor, a selection
+        being scrubbed. It is relayed and forgotten: nothing is sequenced,
+        nothing is written to the record, and a viewport that joins later
+        learns none of it.
+
+        That is the point rather than a limitation. Putting a camera in the
+        session document would sequence and persist a value that changes at
+        pointer rates and that nobody should reload into — someone else's zoom
+        restored at boot is not a feature. What must survive a reload belongs
+        in an intent instead.
+        """
+        if not topic:
+            return {"success": False, "error": "desktop_broadcast needs a topic"}
+        await self._publish_desktop({
+            "type": "desktop.broadcast",
+            "topic": topic,
+            "payload": payload or {},
+        })
+        return {"success": True}
+
+    @tool(exclude=True)
     async def desktop_anchor(self, chat_id: str = "") -> dict:
         """UI-only: which viewport this chat's directed requests should reach.
 


### PR DESCRIPTION
`desktop_broadcast` relays a value to the pod's other viewports and forgets it:
nothing sequenced, nothing written to the record, nothing replayed to a viewport
that joins later.

That is the point rather than a limitation. A camera mid-drag has no version
worth sequencing, and restoring someone else's zoom at boot is not a feature —
so putting it in the session document would be wrong in both directions. What
must survive a reload goes through `desktop_intent` instead.

This is the transport for the sync protocol's `stream` keys (pantheon-ui
`docs/desktop/shared-session.md` §7). Cursors will use it too: only the latest
value matters, and it should vanish with the person who produced it.

Verified on staging (`sha-d82398a`) as part of the protocol, two viewports on
one Viv window:

| | |
|---|---|
| a channel edit in A | reaches the session document tagged with A's viewport id |
| B's own copy of the app | adopts it — `contrastLimits [11, 4242]` |
| the camera | reaches B (`{zoom: -2.5, target: [900,900,0]}`) |
| the camera in the document | **absent** — never sequenced, never persisted |

The browser half is on pantheon-ui `feat/absorb-atrium`, and it carries the
three faults that were stopping any of this from working: the app host never
reported back state the shell handed it, a viewport receiving a shared change
threw on cloning a Vue proxy and showed an error instead of adopting, and a
window opened in a second tab booted on the app's defaults and published them
over the group's.