### PR TITLE
Desktop model access

### DIFF
--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -4618,7 +4618,11 @@ class ChatRoom(ToolSet):
             return True, ""
 
         selector = get_model_selector()
-        available = selector._get_available_providers()
+        # Use _effective_providers() so that under platform budget (force-proxy)
+        # providers served by the proxy (anthropic/openai/gemini) are accepted even
+        # when the user has no BYOK key for them.  In BYOK mode _effective_providers()
+        # delegates to _get_available_providers() — no change in behaviour.
+        available = selector._effective_providers()
 
         # Extract provider from model name
         if "/" in model:
@@ -4631,6 +4635,15 @@ class ChatRoom(ToolSet):
             provider = provider_aliases.get(provider, provider)
 
             if provider not in available:
+                # Platform-OpenRouter mode: the picker offers platform models as
+                # "openrouter/<vendor>/<model>" (and a saved pin can be "<vendor>/<model>"),
+                # whose first segment is a ROUTING prefix, not a native provider — the
+                # platform's OpenRouter key supplies the credentials. Ask the same canonical
+                # routing path the LLM call uses; if it will be routed, it is usable.
+                from pantheon.utils.llm_providers import platform_openrouter_model_id
+
+                if platform_openrouter_model_id(model):
+                    return True, ""
                 return False, f"Provider '{provider}' not available (missing credentials)"
 
         return True, ""

