### PR TITLE
fix(desktop): carry the platform's model mode into the local backend

### DIFF
--- a/pantheon/chatroom/room.py
+++ b/pantheon/chatroom/room.py
@@ -4926,7 +4926,7 @@ class ChatRoom(ToolSet):
 
     @tool(exclude=True)
     async def set_llm_proxy(
-        self, enabled: bool, base_url: str = "", api_key: str = ""
+        self, enabled: bool, base_url: str = "", api_key: str = "", model_mode: str = ""
     ) -> dict:
         """Toggle 'platform budget' mode for THIS local backend (frontend-only).
 
@@ -4934,6 +4934,13 @@ class ChatRoom(ToolSet):
         (base_url) using the user's per-user virtual key (api_key) — usage spends
         against the user's platform budget — bypassing (NOT deleting) the user's own
         provider keys. enabled=False: go back to the user's own keys.
+
+        model_mode carries the DEPLOYMENT's platform routing mode down to this local
+        process: "openrouter" means the platform fronts every vendor through OpenRouter,
+        so the picker should offer the full OpenRouter catalog (list_models →
+        platform_models_by_provider) and openrouter/<vendor>/<model> ids validate —
+        the same view a hub-served client gets, where PLATFORM_MODEL_MODE is set by the
+        deployment. "" (older frontends) leaves the env untouched; "direct" clears it.
 
         Sets the env in this process so it takes effect immediately. The frontend
         re-pushes this on every connect, so it survives backend restarts without
@@ -4952,10 +4959,17 @@ class ChatRoom(ToolSet):
                 os.environ["PANTHEON_PLATFORM_PROXY_BASE"] = base_url
                 os.environ["PANTHEON_PLATFORM_PROXY_KEY"] = api_key
                 os.environ["LLM_FORCE_PROXY"] = "true"
+                mode = (model_mode or "").strip().lower()
+                if mode == "openrouter":
+                    os.environ["PLATFORM_MODEL_MODE"] = "openrouter"
+                elif mode:  # explicit non-openrouter (e.g. "direct") clears it
+                    os.environ.pop("PLATFORM_MODEL_MODE", None)
+                # mode == "": older frontend didn't say — leave the env as-is
             else:
                 os.environ.pop("LLM_FORCE_PROXY", None)
                 os.environ.pop("PANTHEON_PLATFORM_PROXY_BASE", None)
                 os.environ.pop("PANTHEON_PLATFORM_PROXY_KEY", None)
+                os.environ.pop("PLATFORM_MODEL_MODE", None)
             # Rebuild the model selector so quality-tier chains (high/normal/low)
             # re-resolve under the new mode — under budget they must use only the
             # platform's providers, not a cached local one.

--- a/tests/test_set_llm_proxy_model_mode.py
+++ b/tests/test_set_llm_proxy_model_mode.py
@@ -1,0 +1,72 @@
+"""set_llm_proxy carries the deployment's platform model mode to the local backend.
+
+The Desktop backend runs locally, so it never sees the deployment's
+``PLATFORM_MODEL_MODE`` env — without it, ``list_models`` cannot offer the
+platform's OpenRouter catalog (``platform_models_by_provider``) and
+``openrouter/<vendor>/<model>`` picks fail provider validation. The frontend now
+forwards the mode with the proxy creds; the RPC mirrors it into this process.
+"""
+
+import os
+
+import pytest
+
+from pantheon.chatroom.room import ChatRoom
+
+PROXY_ENVS = (
+    "LLM_FORCE_PROXY",
+    "PANTHEON_PLATFORM_PROXY_BASE",
+    "PANTHEON_PLATFORM_PROXY_KEY",
+    "PLATFORM_MODEL_MODE",
+)
+
+
+@pytest.fixture()
+def chatroom(monkeypatch: pytest.MonkeyPatch) -> ChatRoom:
+    for env in PROXY_ENVS:
+        monkeypatch.delenv(env, raising=False)
+    return ChatRoom.__new__(ChatRoom)
+
+
+@pytest.mark.asyncio
+async def test_enable_with_openrouter_mode_sets_env(chatroom: ChatRoom):
+    resp = await chatroom.set_llm_proxy(
+        True, "https://proxy.example/v1", "sk-virtual", model_mode="openrouter"
+    )
+    assert resp["success"] is True
+    assert os.environ["LLM_FORCE_PROXY"] == "true"
+    assert os.environ["PLATFORM_MODEL_MODE"] == "openrouter"
+
+
+@pytest.mark.asyncio
+async def test_enable_without_mode_leaves_env_untouched(
+    chatroom: ChatRoom, monkeypatch: pytest.MonkeyPatch
+):
+    # Older frontends omit model_mode — a pre-set deployment env must survive.
+    monkeypatch.setenv("PLATFORM_MODEL_MODE", "openrouter")
+    resp = await chatroom.set_llm_proxy(True, "https://proxy.example/v1", "sk-virtual")
+    assert resp["success"] is True
+    assert os.environ["PLATFORM_MODEL_MODE"] == "openrouter"
+
+
+@pytest.mark.asyncio
+async def test_enable_with_direct_mode_clears_env(
+    chatroom: ChatRoom, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PLATFORM_MODEL_MODE", "openrouter")
+    resp = await chatroom.set_llm_proxy(
+        True, "https://proxy.example/v1", "sk-virtual", model_mode="direct"
+    )
+    assert resp["success"] is True
+    assert "PLATFORM_MODEL_MODE" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_disable_clears_all_proxy_env(chatroom: ChatRoom):
+    await chatroom.set_llm_proxy(
+        True, "https://proxy.example/v1", "sk-virtual", model_mode="openrouter"
+    )
+    resp = await chatroom.set_llm_proxy(False)
+    assert resp["success"] is True
+    for env in PROXY_ENVS:
+        assert env not in os.environ


### PR DESCRIPTION
Desktop users with platform budget saw only the 3 native proxy families in the model picker, while a hub-served client gets the full OpenRouter catalog. The local backend never sees the deployment's `PLATFORM_MODEL_MODE` env, so `list_models` had no platform view to offer and `openrouter/<vendor>/<model>` picks failed provider validation.

`set_llm_proxy` now accepts `model_mode`: the frontend forwards the deployment's mode with the proxy creds (Nanguage/pantheon-ui#36), and the RPC mirrors it into this process — set on `openrouter`, cleared on `direct`/disable, untouched when an older frontend omits it. Regression tests cover all four transitions.

Follow-up to #196. Shipped in desktop 0.3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SS9mntiDnmsJ7tV8qYFGWc