--- a/pantheon/utils/llm_providers.py
+++ b/pantheon/utils/llm_providers.py
@@ -88,20 +88,16 @@ def get_provider_base_env(
 # ============ Provider Detection ============
 
 
-def _platform_openrouter_config(
-    model: str, relaxed_schema: bool
-) -> Optional[ProviderConfig]:
-    """Platform-OpenRouter mode: route EVERY model (incl. anthropic/openai/gemini) through
-    OpenRouter for unified billing. Returns a config that forces the OpenAI-compatible path
-    with the full ``openrouter/<vendor>/<model>`` id, so the LiteLLM proxy's ``openrouter/*``
-    group serves it (and OpenRouter fronts one key for all vendors) — bypassing the native
-    anthropic/gemini adapters. Returns None (→ fall through to normal per-provider detection)
-    when: not in platform-openrouter mode, not proxying, or the model isn't on OpenRouter
-    (naming mismatch / native-only release → keeps its native route instead of 404-ing).
+def platform_openrouter_model_id(model: str) -> Optional[str]:
+    """The id a model will actually be SENT as under platform-OpenRouter routing, or None.
 
-    Prompt caching still works: the agent injects Anthropic-style cache_control breakpoints
-    (supports_explicit_cache_control), the OpenAI adapter passes them through, and OpenRouter
-    forwards them to the vendor — verified end-to-end (repeat call → cached_tokens > 0)."""
+    Returns the canonical ``openrouter/<vendor>/<model>`` id when the deployment fronts the
+    platform budget with OpenRouter (``PLATFORM_MODEL_MODE=openrouter``), we're proxying, and
+    OpenRouter serves the model. None means "not routed through OpenRouter" — the model keeps
+    its normal per-provider route. Callers that need to know whether a model is reachable
+    (e.g. provider validation) should ask here rather than parsing the id's first segment:
+    ``openrouter`` is a ROUTING prefix, not a provider with its own credentials.
+    """
     import os
 
     if not isinstance(model, str) or not model.strip():
@@ -120,9 +116,26 @@ def _platform_openrouter_config(
     try:
         from .openrouter_catalog import canonical_openrouter_id
 
-        canon = canonical_openrouter_id(core)
+        return canonical_openrouter_id(core)
     except Exception:  # noqa: BLE001
-        canon = None
+        return None
+
+
+def _platform_openrouter_config(
+    model: str, relaxed_schema: bool
+) -> Optional[ProviderConfig]:
+    """Platform-OpenRouter mode: route EVERY model (incl. anthropic/openai/gemini) through
+    OpenRouter for unified billing. Returns a config that forces the OpenAI-compatible path
+    with the full ``openrouter/<vendor>/<model>`` id, so the LiteLLM proxy's ``openrouter/*``
+    group serves it (and OpenRouter fronts one key for all vendors) — bypassing the native
+    anthropic/gemini adapters. Returns None (→ fall through to normal per-provider detection)
+    when: not in platform-openrouter mode, not proxying, or the model isn't on OpenRouter
+    (naming mismatch / native-only release → keeps its native route instead of 404-ing).
+
+    Prompt caching still works: the agent injects Anthropic-style cache_control breakpoints
+    (supports_explicit_cache_control), the OpenAI adapter passes them through, and OpenRouter
+    forwards them to the vendor — verified end-to-end (repeat call → cached_tokens > 0)."""
+    canon = platform_openrouter_model_id(model)
     if not canon:
         return None
     return ProviderConfig(
@@ -340,14 +353,29 @@ def get_global_fallback_base_url() -> str:
 def is_force_proxy_enabled() -> bool:
     """True when this backend is in 'platform budget' mode: every LLM call is routed
     through the platform LiteLLM proxy + the user's virtual key, bypassing the user's
-    own provider keys (without deleting them). Toggled at runtime via the
-    ``set_llm_proxy`` RPC, which sets ``LLM_FORCE_PROXY`` +
-    ``PANTHEON_PLATFORM_PROXY_BASE`` / ``PANTHEON_PLATFORM_PROXY_KEY`` (dedicated env
-    so the user's own ``LLM_API_BASE`` is never touched)."""
+    own provider keys (without deleting them).
+
+    Activated in two ways:
+    1. Explicitly via the ``set_llm_proxy`` RPC (frontend toggles at runtime), which
+       sets ``LLM_FORCE_PROXY=true`` together with the proxy credentials.
+    2. Implicitly when ``PANTHEON_PLATFORM_PROXY_BASE`` **and**
+       ``PANTHEON_PLATFORM_PROXY_KEY`` are both present in the environment at process
+       start — e.g. when an admin pre-configures the Desktop app's launch environment
+       with the platform proxy URL and the user's virtual key, so proxy routing is
+       active immediately without requiring the frontend to call ``set_llm_proxy``.
+       This is what allows the $200 platform-budget credits to be used on the Desktop
+       app even before the frontend has had a chance to push the proxy config.
+    """
     import os
 
     val = os.environ.get("LLM_FORCE_PROXY", "")
-    return val.strip().lower() in ("1", "true", "yes", "on")
+    if val.strip().lower() in ("1", "true", "yes", "on"):
+        return True
+    # Auto-activate: if both proxy credential vars are already in the environment
+    # (pre-configured by the deployment / launch script), treat that as force-proxy on.
+    proxy_base = os.environ.get("PANTHEON_PLATFORM_PROXY_BASE", "").strip()
+    proxy_key = os.environ.get("PANTHEON_PLATFORM_PROXY_KEY", "").strip()
+    return bool(proxy_base and proxy_key)
 
 
 def get_force_proxy_config() -> tuple[Optional[str], Optional[str]]:

--- a/pantheon/utils/model_selector.py
+++ b/pantheon/utils/model_selector.py
@@ -927,7 +927,12 @@ class ModelSelector:
                 "supported_tags": ["high", "normal", "low", "vision", ...]
             }
         """
-        available_providers = list(self._get_available_providers())
+        # Use _effective_providers() so that under platform budget (force-proxy)
+        # the picker lists the proxy-served families (anthropic/openai/gemini) even
+        # when the user has no BYOK key for those providers.  BYOK mode is unchanged:
+        # _effective_providers() delegates to _get_available_providers() when
+        # force-proxy is off.
+        available_providers = list(self._effective_providers())
         current_provider = self._detected_provider or self.detect_available_provider()
 
         # Collect models for each available provider

--- a/tests/test_chatroom_platform_model_validation.py
+++ b/tests/test_chatroom_platform_model_validation.py
@@ -1,0 +1,215 @@
+"""Provider validation for platform models routed through OpenRouter.
+
+In ``PLATFORM_MODEL_MODE=openrouter`` the model picker offers platform models as
+``openrouter/<vendor>/<model>`` ids that the platform's own OpenRouter key pays for.
+The first path segment is a routing prefix, not a native provider, so validating it
+against the native-provider credential set rejected every such pick and blocked both
+chat/agent creation and agent model updates.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pantheon.chatroom.room import ChatRoom
+from pantheon.factory import get_template_manager
+from pantheon.internal.memory import MemoryManager
+from pantheon.utils.model_selector import ModelSelector
+
+PLATFORM_MODEL = "openrouter/x-ai/grok-4.5"
+
+
+def _make_chatroom(tmp_path: Path) -> ChatRoom:
+    chatroom = ChatRoom.__new__(ChatRoom)
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    chatroom.memory_manager = MemoryManager(memory_dir, use_jsonl=True)
+    chatroom.template_manager = get_template_manager(tmp_path)
+    chatroom.chat_teams = {}
+    chatroom.project_manager = type(
+        "PM",
+        (),
+        {
+            "list_projects": lambda self: [],
+            "active_project": None,
+        },
+    )()
+    return chatroom
+
+
+def _enable_platform_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deployment fronted by the platform proxy with OpenRouter as the model source."""
+    monkeypatch.setenv("PLATFORM_MODEL_MODE", "openrouter")
+    monkeypatch.setenv("PANTHEON_PLATFORM_PROXY_BASE", "https://proxy.example/v1")
+    monkeypatch.setenv("PANTHEON_PLATFORM_PROXY_KEY", "sk-virtual-key")
+    monkeypatch.delenv("LLM_FORCE_PROXY", raising=False)
+
+
+def _disable_platform_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PLATFORM_MODEL_MODE", raising=False)
+    monkeypatch.delenv("PANTHEON_PLATFORM_PROXY_BASE", raising=False)
+    monkeypatch.delenv("PANTHEON_PLATFORM_PROXY_KEY", raising=False)
+    monkeypatch.delenv("LLM_FORCE_PROXY", raising=False)
+    monkeypatch.delenv("LLM_API_BASE", raising=False)
+
+
+class _StubAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.models = ["openai/gpt-5.4"]
+        self.model_params: dict = {}
+
+
+class _StubTeam:
+    def __init__(self, agents: list, source_path: str):
+        self.team_agents = agents
+        self._source_path = source_path
+
+
+def test_validate_model_provider_accepts_platform_openrouter_model(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _enable_platform_openrouter(monkeypatch)
+    room = ChatRoom.__new__(ChatRoom)
+
+    assert ChatRoom._validate_model_provider(room, PLATFORM_MODEL) == (True, "")
+
+
+def test_validate_model_provider_accepts_platform_vendor_prefixed_model(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A saved/pinned id can arrive without the openrouter/ routing prefix."""
+    _enable_platform_openrouter(monkeypatch)
+    room = ChatRoom.__new__(ChatRoom)
+
+    assert ChatRoom._validate_model_provider(room, "x-ai/grok-4.5") == (True, "")
+
+
+def test_validate_model_provider_rejects_openrouter_model_in_direct_mode(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Platform budget without OpenRouter as the source: nothing routes there."""
+    _enable_platform_openrouter(monkeypatch)
+    monkeypatch.setenv("PLATFORM_MODEL_MODE", "direct")
+    room = ChatRoom.__new__(ChatRoom)
+
+    is_valid, message = ChatRoom._validate_model_provider(room, PLATFORM_MODEL)
+    assert is_valid is False
+    assert "openrouter" in message
+
+
+def test_validate_model_provider_rejects_openrouter_model_without_byok_key(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _disable_platform_proxy(monkeypatch)
+    monkeypatch.setattr(
+        ModelSelector, "_get_available_providers", lambda _self: {"openai"}
+    )
+    room = ChatRoom.__new__(ChatRoom)
+
+    is_valid, message = ChatRoom._validate_model_provider(room, PLATFORM_MODEL)
+    assert is_valid is False
+    assert "openrouter" in message
+
+
+@pytest.mark.asyncio
+async def test_create_chat_accepts_platform_openrouter_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _enable_platform_openrouter(monkeypatch)
+    chatroom = _make_chatroom(tmp_path)
+
+    result = await ChatRoom.create_chat(
+        chatroom,
+        chat_name="Platform Model Chat",
+        template_id="default",
+        model=PLATFORM_MODEL,
+    )
+
+    assert result["success"] is True
+    memory = chatroom.memory_manager.get_memory(result["chat_id"])
+    team_template = memory.extra_data["team_template"]
+    assert {agent["model"] for agent in team_template["agents"]} == {PLATFORM_MODEL}
+
+
+@pytest.mark.asyncio
+async def test_set_agent_model_accepts_platform_openrouter_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _enable_platform_openrouter(monkeypatch)
+    chatroom = _make_chatroom(tmp_path)
+
+    created = await ChatRoom.create_chat(
+        chatroom,
+        chat_name="Platform Model Update Chat",
+        template_id="default",
+    )
+    chat_id = created["chat_id"]
+
+    # Persist into a copy of the template so the test never writes to the factory file.
+    factory_default = Path(chatroom.template_manager.get_template("default").source_path)
+    team_file = tmp_path / "default.md"
+    team_file.write_text(factory_default.read_text(encoding="utf-8"), encoding="utf-8")
+
+    team = _StubTeam([_StubAgent("Leader")], str(team_file))
+
+    async def _get_team_for_chat(*_args, **_kwargs):
+        return team
+
+    chatroom.get_team_for_chat = _get_team_for_chat
+
+    result = await ChatRoom.set_agent_model(
+        chatroom,
+        chat_id=chat_id,
+        agent_name="Leader",
+        model=PLATFORM_MODEL,
+    )
+
+    assert result["success"] is True, result.get("message")
+    assert result["resolved_models"] == [PLATFORM_MODEL]
+    assert team.team_agents[0].models == [PLATFORM_MODEL]
+
+    memory = chatroom.memory_manager.get_memory(chat_id)
+    leader = next(
+        agent
+        for agent in memory.extra_data["team_template"]["agents"]
+        if (agent.get("name") or "").lower() == "leader"
+    )
+    assert leader["model"] == PLATFORM_MODEL
+
+
+@pytest.mark.asyncio
+async def test_set_agent_model_still_rejects_unreachable_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _disable_platform_proxy(monkeypatch)
+    monkeypatch.setattr(
+        ModelSelector, "_get_available_providers", lambda _self: {"openai"}
+    )
+    chatroom = _make_chatroom(tmp_path)
+
+    created = await ChatRoom.create_chat(
+        chatroom,
+        chat_name="Rejected Update Chat",
+        template_id="default",
+    )
+    team = _StubTeam([_StubAgent("Leader")], str(tmp_path / "missing.md"))
+
+    async def _get_team_for_chat(*_args, **_kwargs):
+        return team
+
+    chatroom.get_team_for_chat = _get_team_for_chat
+
+    result = await ChatRoom.set_agent_model(
+        chatroom,
+        chat_id=created["chat_id"],
+        agent_name="Leader",
+        model=PLATFORM_MODEL,
+    )
+
+    assert result["success"] is False
+    assert "openrouter" in result["message"]
+    assert team.team_agents[0].models == ["openai/gpt-5.4"]


### PR DESCRIPTION
## Summary
- Replaces the runtime half of #193 with a linear, single-commit history based directly on current `main` (no docs changes, no upstream merge commits).
- Restores Desktop multi-provider model access under platform budget (`_effective_providers()`), treats `PANTHEON_PLATFORM_PROXY_*` as force-proxy so credits are used, and accepts OpenRouter-prefixed platform model ids in provider validation.
- Includes the matching create/update regression tests in the same commit so the picker/proxy changes are not mergeable without the OpenRouter validation fix.

This is the same runtime change as #193 (`room.py`, `llm_providers.py`, `model_selector.py`, `tests/test_chatroom_platform_model_validation.py`). Please review and merge this PR independently; #193 is left open as the review reference.

## Test plan
- [ ] `pytest tests/test_chatroom_platform_model_validation.py`
- [ ] Desktop picker lists Anthropic/Gemini/OpenAI when platform proxy env is set
- [ ] Selecting `openrouter/<vendor>/<model>` passes create/update validation
- [ ] History is one commit on current `main` and can merge without squash


Made with [Cursor](https://cursor.com)